### PR TITLE
fix(i18n): translate the Discord announcement copy in all locales

### DIFF
--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -2,8 +2,8 @@
 de:
   discord:
     new_ship:
-      message: 'Allow me to introduce: The %{manufacturer} %{model}'
-      title: New Ship/Vehicle added
+      message: 'Darf ich vorstellen: %{manufacturer} %{model}'
+      title: Neues Schiff/Fahrzeug hinzugefügt
     new_supporter:
       message: '%{name} ist jetzt Patreon-Unterstützer (%{amount})'
       title: Neuer Patreon-Unterstützer
@@ -14,7 +14,7 @@ de:
       message: Es gab %{changes} Änderungen an der Roadmap
       title: Neue Änderungen auf der Roadmap
     ship_on_sale:
-      message: Starting at %{price} excl. VAT
-      title: The %{model} is now on Sale!
+      message: Ab %{price} zzgl. MwSt.
+      title: 'Die %{model} ist jetzt im Angebot!'
     youtube_video:
-      title: New Video on Youtube!
+      title: 'Neues Video auf YouTube!'

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -2,8 +2,11 @@
 es:
   discord:
     new_ship:
-      message: 'Allow me to introduce: The %{manufacturer} %{model}'
-      title: New Ship/Vehicle added
+      message: 'Permitidme presentaros: %{manufacturer} %{model}'
+      title: Nueva nave/vehículo añadido
+    new_supporter:
+      message: '%{name} acaba de convertirse en patrocinador de Patreon (%{amount})'
+      title: Nuevo patrocinador de Patreon
     progress_tracker_update:
       message: Ha habido %{changes} cambios en el rastreador de progreso
       title: Nuevos cambios en el rastreador de progreso
@@ -11,7 +14,7 @@ es:
       message: Ha habido %{changes} cambios en la hoja de ruta
       title: Nuevos cambios en la hoja de ruta
     ship_on_sale:
-      message: Starting at %{price} excl. VAT
-      title: The %{model} is now on Sale!
+      message: Desde %{price} sin IVA
+      title: '¡La %{model} ya está en oferta!'
     youtube_video:
-      title: New Video on Youtube!
+      title: '¡Nuevo vídeo en YouTube!'

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -4,6 +4,9 @@ fr:
     new_ship:
       message: 'Permettez-moi de vous présenter : %{manufacturer} %{model}'
       title: Nouveau vaisseau / véhicule ajouté
+    new_supporter:
+      message: '%{name} vient de devenir soutien Patreon (%{amount})'
+      title: Nouveau soutien Patreon
     progress_tracker_update:
       message: Il y a eu %{changes} modifications sur le Progress Tracker
       title: Nouveaux changements sur le Progress Tracker
@@ -12,6 +15,6 @@ fr:
       title: Nouveaux changements sur la Roadmap
     ship_on_sale:
       message: À partir de %{price} hors TVA
-      title: Le %{model} est maintenant en vente !
+      title: 'Le %{model} est maintenant en vente !'
     youtube_video:
-      title: Nouvelle vidéo sur YouTube !
+      title: 'Nouvelle vidéo sur YouTube !'

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -2,8 +2,11 @@
 it:
   discord:
     new_ship:
-      message: 'Allow me to introduce: The %{manufacturer} %{model}'
-      title: New Ship/Vehicle added
+      message: 'Permettetemi di presentarvi: %{manufacturer} %{model}'
+      title: Nuova nave/veicolo aggiunto
+    new_supporter:
+      message: '%{name} è appena diventato sostenitore su Patreon (%{amount})'
+      title: Nuovo sostenitore Patreon
     progress_tracker_update:
       message: Ci sono stati %{changes} cambiamenti nel tracker dei progressi
       title: Nuove modifiche nel tracker dei progressi
@@ -11,7 +14,7 @@ it:
       message: Ci sono stati %{changes} cambiamenti sulla roadmap
       title: Nuove modifiche sulla roadmap
     ship_on_sale:
-      message: Starting at %{price} excl. VAT
-      title: The %{model} is now on Sale!
+      message: A partire da %{price} IVA esclusa
+      title: 'La %{model} è ora in offerta!'
     youtube_video:
-      title: New Video on Youtube!
+      title: 'Nuovo video su YouTube!'

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -2,16 +2,19 @@
 zh-CN:
   discord:
     new_ship:
-      message: '请允许我介绍一下： %{manufacturer} %{model}'
-      title: 添加新的货运/车辆
+      message: '请允许我介绍：%{manufacturer} %{model}'
+      title: 新增飞船／载具
+    new_supporter:
+      message: '%{name} 刚刚成为 Patreon 支持者（%{amount}）'
+      title: 新的 Patreon 支持者
     progress_tracker_update:
-      message: 进度跟踪器已发生 %{changes} 更改
+      message: 进度追踪器有 %{changes} 项更改
       title: 进度追踪器上的新更改
     roadmap_update:
-      message: 进度跟踪器已发生 %{changes} 更改
+      message: 路线图有 %{changes} 项更改
       title: 路线图上的新更改
     ship_on_sale:
-      message: 起价为 %{price}，不含税。 增值税
-      title: '%{model} 现已发售！'
+      message: 起价 %{price}，不含增值税
+      title: '%{model} 现已开售！'
     youtube_video:
-      title: 在Youtube上给视频点赞
+      title: 'YouTube 上有新视频！'

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -2,8 +2,11 @@
 zh-TW:
   discord:
     new_ship:
-      message: 'Allow me to introduce: The %{manufacturer} %{model}'
-      title: New Ship/Vehicle added
+      message: '讓我來介紹：%{manufacturer} %{model}'
+      title: 新增船艦／載具
+    new_supporter:
+      message: '%{name} 剛剛成為 Patreon 支持者（%{amount}）'
+      title: 新的 Patreon 支持者
     progress_tracker_update:
       message: 進度追蹤有 %{changes} 項變更
       title: 進度追蹤新變更
@@ -11,7 +14,7 @@ zh-TW:
       message: 路線圖有 %{changes} 項變更
       title: 路線圖新變更
     ship_on_sale:
-      message: Starting at %{price} excl. VAT
-      title: The %{model} is now on Sale!
+      message: 起價 %{price}，未含加值稅
+      title: '%{model} 現正特價中！'
     youtube_video:
-      title: New Video on Youtube!
+      title: 'YouTube 上有新影片！'


### PR DESCRIPTION
Off `main`, independent of the Discord bot stack.

`config/locales/*/discord.yml` had three separate problems, only the first of which a key-parity check would ever have found.

## 1. Missing keys

`new_supporter.message` and `new_supporter.title` existed only in `en` and `de`. For **es, fr, it, zh-CN and zh-TW** the Patreon announcement fell back to English.

## 2. Keys that were present but not translated

`de`, `es`, `it` and `zh-TW` carried literal English strings under a non-English locale:

| Locale | Keys holding English text |
| --- | --- |
| de | `new_ship.message`, `new_ship.title`, `ship_on_sale.message`, `ship_on_sale.title`, `youtube_video.title` |
| es | same five |
| it | same five |
| zh-TW | same five |

These are the ones worth noticing: the keys exist, so parity is satisfied, and `enableFallback` produces the same output whether the key is missing or holds English — there is no way to see it except by reading the files.

## 3. Two wrong strings in zh-CN

- `roadmap_update.message` was a copy of `progress_tracker_update.message` and announced changes to the *progress tracker* under the roadmap heading.
- `youtube_video.title` read "like the video on YouTube" rather than announcing a new one.

Also tidied a stray space after a full-width colon and `新的货运/车辆` ("new freight") → `新增飞船／载具`.

## Verified

- All seven files parse and carry the **same 11 keys**
- No locale still holds a string byte-identical to its English source
- No `%{}` placeholder differs from the English original in name or count — checked per key, since a dropped `%{amount}` would raise at post time rather than at boot

Nothing in CI validates any of the three, which is why all of it accumulated. That is worth its own change: a spec that walks `config/locales` and `app/frontend/translations` and fails on a missing key or a placeholder mismatch would have caught #1 and #3 the day they landed.

## Not in this PR

The wider gap. A full audit across every locale file:

| | missing keys |
| --- | --- |
| `config/locales` (server) | **933** across the six non-English locales — mailer 345, filter 222, validation_error 167, notifications 78, activerecord 60, the rest small |
| `app/frontend/translations` | **64** — filterGroup 43, empty 15, filteredList 4, appModal 2 |

That is roughly 195 unique English strings needing six translations each, and it is a translation deliverable rather than a code change — worth deciding deliberately rather than folding into a Discord PR.

🤖
