### PR TITLE
fix(forms): make the affix select a real control

### DIFF
--- a/app/frontend/frontend/components/Fleets/Logistics/InventoryItemModal/index.vue
+++ b/app/frontend/frontend/components/Fleets/Logistics/InventoryItemModal/index.vue
@@ -10,6 +10,7 @@ import Modal from "@/shared/components/AppModal/Inner/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
+import AffixSelect from "@/shared/components/base/FormInput/AffixSelect/index.vue";
 import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
@@ -408,15 +409,11 @@ const onSubmit = handleSubmit(async (values) => {
           >
             <template #suffix>
               <template v-if="isDeposit && unitOptions.length > 1">
-                <select v-model="unit" class="base-input__suffix-select">
-                  <option
-                    v-for="opt in unitOptions"
-                    :key="String(opt.value)"
-                    :value="opt.value"
-                  >
-                    {{ opt.label }}
-                  </option>
-                </select>
+                <AffixSelect
+                  v-model="unit"
+                  :options="unitOptions"
+                  :label="t('labels.logistics.unit')"
+                />
               </template>
               <span v-else class="base-input__suffix-text">
                 {{ t(`labels.logistics.units.${unit}`) }}

--- a/app/frontend/frontend/components/Logistics/InventoryItemModal/index.vue
+++ b/app/frontend/frontend/components/Logistics/InventoryItemModal/index.vue
@@ -10,6 +10,7 @@ import Modal from "@/shared/components/AppModal/Inner/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
+import AffixSelect from "@/shared/components/base/FormInput/AffixSelect/index.vue";
 import { InputTypesEnum } from "@/shared/components/base/FormInput/types";
 import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
 import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
@@ -404,15 +405,11 @@ const onSubmit = handleSubmit(async (values) => {
           >
             <template #suffix>
               <template v-if="isDeposit && unitOptions.length > 1">
-                <select v-model="unit" class="base-input__suffix-select">
-                  <option
-                    v-for="opt in unitOptions"
-                    :key="String(opt.value)"
-                    :value="opt.value"
-                  >
-                    {{ opt.label }}
-                  </option>
-                </select>
+                <AffixSelect
+                  v-model="unit"
+                  :options="unitOptions"
+                  :label="t('labels.logistics.unit')"
+                />
               </template>
               <span v-else class="base-input__suffix-text">
                 {{ t(`labels.logistics.units.${unit}`) }}

--- a/app/frontend/frontend/pages/visual-tests/forms.vue
+++ b/app/frontend/frontend/pages/visual-tests/forms.vue
@@ -12,6 +12,7 @@ import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
 import FormDatePicker from "@/shared/components/base/FormDatePicker/index.vue";
 import FormDateTime from "@/shared/components/base/FormDateTime/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
+import AffixSelect from "@/shared/components/base/FormInput/AffixSelect/index.vue";
 import FormInputGroup from "@/shared/components/base/FormInputGroup/index.vue";
 import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
 import FormToggle from "@/shared/components/base/FormToggle/index.vue";
@@ -41,6 +42,15 @@ const url = ref("https://fleetyards.net");
 const color = ref("#ffcc00");
 const clearable = ref("Clear me");
 const prefixed = ref(1250);
+
+const quantity = ref(12);
+const quantityUnit = ref("scu");
+
+const unitAffixOptions = [
+  { value: "scu", label: "SCU" },
+  { value: "cscu", label: "cSCU" },
+  { value: "mscu", label: "mSCU" },
+];
 const empty = ref<string | null>(null);
 const dateTime = ref<string | null>("2029-06-14T19:30:00.000Z");
 const dateOnly = ref<string | null>("2029-06-14T00:00:00.000Z");
@@ -229,6 +239,27 @@ const powerMarks = (value: number) => ({ label: String(value) });
         prefix="UEC"
         suffix="/ SCU"
       />
+    </div>
+    <div class="col-12 col-md-6 col-lg-3">
+      <!--
+        A select in the suffix slot, which the logistics quantity fields use for
+        their unit picker. It was uncovered here, and the rule behind its class
+        had to reach slot content to apply at all.
+      -->
+      <FormInput
+        v-model="quantity"
+        name="affix-select"
+        label="With a select affix"
+        :type="InputTypesEnum.NUMBER"
+      >
+        <template #suffix>
+          <AffixSelect
+            v-model="quantityUnit"
+            :options="unitAffixOptions"
+            label="Unit"
+          />
+        </template>
+      </FormInput>
     </div>
     <div class="col-12 col-md-6 col-lg-3">
       <FormInput

--- a/app/frontend/shared/components/base/FormInput/AffixSelect/index.scss
+++ b/app/frontend/shared/components/base/FormInput/AffixSelect/index.scss
@@ -1,0 +1,47 @@
+/*
+ * A select that lives in a field's prefix or suffix slot -- the logistics
+ * quantity fields use one for their unit picker.
+ *
+ * It is a component rather than a class the call sites write themselves, which is
+ * what it was: `base-input__suffix-select` appeared at two call sites with no
+ * rule anywhere behind it, so both rendered as raw platform controls inside a
+ * field that has none. A <select> inherits neither font nor colour, the same trap
+ * the FilterGroup trigger hit as a <button>.
+ *
+ * Styling it from FormInput was the obvious repair and does not work: the element
+ * arrives through a slot, so it carries the caller's scope attribute. `:slotted`
+ * is the answer to that in principle, but this project puts component styles in
+ * an imported file, and the runtime marker comes from analysing the <style> block
+ * itself -- which sees only the @import. Owning its own scope sidesteps all of
+ * it, and inheritance still reaches it from the affix wrapper in the DOM.
+ */
+.form-input-affix-select {
+  appearance: none;
+  padding: 0 14px 0 0;
+  border: none;
+  background: none;
+
+  /*
+   * The caret's colour is written out rather than read from --color-endcap: a
+   * data URI cannot resolve a custom property, and a mask over the element would
+   * swallow the label with it.
+   */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5' viewBox='0 0 8 5'%3E%3Cpath d='M.7.7 4 4 7.3.7' fill='none' stroke='%237a8288' stroke-width='1.2' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right center;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+
+  // The field's own cap already answers :focus-within, so this only has to say
+  // which control inside the field has focus, and can stay at a hairline.
+  &:focus-visible {
+    outline: 1px solid var(--color-primary, #428bca);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+}

--- a/app/frontend/shared/components/base/FormInput/AffixSelect/index.vue
+++ b/app/frontend/shared/components/base/FormInput/AffixSelect/index.vue
@@ -1,0 +1,49 @@
+<script lang="ts">
+export default {
+  name: "FormInputAffixSelect",
+};
+</script>
+
+<script lang="ts" setup>
+import { type FilterOption } from "@/services/fyApi";
+
+type Props = {
+  options: FilterOption[];
+  label: string;
+  modelValue?: string | number | null;
+  disabled?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: undefined,
+  disabled: false,
+});
+
+const emit = defineEmits(["update:modelValue"]);
+
+const onChange = (event: Event) => {
+  emit("update:modelValue", (event.target as HTMLSelectElement).value);
+};
+</script>
+
+<template>
+  <select
+    class="form-input-affix-select"
+    :value="props.modelValue"
+    :disabled="props.disabled"
+    :aria-label="props.label"
+    @change="onChange"
+  >
+    <option
+      v-for="option in props.options"
+      :key="String(option.value)"
+      :value="option.value"
+    >
+      {{ option.label }}
+    </option>
+  </select>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>


### PR DESCRIPTION
Found while answering "what do we do with `suffix-select`" ahead of the
FilterGroup rename.

Two logistics quantity fields put a bare `<select class="base-input__suffix-select">`
into `FormInput`'s suffix slot for their unit picker. **That class has no rule
anywhere in the codebase**, so both have been rendering as raw platform controls
inside a field that has none — a `<select>` inherits neither font nor colour,
which is the same trap the `FilterGroup` trigger hit as a `<button>`. The `<span>`
sibling beside it looks right only because the affix wrapper colours its text
children by inheritance.

## Why it is a component and not a rule

Styling it from `FormInput` is the obvious repair and does not work. The element
arrives through a slot, so it carries the *caller's* scope attribute, not
`FormInput`'s. `:slotted` answers that in principle, but this project keeps
component styles in an imported file and the runtime marker comes from analysing
the `<style>` block itself — which sees only the `@import`.

Verified rather than assumed: with `:slotted` in place the compiled CSS did carry
`[data-v-…-s]`, and the element in the DOM had **no scope attribute at all**, so
the rule could never match. No other component in the codebase uses `:slotted`,
so there was no precedent to check against.

A component with its own scope sidesteps the whole question, and removes the
duplicated markup at both call sites. Inheritance still reaches it from the affix
wrapper in the DOM.

## Verified

Live on a local server: `appearance` reset, the field's own font, the affix's
colour, a caret, no border, transparent background, three options, and its
accessible name from `labels.logistics.unit` — which already exists in all seven
locales.

It is also now on the visual-tests forms page, where an affix select had no
coverage at all.

🤖
