### PR TITLE
fix(visual-tests): stop framing the metric rails twice

### DIFF
--- a/app/frontend/frontend/pages/visual-tests/metrics.vue
+++ b/app/frontend/frontend/pages/visual-tests/metrics.vue
@@ -271,21 +271,19 @@ const sampleMetrics = [
   <Heading :level="HeadingLevelEnum.H2">Model Metrics | Panel Rails</Heading>
   <p>
     The rail panels from the ship detail page, fed with live
-    <code>{{ SLUG }}</code> data.
+    <code>{{ SLUG }}</code> data. Base and crew carry their own frame through
+    <code>MetricsCard</code>; speed is bare rows, so it is the only one that
+    needs a <code>Panel</code> around it.
     <Btn @click="toggleExtended">
       {{ extended ? "Collapse" : "Extend" }} dimensions
     </Btn>
   </p>
   <div v-if="model" class="row">
     <div class="col-12 col-lg-4">
-      <Panel>
-        <ModelBaseMetrics :model="model" :extended="extended" />
-      </Panel>
+      <ModelBaseMetrics :model="model" :extended="extended" />
     </div>
     <div class="col-12 col-lg-4">
-      <Panel>
-        <ModelCrewMetrics :model="model" />
-      </Panel>
+      <ModelCrewMetrics :model="model" />
     </div>
     <div class="col-12 col-lg-4">
       <Panel>


### PR DESCRIPTION
`/visual-tests/metrics` drew a double frame around the first two rail panels — two borders and two sets of end caps around one card.

`MetricsCard` has been a `Panel` in its own right since the panel redesign, so the extra `<Panel>` wrapper around `ModelBaseMetrics` and `ModelCrewMetrics` framed them a second time. The ship detail page renders both bare; the demo page now matches.

`ModelSpeedMetrics` keeps its wrapper — it is a bare row grid with no frame of its own — and a sentence in the section text now says why exactly one of the three columns has one.

Only the visual-test page changes; no component was touched. 🤖