### PR TITLE
fix(fleets): accept the s sort param on the member list

### DIFF
--- a/app/api_components/admin/v1/schemas/queries/admin_fleet_member_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/admin_fleet_member_query.rb
@@ -13,6 +13,9 @@ module Admin
               usernameCont: {type: :string},
               stateEq: {type: :string},
               roleCont: {type: :string},
+              s: {anyOf: [{
+                type: :array, items: ::Shared::V1::Schemas::Sorts::FleetMembershipSortEnum
+              }, ::Shared::V1::Schemas::Sorts::FleetMembershipSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Shared::V1::Schemas::Sorts::FleetMembershipSortEnum
               }, ::Shared::V1::Schemas::Sorts::FleetMembershipSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/admin_notification_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/admin_notification_query.rb
@@ -15,6 +15,9 @@ module Admin
               readAtNull: {type: :boolean},
               archivedAtNull: {type: :boolean},
               searchCont: {type: :string},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::AdminNotificationSortEnum
+              }, ::Admin::V1::Schemas::Sorts::AdminNotificationSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::AdminNotificationSortEnum
               }, ::Admin::V1::Schemas::Sorts::AdminNotificationSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/commodity_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/commodity_query.rb
@@ -25,6 +25,9 @@ module Admin
               sellPriceGteq: {type: :number},
               sellPriceLteq: {type: :number},
 
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::CommoditySortEnum
+              }, ::Admin::V1::Schemas::Sorts::CommoditySortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::CommoditySortEnum
               }, ::Admin::V1::Schemas::Sorts::CommoditySortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/component_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/component_query.rb
@@ -27,6 +27,9 @@ module Admin
               sellPriceGteq: {type: :number},
               sellPriceLteq: {type: :number},
 
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::ComponentSortEnum
+              }, ::Admin::V1::Schemas::Sorts::ComponentSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::ComponentSortEnum
               }, ::Admin::V1::Schemas::Sorts::ComponentSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/equipment_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/equipment_query.rb
@@ -32,6 +32,9 @@ module Admin
               sellPriceGteq: {type: :number},
               sellPriceLteq: {type: :number},
 
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::EquipmentSortEnum
+              }, ::Admin::V1::Schemas::Sorts::EquipmentSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::EquipmentSortEnum
               }, ::Admin::V1::Schemas::Sorts::EquipmentSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/fleet_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/fleet_query.rb
@@ -12,6 +12,9 @@ module Admin
             properties: {
               nameCont: {type: :string},
               fidCont: {type: :string},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::FleetSortEnum
+              }, ::Admin::V1::Schemas::Sorts::FleetSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::FleetSortEnum
               }, ::Admin::V1::Schemas::Sorts::FleetSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/funding_goal_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/funding_goal_query.rb
@@ -13,6 +13,9 @@ module Admin
               titleCont: {type: :string},
               effectiveFromGteq: {type: :string, format: :date},
               effectiveFromLteq: {type: :string, format: :date},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::FundingGoalSortEnum
+              }, ::Admin::V1::Schemas::Sorts::FundingGoalSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::FundingGoalSortEnum
               }, ::Admin::V1::Schemas::Sorts::FundingGoalSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/image_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/image_query.rb
@@ -12,6 +12,9 @@ module Admin
             properties: {
               galleryIdEq: {type: :string, format: :uuid},
               galleryTypeEq: {type: :string},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::ImageSortEnum
+              }, ::Admin::V1::Schemas::Sorts::ImageSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::ImageSortEnum
               }, ::Admin::V1::Schemas::Sorts::ImageSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/manufacturer_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/manufacturer_query.rb
@@ -18,6 +18,9 @@ module Admin
               slugEq: {type: :string},
               slugCont: {type: :string},
               slugIn: {type: :array, items: {type: :string}},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::ManufacturerSortEnum
+              }, ::Admin::V1::Schemas::Sorts::ManufacturerSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::ManufacturerSortEnum
               }, ::Admin::V1::Schemas::Sorts::ManufacturerSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/model_module_package_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/model_module_package_query.rb
@@ -14,6 +14,9 @@ module Admin
               nameCont: {type: :string},
               nameEq: {type: :string},
               modelIdEq: {type: :string, format: :uuid},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::ModelModulePackageSortEnum
+              }, ::Admin::V1::Schemas::Sorts::ModelModulePackageSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::ModelModulePackageSortEnum
               }, ::Admin::V1::Schemas::Sorts::ModelModulePackageSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/model_paint_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/model_paint_query.rb
@@ -19,6 +19,9 @@ module Admin
               idNotIn: {type: :array, items: {type: :string}},
               modelSlugIn: {type: :array, items: {type: :string}},
               modelSlugEq: {type: :string},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::ModelPaintSortEnum
+              }, ::Admin::V1::Schemas::Sorts::ModelPaintSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::ModelPaintSortEnum
               }, ::Admin::V1::Schemas::Sorts::ModelPaintSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/model_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/model_query.rb
@@ -24,6 +24,9 @@ module Admin
               topViewColoredBlank: {type: :boolean},
               frontViewBlank: {type: :boolean},
               positionsNeedCurationEq: {type: :boolean},
+              s: {anyOf: [{
+                type: :array, items: ::Shared::V1::Schemas::Sorts::ModelSortEnum
+              }, ::Shared::V1::Schemas::Sorts::ModelSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Shared::V1::Schemas::Sorts::ModelSortEnum
               }, ::Shared::V1::Schemas::Sorts::ModelSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/sc_data_unlisted_model_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/sc_data_unlisted_model_query.rb
@@ -21,6 +21,9 @@ module Admin
               decisionEq: ::Admin::V1::Schemas::Enums::UnlistedModelDecisionEnum,
               decisionNull: {type: :boolean},
 
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::ScDataUnlistedModelSortEnum
+              }, ::Admin::V1::Schemas::Sorts::ScDataUnlistedModelSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::ScDataUnlistedModelSortEnum
               }, ::Admin::V1::Schemas::Sorts::ScDataUnlistedModelSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/supporter_contribution_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/supporter_contribution_query.rb
@@ -22,6 +22,9 @@ module Admin
               userIdEq: {type: :string, format: :uuid},
               userIdNull: {type: :boolean},
               userUsernameCont: {type: :string},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::SupporterContributionSortEnum
+              }, ::Admin::V1::Schemas::Sorts::SupporterContributionSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::SupporterContributionSortEnum
               }, ::Admin::V1::Schemas::Sorts::SupporterContributionSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/user_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/user_query.rb
@@ -20,6 +20,9 @@ module Admin
               usernameIn: {type: :array, items: {type: :string}},
               emailIn: {type: :array, items: {type: :string}},
               rsihandleIn: {type: :array, items: {type: :string}},
+              s: {anyOf: [{
+                type: :array, items: ::Admin::V1::Schemas::Sorts::UserSortEnum
+              }, ::Admin::V1::Schemas::Sorts::UserSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Admin::V1::Schemas::Sorts::UserSortEnum
               }, ::Admin::V1::Schemas::Sorts::UserSortEnum]}

--- a/app/api_components/admin/v1/schemas/queries/vehicle_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/vehicle_query.rb
@@ -28,6 +28,9 @@ module Admin
               modelSearchCont: {type: :string},
               loanerEq: ::Shared::V1::Schemas::Enums::LoanerFilterEnum,
               wantedEq: {type: :boolean},
+              s: {anyOf: [{
+                type: :array, items: ::Shared::V1::Schemas::Sorts::VehicleSortEnum
+              }, ::Shared::V1::Schemas::Sorts::VehicleSortEnum]},
               sorts: {anyOf: [{
                 type: :array, items: ::Shared::V1::Schemas::Sorts::VehicleSortEnum
               }, ::Shared::V1::Schemas::Sorts::VehicleSortEnum]}

--- a/app/api_components/v1/schemas/queries/fleet_inventory_item_query.rb
+++ b/app/api_components/v1/schemas/queries/fleet_inventory_item_query.rb
@@ -15,6 +15,7 @@ module V1
             categoryEq: ::V1::Schemas::Enums::InventoryCategoryEnum,
             qualityGteq: {type: :integer},
             qualityLteq: {type: :integer},
+            s: {type: :string},
             sorts: {type: :string}
           },
           additionalProperties: false,

--- a/app/api_components/v1/schemas/queries/fleet_member_query.rb
+++ b/app/api_components/v1/schemas/queries/fleet_member_query.rb
@@ -21,6 +21,9 @@ module V1
             requestedAtLteq: {type: :string, format: :date},
             declinedAtGteq: {type: :string, format: :date},
             declinedAtLteq: {type: :string, format: :date},
+            s: {anyOf: [{
+              type: :array, items: ::Shared::V1::Schemas::Sorts::FleetMembershipSortEnum
+            }, ::Shared::V1::Schemas::Sorts::FleetMembershipSortEnum]},
             sorts: {anyOf: [{
               type: :array, items: ::Shared::V1::Schemas::Sorts::FleetMembershipSortEnum
             }, ::Shared::V1::Schemas::Sorts::FleetMembershipSortEnum]}

--- a/app/api_components/v1/schemas/queries/hangar_inventory_item_query.rb
+++ b/app/api_components/v1/schemas/queries/hangar_inventory_item_query.rb
@@ -15,6 +15,7 @@ module V1
             categoryEq: ::V1::Schemas::Enums::InventoryCategoryEnum,
             qualityGteq: {type: :integer},
             qualityLteq: {type: :integer},
+            s: {type: :string},
             sorts: {type: :string}
           },
           additionalProperties: false,

--- a/app/api_components/v1/schemas/queries/hangar_inventory_query.rb
+++ b/app/api_components/v1/schemas/queries/hangar_inventory_query.rb
@@ -10,6 +10,7 @@ module V1
           type: :object,
           properties: {
             nameCont: {type: :string},
+            s: {type: :string},
             sorts: {type: :string}
           },
           additionalProperties: false,

--- a/app/api_components/v1/schemas/queries/inventory_item_query.rb
+++ b/app/api_components/v1/schemas/queries/inventory_item_query.rb
@@ -15,6 +15,7 @@ module V1
             categoryEq: ::V1::Schemas::Enums::InventoryCategoryEnum,
             qualityGteq: {type: :integer},
             qualityLteq: {type: :integer},
+            s: {type: :string},
             sorts: {type: :string}
           },
           additionalProperties: false,

--- a/app/api_components/v1/schemas/queries/notification_query.rb
+++ b/app/api_components/v1/schemas/queries/notification_query.rb
@@ -13,6 +13,9 @@ module V1
             readAtNull: {type: :boolean},
             archivedAtNull: {type: :boolean},
             searchCont: {type: :string},
+            s: {anyOf: [{
+              type: :array, items: ::V1::Schemas::Sorts::NotificationSortEnum
+            }, ::V1::Schemas::Sorts::NotificationSortEnum]},
             sorts: {anyOf: [{
               type: :array, items: ::V1::Schemas::Sorts::NotificationSortEnum
             }, ::V1::Schemas::Sorts::NotificationSortEnum]}

--- a/app/controllers/admin/api/v1/commodities_controller.rb
+++ b/app/controllers/admin/api/v1/commodities_controller.rb
@@ -9,6 +9,7 @@ module Admin
         def index
           authorize! with: ::Admin::CommodityPolicy
 
+          normalize_sort_params(commodity_query_params)
           commodity_query_params["sorts"] = sorting_params(Commodity, commodity_query_params[:sorts])
 
           # The fallback join, not the current one: an admin list has to show a
@@ -75,7 +76,7 @@ module Admin
           @commodity_query_params ||= params.permit(q: [
             :name_cont, :name_eq, :id_eq, :commodity_type_eq, :commodity_type_cont,
             :uex_code_cont, :store_image_blank, :buy_price_gteq, :buy_price_lteq, :sell_price_gteq,
-            :sell_price_lteq, :sorts,
+            :sell_price_lteq, :s, :sorts,
             sorts: [], name_in: [], id_in: [], commodity_type_in: []
           ]).fetch(:q, {})
         end

--- a/app/controllers/admin/api/v1/components_controller.rb
+++ b/app/controllers/admin/api/v1/components_controller.rb
@@ -9,6 +9,7 @@ module Admin
         def index
           authorize! with: ::Admin::ComponentPolicy
 
+          normalize_sort_params(component_query_params)
           component_query_params["sorts"] = sorting_params(Component, component_query_params[:sorts])
 
           # The fallback join, not the fast one: the admin list has to show a
@@ -85,7 +86,7 @@ module Admin
           @component_query_params ||= params.permit(q: [
             :name_cont, :name_eq, :id_eq, :item_type_eq,
             :item_type_cont, :component_class_cont, :store_image_blank, :buy_price_gteq,
-            :buy_price_lteq, :sell_price_gteq, :sell_price_lteq, :sorts,
+            :buy_price_lteq, :sell_price_gteq, :sell_price_lteq, :s, :sorts,
             sorts: [], name_in: [], id_in: [], item_type_in: [], component_class_in: [],
             manufacturer_id_in: []
           ]).fetch(:q, {})

--- a/app/controllers/admin/api/v1/equipment_controller.rb
+++ b/app/controllers/admin/api/v1/equipment_controller.rb
@@ -9,6 +9,7 @@ module Admin
         def index
           authorize! with: ::Admin::EquipmentPolicy
 
+          normalize_sort_params(equipment_query_params)
           sorts = sorting_params(Equipment, equipment_query_params[:sorts])
           name_sort = sorts.find { |sort| sort.start_with?("name ") }
           equipment_query_params["sorts"] = sorts - [name_sort].compact
@@ -119,7 +120,7 @@ module Admin
             :name_cont, :name_eq, :id_eq, :equipment_type_eq, :equipment_type_cont,
             :item_type_eq, :item_type_cont, :sub_type_cont, :weapon_class_cont,
             :hidden_eq, :store_image_blank, :buy_price_gteq, :buy_price_lteq, :sell_price_gteq,
-            :sell_price_lteq, :sorts,
+            :sell_price_lteq, :s, :sorts,
             sorts: [], name_in: [], id_in: [], equipment_type_in: [], item_type_in: [],
             weapon_class_in: [], slot_in: [], manufacturer_id_in: []
           ]).fetch(:q, {})

--- a/app/controllers/admin/api/v1/fleet_members_controller.rb
+++ b/app/controllers/admin/api/v1/fleet_members_controller.rb
@@ -12,6 +12,7 @@ module Admin
         end
 
         def index
+          normalize_sort_params(member_query_params)
           member_query_params["sorts"] = sorting_params(FleetMembership, member_query_params[:sorts])
 
           @q = @fleet.fleet_memberships.kept.ransack(member_query_params)
@@ -82,7 +83,7 @@ module Admin
 
         private def member_query_params
           @member_query_params ||= params.permit(q: [
-            :username_cont, :state_eq, :role_cont, :sorts, sorts: []
+            :username_cont, :state_eq, :role_cont, :s, :sorts, s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/fleets_controller.rb
+++ b/app/controllers/admin/api/v1/fleets_controller.rb
@@ -13,6 +13,7 @@ module Admin
         def index
           authorize! with: ::Admin::FleetPolicy
 
+          normalize_sort_params(fleet_query_params)
           fleet_query_params["sorts"] = sorting_params(Fleet, fleet_query_params[:sorts])
 
           @q = Fleet.kept.ransack(fleet_query_params)
@@ -76,7 +77,7 @@ module Admin
 
         private def fleet_query_params
           @fleet_query_params ||= params.permit(q: [
-            :name_cont, :fid_cont, :sorts, sorts: []
+            :name_cont, :fid_cont, :s, :sorts, s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/funding_goals_controller.rb
+++ b/app/controllers/admin/api/v1/funding_goals_controller.rb
@@ -13,6 +13,7 @@ module Admin
         def index
           authorize! with: ::Admin::FundingGoalPolicy
 
+          normalize_sort_params(funding_goal_query_params)
           funding_goal_query_params["sorts"] = sorting_params(FundingGoal, funding_goal_query_params[:sorts])
 
           q = FundingGoal.ransack(funding_goal_query_params)
@@ -64,7 +65,7 @@ module Admin
             :title_cont,
             :amount_cents_eq, :amount_cents_gteq, :amount_cents_lteq,
             :effective_from_eq, :effective_from_gteq, :effective_from_lteq,
-            :sorts, sorts: []
+            :s, :sorts, s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/images_controller.rb
+++ b/app/controllers/admin/api/v1/images_controller.rb
@@ -12,6 +12,7 @@ module Admin
         def index
           authorize!
 
+          normalize_sort_params(image_query_params)
           image_query_params["sorts"] = sorting_params(Image, image_query_params[:sorts])
 
           @q = authorized_scope(Image.all).ransack(image_query_params)
@@ -61,8 +62,8 @@ module Admin
 
         private def image_query_params
           @image_query_params ||= params.permit(q: [
-            :gallery_id_eq, :gallery_type_eq, :sorts,
-            sorts: []
+            :gallery_id_eq, :gallery_type_eq, :s, :sorts,
+            s: [], sorts: []
           ]).fetch(:q, {})
         end
 

--- a/app/controllers/admin/api/v1/manufacturers_controller.rb
+++ b/app/controllers/admin/api/v1/manufacturers_controller.rb
@@ -17,6 +17,7 @@ module Admin
 
           scope = scope.with_model if manufacturer_query_params.delete(:with_models)
 
+          normalize_sort_params(manufacturer_query_params)
           manufacturer_query_params["sorts"] = sorting_params(Manufacturer, manufacturer_query_params[:sorts])
 
           q = scope.ransack(manufacturer_query_params)
@@ -88,8 +89,8 @@ module Admin
 
         private def manufacturer_query_params
           @manufacturer_query_params ||= params.permit(q: [
-            :with_models, :name_eq, :name_cont, :slug_eq, :slug_cont, :logo_blank, :sorts,
-            name_in: [], slug_in: [], sorts: []
+            :with_models, :name_eq, :name_cont, :slug_eq, :slug_cont, :logo_blank, :s, :sorts,
+            name_in: [], slug_in: [], s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/model_module_packages_controller.rb
+++ b/app/controllers/admin/api/v1/model_module_packages_controller.rb
@@ -13,6 +13,7 @@ module Admin
         def index
           authorize! with: ::Admin::ModelModulePackagePolicy
 
+          normalize_sort_params(model_module_package_query_params)
           model_module_package_query_params["sorts"] = sorting_params(ModelModulePackage, model_module_package_query_params[:sorts], "created_at desc")
 
           @q = authorized_scope(ModelModulePackage.all).ransack(model_module_package_query_params)
@@ -75,8 +76,8 @@ module Admin
 
         private def model_module_package_query_params
           @model_module_package_query_params ||= params.permit(q: [
-            :name_in, :id_eq, :name_cont, :name_eq, :model_id_eq, :sorts,
-            sorts: []
+            :name_in, :id_eq, :name_cont, :name_eq, :model_id_eq, :s, :sorts,
+            s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/model_paints_controller.rb
+++ b/app/controllers/admin/api/v1/model_paints_controller.rb
@@ -13,6 +13,7 @@ module Admin
         def index
           authorize! with: ::Admin::ModelPaintPolicy
 
+          normalize_sort_params(model_paint_query_params)
           model_paint_query_params["sorts"] = sorting_params(ModelPaint, model_paint_query_params[:sorts], "created_at desc")
 
           @q = authorized_scope(ModelPaint.all).ransack(model_paint_query_params)
@@ -64,8 +65,8 @@ module Admin
 
         private def model_paint_query_params
           @model_paint_query_params ||= params.permit(q: [
-            :name_in, :id_eq, :name_cont, :name_eq, :model_id_eq, :sorts,
-            sorts: []
+            :name_in, :id_eq, :name_cont, :name_eq, :model_id_eq, :s, :sorts,
+            s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/models_controller.rb
+++ b/app/controllers/admin/api/v1/models_controller.rb
@@ -155,6 +155,7 @@ module Admin
         end
 
         private def index_scope
+          normalize_sort_params(model_query_params)
           model_query_params["sorts"] = sorting_params(Model, model_query_params[:sorts])
 
           Model.includes([:manufacturer]).ransack(model_query_params)
@@ -163,9 +164,9 @@ module Admin
         private def model_query_params
           @model_query_params ||= params.permit(q: [
             :search_cont, :name_cont, :id_eq, :front_view_blank, :fleetchart_image_blank,
-            :top_view_colored_blank, :holo_blank, :sc_key_blank, :sorts,
+            :top_view_colored_blank, :holo_blank, :sc_key_blank, :s, :sorts,
             name_in: [], id_in: [], id_not_in: [], production_status_in: [],
-            manufacturer_in: [], sorts: []
+            manufacturer_in: [], s: [], sorts: []
           ]).fetch(:q, {})
         end
 

--- a/app/controllers/admin/api/v1/notifications_controller.rb
+++ b/app/controllers/admin/api/v1/notifications_controller.rb
@@ -13,6 +13,7 @@ module Admin
 
           notification_query_params["archived_at_null"] = true unless notification_query_params.key?("archived_at_null")
 
+          normalize_sort_params(notification_query_params)
           notification_query_params["sorts"] = unread_first(
             sorting_params(AdminNotification, notification_query_params["sorts"])
           )
@@ -166,7 +167,7 @@ module Admin
 
         private def notification_query_params
           @notification_query_params ||= params.permit(q: [
-            :notification_type_eq, :severity_eq, :read_at_null, :archived_at_null, :search_cont, :sorts, sorts: []
+            :notification_type_eq, :severity_eq, :read_at_null, :archived_at_null, :search_cont, :s, :sorts, s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
+++ b/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
@@ -13,6 +13,7 @@ module Admin
         def index
           authorize! with: ::Admin::ScDataUnlistedModelPolicy
 
+          normalize_sort_params(query_params)
           query_params["sorts"] = sorting_params(ScDataUnlistedModel, query_params[:sorts])
 
           # Undecided by default, because that is the working list. An explicit
@@ -87,7 +88,7 @@ module Admin
 
         private def query_params
           @query_params ||= params.permit(q: [
-            :sorts, :identifier_cont, :name_cont, :comparison_eq, :decision_eq,
+            :s, :sorts, :identifier_cont, :name_cont, :comparison_eq, :decision_eq,
             :decision_null, :manufacturer_code_eq
           ]).fetch(:q, {})
         end

--- a/app/controllers/admin/api/v1/supporter_contributions_controller.rb
+++ b/app/controllers/admin/api/v1/supporter_contributions_controller.rb
@@ -13,6 +13,7 @@ module Admin
         def index
           authorize! with: ::Admin::SupporterContributionPolicy
 
+          normalize_sort_params(supporter_contribution_query_params)
           supporter_contribution_query_params["sorts"] = sorting_params(SupporterContribution, supporter_contribution_query_params[:sorts])
 
           q = SupporterContribution.ransack(supporter_contribution_query_params)
@@ -106,7 +107,7 @@ module Admin
             :name_cont, :name_eq, :recurring_eq, :anonymous_eq, :source_eq,
             :started_at_gteq, :started_at_lteq, :ended_at_gteq, :ended_at_lteq,
             :user_id_eq, :user_id_null, :user_username_cont,
-            :sorts, sorts: []
+            :s, :sorts, s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/users_controller.rb
+++ b/app/controllers/admin/api/v1/users_controller.rb
@@ -13,6 +13,7 @@ module Admin
         def index
           authorize! with: ::Admin::UserPolicy
 
+          normalize_sort_params(user_query_params)
           user_query_params["sorts"] = sorting_params(User, user_query_params[:sorts])
 
           q = authorized_scope(User.all).ransack(user_query_params)
@@ -83,8 +84,8 @@ module Admin
 
         private def user_query_params
           @user_query_params ||= params.permit(q: [
-            :id_eq, :search_cont, :username_cont, :username_eq, :email_cont, :rsi_handle_cont, :sorts,
-            id_in: [], username_in: [], email_in: [], rsi_handle_in: [], sorts: []
+            :id_eq, :search_cont, :username_cont, :username_eq, :email_cont, :rsi_handle_cont, :s, :sorts,
+            id_in: [], username_in: [], email_in: [], rsi_handle_in: [], s: [], sorts: []
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/admin/api/v1/vehicles_controller.rb
+++ b/app/controllers/admin/api/v1/vehicles_controller.rb
@@ -51,6 +51,7 @@ module Admin
         end
 
         private def index_scope
+          normalize_sort_params(vehicle_query_params)
           vehicle_query_params["sorts"] ||= sorting_params(Vehicle, vehicle_query_params["sorts"])
 
           scope = authorized_scope(Vehicle.all).includes(:user, model: :manufacturer).where(hidden: false)
@@ -63,7 +64,8 @@ module Admin
         private def vehicle_query_params
           @vehicle_query_params ||= params.permit(q: [
             :search_cont, :name_cont, :model_name_cont, :id_eq, :model_id_eq,
-            :loaner_eq, :wanted_eq,
+            :loaner_eq, :wanted_eq, :s, :sorts,
+            s: [], sorts: [],
             name_in: [], id_in: [], id_not_in: [], model_slug_in: [], model_name_in: [],
             model_id_in: [], model_id_not_in: [], model_production_status_in: [],
             manufacturer_in: [], user_username_in: []

--- a/app/controllers/api/v1/fleet_members_controller.rb
+++ b/app/controllers/api/v1/fleet_members_controller.rb
@@ -27,6 +27,7 @@ module Api
 
         scope = @fleet.fleet_memberships.kept
 
+        normalize_sort_params(member_query_params)
         member_query_params["sorts"] = sorting_params(FleetMembership, member_query_params["sorts"])
 
         @q = scope.ransack(member_query_params)

--- a/app/controllers/api/v1/fleet_stats_controller.rb
+++ b/app/controllers/api/v1/fleet_stats_controller.rb
@@ -13,7 +13,9 @@ module Api
       before_action :set_fleet
 
       def members
-        @q = @fleet.fleet_memberships.kept.accepted.ransack(member_query_params)
+        # Sorting a grouped count puts the ordered column outside the GROUP BY,
+        # which Postgres rejects. Stats never need an order anyway.
+        @q = @fleet.fleet_memberships.kept.accepted.ransack(member_query_params.except("sorts", "s"))
 
         members = @q.result
 

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -19,6 +19,7 @@ module Api
       def index
         authorize! with: NotificationPolicy
 
+        normalize_sort_params(notification_query_params)
         notification_query_params["sorts"] = unread_first(
           sorting_params(Notification, notification_query_params["sorts"])
         )
@@ -190,7 +191,7 @@ module Api
 
       private def notification_query_params
         @notification_query_params ||= params.permit(q: [
-          :notification_type_eq, :read_at_null, :archived_at_null, :search_cont, :sorts, sorts: []
+          :notification_type_eq, :read_at_null, :archived_at_null, :search_cont, :s, :sorts, s: [], sorts: []
         ]).fetch(:q, {})
       end
     end

--- a/app/controllers/api/v1/public/fleet_stats_controller.rb
+++ b/app/controllers/api/v1/public/fleet_stats_controller.rb
@@ -24,7 +24,7 @@ module Api
         end
 
         def members
-          @q = @fleet.fleet_memberships.kept.accepted.ransack(member_query_params)
+          @q = @fleet.fleet_memberships.kept.accepted.ransack(member_query_params.except("sorts", "s"))
 
           members = @q.result
 

--- a/app/controllers/api/v1/public/hangars_controller.rb
+++ b/app/controllers/api/v1/public/hangars_controller.rb
@@ -13,6 +13,7 @@ module Api
         after_action -> { pagination_header(:vehicles) }, only: %i[show]
 
         def show
+          normalize_sort_params(vehicle_query_params)
           vehicle_query_params["sorts"] = sorting_params(Vehicle, vehicle_query_params[:sorts])
 
           scope = @user.vehicles
@@ -40,6 +41,7 @@ module Api
           usernames = params.fetch(:usernames, []).map(&:downcase)
           user_ids = User.where(normalized_username: usernames, public_hangar: true).pluck(:id)
 
+          normalize_sort_params(vehicle_query_params)
           vehicle_query_params["sorts"] = sorting_params(Vehicle, vehicle_query_params[:sorts], ["model_name asc"])
 
           @q = Vehicle.where(user_id: user_ids)

--- a/app/controllers/api/v1/public/wishlists_controller.rb
+++ b/app/controllers/api/v1/public/wishlists_controller.rb
@@ -10,6 +10,7 @@ module Api
         after_action -> { pagination_header(:vehicles) }, only: %i[show]
 
         def show
+          normalize_sort_params(vehicle_query_params)
           vehicle_query_params["sorts"] = sorting_params(Vehicle, vehicle_query_params[:sorts], ["name asc", "model_name asc"])
 
           scope = @user.vehicles.wanted.where(loaner: false)

--- a/app/controllers/api/v1/wishlists_controller.rb
+++ b/app/controllers/api/v1/wishlists_controller.rb
@@ -34,6 +34,7 @@ module Api
         scope = bundled_included?(scope)
         scope = will_it_fit?(scope) if vehicle_query_params["will_it_fit"].present?
 
+        normalize_sort_params(vehicle_query_params)
         vehicle_query_params["sorts"] = sorting_params(Vehicle, vehicle_query_params["sorts"], ["name asc", "model_name asc"])
 
         @q = scope.ransack(vehicle_query_params)

--- a/app/controllers/concerns/fleet_member_filters_concern.rb
+++ b/app/controllers/concerns/fleet_member_filters_concern.rb
@@ -3,12 +3,12 @@
 module FleetMemberFiltersConcern
   private def member_query_params
     @member_query_params ||= params.permit(q: [
-      :username_cont, :name_cont, :sorts,
+      :username_cont, :name_cont, :s, :sorts,
       :accepted_at_gteq, :accepted_at_lteq,
       :invited_at_gteq, :invited_at_lteq,
       :requested_at_gteq, :requested_at_lteq,
       :declined_at_gteq, :declined_at_lteq,
-      role_in: [], state_in: [], sorts: []
+      role_in: [], state_in: [], s: [], sorts: []
     ]).fetch(:q, {})
   end
 end

--- a/app/helpers/ransack_helper.rb
+++ b/app/helpers/ransack_helper.rb
@@ -12,7 +12,13 @@ module RansackHelper
   # Ransack accepts both "s" and "sorts" for sorting. This helper
   # normalizes the query params so that sorting_params always has data
   # regardless of which key the client used.
+  #
+  # "s" is always removed, not just when it is the one that fills "sorts" in:
+  # ransack reads "s" itself, so a leftover would silently outrank the "sorts"
+  # that sorting_params has whitelisted.
   def normalize_sort_params(query_params)
-    query_params["sorts"] ||= query_params.delete("s") if query_params["s"].present?
+    sorts = query_params.delete("s")
+
+    query_params["sorts"] ||= sorts if sorts.present?
   end
 end

--- a/docs/exec-plans/4637-members-list-sorting-server-error.md
+++ b/docs/exec-plans/4637-members-list-sorting-server-error.md
@@ -1,0 +1,205 @@
+# Server Error Members List
+
+## Goal
+Sorting any list in the app sends a query the API accepts, so clicking a sortable
+table header sorts the list instead of rendering the ServerError page.
+
+## Context
+Sorting the fleet member list returns **400 Bad Request**, which `FilteredList`
+renders as the generic `ServerError` component — hence the "Server Error"
+report. Reproduced locally against `/api/v1/fleets/:slug/members`:
+
+```
+q[s]=username asc     -> 400 {"error":"Request validation failed",
+  "details":["Invalid query parameter 'q': object property at `/s` is a disallowed additional property"]}
+q[sorts]=username asc -> 200
+```
+
+The chain:
+
+1. `useTableSorting` writes the active sort into the **route** query as `?s=username asc`.
+2. `useFilters.getQuery()` spreads the whole `route.query` into the API's `q`
+   object, so `s` is sent as `q[s]`.
+3. The endpoint's query schema declares only `sorts` and sets
+   `additionalProperties: false`. openapi-ruby request validation is
+   `:enabled` globally (`config/initializers/openapi_ruby.rb`), production
+   included, so the request is rejected before the controller runs.
+4. `FleetMemberFiltersConcern` does not permit `:s` and the controller never
+   calls `normalize_sort_params`, so even past the validator the sort would be
+   silently dropped in favour of `DEFAULT_SORTING_PARAMS`.
+
+`410fc1971 "fix(api): support s param for sorting across all endpoints"`
+(2026-04-25) established the fix pattern but only applied it to three schemas:
+`fleet_vehicle_query`, `hangar_query`, `model_query`. Of 25 query schemas that
+accept `sorts`, only those 3 also accept `s`.
+
+Resolves #4637
+
+## Decisions
+
+### D1 — Fix on the API side, not in `useFilters`
+The tempting one-line fix is to have `getQuery()` translate `s` into `sorts`.
+Rejected: `getQuery()` serves double duty — `debouncedFilter` feeds its result
+straight into `router.replace({ query: ... })`. Renaming the key there would
+rewrite the browser URL to `?sorts=…`, which `useTableSorting` (reads
+`route.query.s`) no longer recognises, breaking the sort indicator and every
+shared/bookmarked sort link. The URL contract stays `s`; the API learns to
+accept it.
+
+### D2 — Apply the rule uniformly: every schema that accepts `sorts` accepts `s`
+Only 8 pages leak `s` into `q` today (see Key files). Most admin pages are
+unaffected because they map `route.query.s` to `q.sorts` themselves and
+`filters.value` strips `s`. Two admin pages (`models`, `vehicles`) do leak it,
+because they spread `...getQuery()` *and* pass an explicit `sorts`.
+
+Still applying `s` to all schemas that accept `sorts`, rather than only the 8
+reachable ones, because:
+- The invariant "`s` is the alias for `sorts`" is then true everywhere, so this
+  bug class cannot come back the next time a page starts spreading `route.query`.
+- It is what the earlier commit's title already promised.
+- A per-endpoint exception list is invisible in the frontend and would be
+  re-discovered as a production 400.
+
+Schemas with **no** `sorts` (e.g. `inventory_stock_query`) are left alone — they
+have no sort surface, and none of them receive a leaked `s`.
+
+### D3 — Permit and normalize wherever the schema gains `s`
+Adding `s` to a schema alone only stops the 400; the sort would still be
+ignored. Every controller whose schema gains `s` also gets `:s` permitted and
+`normalize_sort_params` called before `sorting_params`, matching
+`fleet_vehicle_filters_concern` / `hangar_inventories_controller`. Exception:
+controllers that never read `q[s]` because the frontend already sends an
+explicit `sorts` (admin `models`, `vehicles`) still get it, so the param means
+the same thing on every endpoint.
+
+### D4 — Leave the permit lists explicit, do not switch to ParamsHelper
+`HangarFiltersConcern` derives its permit list straight from the schema
+(`ParamsHelper.new("v1/schema.yaml").to_params("HangarQuery")`), which is why
+the hangar endpoints never drifted. That is the durable answer to this bug
+class, but converting 20 controllers to it is a refactor with its own failure
+mode (a stale committed yaml silently narrows strong params). Kept explicit
+here; noted as the follow-up.
+
+## What changed
+
+### Phase 1 — Fleet members (the reported bug)
+1. `V1::Schemas::Queries::FleetMemberQuery` — add `s` mirroring `sorts`
+   (`anyOf` of array-of-`FleetMembershipSortEnum` and the bare enum).
+2. `FleetMemberFiltersConcern` — permit `:s`.
+3. `Api::V1::FleetMembersController#index` — call
+   `normalize_sort_params(member_query_params)` before `sorting_params`.
+4. Regression tests in `test/integration/api/v1/fleets_members_index_test.rb`
+   for each of the four sortable columns via `q[s]`, asserting 200 and order.
+
+### Phase 2 — The other endpoints the frontend actually breaks
+Same three-part change for:
+- `V1::Schemas::Queries::FleetInventoryItemQuery` (fleet logistics, fleet inventory detail)
+- `V1::Schemas::Queries::HangarInventoryItemQuery` (hangar inventories, inventory detail)
+- `V1::Schemas::Queries::HangarInventoryQuery`
+- `V1::Schemas::Queries::InventoryItemQuery` (ship cargo page)
+- `Admin::V1::Schemas::Queries::ModelQuery` (admin models list)
+- `Admin::V1::Schemas::Queries::VehicleQuery` (admin vehicles list)
+
+The four inventory controllers already permit `:s` and call
+`normalize_sort_params`; only their schemas need the addition.
+
+### Phase 3 — Uniform sweep of the remaining `sorts` schemas
+Add `s` to the remaining schemas that accept `sorts` and give their controllers
+`:s` + `normalize_sort_params`: `notification_query`, and the admin
+`admin_fleet_member`, `admin_notification`, `commodity`, `component`,
+`equipment`, `fleet`, `funding_goal`, `image`, `manufacturer`,
+`model_module_package`, `model_paint`, `sc_data_unlisted_model`,
+`supporter_contribution` queries.
+
+### Phase 3b — Two further bugs the new tests exposed
+1. `normalize_sort_params` only deleted `s` when it was the key that filled
+   `sorts` in. With both present, `||=` short-circuits, `s` survives into
+   `ransack`, and ransack reads `s` itself — so the unvalidated `s` outranked
+   the whitelisted `sorts`. It now always deletes `s`.
+2. `/fleets/:slug/stats/members` returned a **500** for any sort param:
+   `members_by_role` is a grouped count, so an ORDER BY on `users.username`
+   leaves an ungrouped column in the query and Postgres rejects it
+   (`PG::GroupingError`). Both stats controllers now strip `sorts`/`s` the way
+   `model_counts` already did. This was live before this change — `sorts` alone
+   was enough to trigger it.
+
+### Phase 4 — Schema regeneration and diff review
+1. Regenerate `swagger/v1/schema.yaml` and `swagger/admin/v1/schema.yaml`.
+2. Regenerate the TS clients so `lint:ts` stays clean.
+3. Review the `oasdiff` result — additive optional properties only, so
+   `api-schema-breaking` must stay green.
+
+## Intent Verification
+
+- [ ] **All four member columns sort** — `/fleets/:slug/members/?s=username asc`,
+      `rsiHandle asc`, `acceptedAt asc`, `lastActiveAt asc` each return 200 and
+      the documented order, asc and desc.
+- [ ] **The invites list sorts** — same endpoint, `variant="invites"` page.
+- [ ] **No page leaks a rejected param** — for every `getQuery()` call site, the
+      endpoint's schema accepts `s`.
+- [ ] **`s` and `sorts` agree** — where both are sent, `sorts` wins (unchanged
+      `normalize_sort_params` semantics: `s` only fills in when `sorts` is absent).
+- [ ] **Schema diff is additive** — `api-schema-breaking` green.
+- [ ] **Ruby + TS lint and the touched integration tests pass.**
+
+## Key files
+
+| File | Role |
+|------|------|
+| `app/frontend/shared/composables/useTableSorting.ts` | Writes `?s=<field> <dir>` into the route |
+| `app/frontend/shared/composables/useFilters.ts` | `getQuery()` spreads `route.query` into the API `q` — the leak |
+| `app/frontend/shared/components/FilteredList/index.vue` | Renders `ServerError` for any non-403 error, masking the 400 |
+| `app/api_components/v1/schemas/queries/fleet_member_query.rb` | Rejects `q[s]` via `additionalProperties: false` |
+| `app/api_components/v1/schemas/queries/fleet_vehicle_query.rb` | Reference for the `s` declaration |
+| `app/controllers/concerns/fleet_member_filters_concern.rb` | Strong params for the member list |
+| `app/controllers/api/v1/fleet_members_controller.rb` | Missing `normalize_sort_params` |
+| `app/helpers/ransack_helper.rb` | `normalize_sort_params` / `sorting_params` |
+| `config/initializers/openapi_ruby.rb` | `request_validation = :enabled` — why this is a 400 in production |
+| `test/integration/api/v1/fleets_members_index_test.rb` | Existing `sorts` coverage to extend with `s` |
+
+**Pages that leak `s` into `q`** (via `getQuery()`):
+`fleets/[slug]/members/index.vue`, `fleets/[slug]/members/invites.vue`,
+`fleets/[slug]/logistics/index.vue`,
+`fleets/[slug]/logistics/inventories/[inventory].vue`,
+`hangar/inventories/index.vue`, `hangar/inventories/[inventory].vue`,
+`hangar/[id]/cargo.vue`, `admin/pages/models/index.vue`,
+`admin/pages/vehicles/index.vue`. (`ships/index.vue`, `hangar/index.vue` and
+`Fleets/ShipsList` also leak it, but their schemas already accept `s`.)
+
+## Not in scope (deferred)
+- **Making `FilteredList` distinguish 400 from 5xx** — a 400 rendering as
+  "Server Error" is why this took a user report to surface, but changing the
+  error surface is its own UX decision.
+- **Retiring `s` in favour of `sorts` end to end** — would change every
+  bookmarkable sort URL.
+- **Schemas with no `sorts`** — no sort surface, no leaked `s`.
+- **A CI check that every `getQuery()` call site's schema accepts `s`** — worth
+  having, but needs a frontend↔schema mapping that does not exist yet.
+- **Deriving permit lists from the schema everywhere** (see D4) — the real cure
+  for permit-vs-schema drift.
+- **`ModelUpgradeQuery`** — its controller permits and reads `sorts`, but the
+  schema declares no sorting at all, so `q[sorts]` 400s there today. Nothing in
+  the UI sorts that list and there is no `ModelUpgradeSortEnum` to reference, so
+  fixing it means designing the sort surface, not adding a param.
+
+## Discovery Log
+
+- **2026-08-31** Reproduced the failure as a 400 from openapi-ruby request
+  validation, not a 500. Traced the leak to `useFilters.getQuery()` spreading
+  `route.query`. Audited all 25 `sorts`-accepting schemas: 22 reject `s`.
+  Established that most admin pages are unaffected (they map `s` to `sorts`
+  themselves); `admin/models` and `admin/vehicles` are not. Rejected fixing
+  `getQuery()` because it also builds the browser URL.
+- **2026-08-31** Implemented. The new "prefers sorts over s" test failed and
+  exposed the `normalize_sort_params` short-circuit; the stats probe exposed a
+  pre-existing 500 on `/fleets/:slug/stats/members` for any sort param. Both
+  fixed. Generated clients live under `.gitignore`, so only the two
+  `swagger/*.yaml` files carry the regeneration. 22 schemas gained `s`
+  (+116 lines of yaml, all additive optional properties).
+
+## Progress
+- [x] Phase 1 — Fleet members
+- [x] Phase 2 — Other reachable endpoints
+- [x] Phase 3 — Uniform sweep
+- [x] Phase 3b — `normalize_sort_params` and the member stats 500
+- [x] Phase 4 — Schema regeneration and diff review

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -8236,6 +8236,12 @@ components:
           type: string
         roleCont:
           type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/FleetMembershipSortEnum"
+          - "$ref": "#/components/schemas/FleetMembershipSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -8478,6 +8484,12 @@ components:
           type: boolean
         searchCont:
           type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/AdminNotificationSortEnum"
+          - "$ref": "#/components/schemas/AdminNotificationSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -9104,6 +9116,12 @@ components:
           type: number
         sellPriceLteq:
           type: number
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/CommoditySortEnum"
+          - "$ref": "#/components/schemas/CommoditySortEnum"
         sorts:
           anyOf:
           - type: array
@@ -9608,6 +9626,12 @@ components:
           type: number
         sellPriceLteq:
           type: number
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/ComponentSortEnum"
+          - "$ref": "#/components/schemas/ComponentSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -10616,6 +10640,12 @@ components:
           type: number
         sellPriceLteq:
           type: number
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/EquipmentSortEnum"
+          - "$ref": "#/components/schemas/EquipmentSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -11155,6 +11185,12 @@ components:
           type: string
         fidCont:
           type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/FleetSortEnum"
+          - "$ref": "#/components/schemas/FleetSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -11270,6 +11306,12 @@ components:
         effectiveFromLteq:
           type: string
           format: date
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/FundingGoalSortEnum"
+          - "$ref": "#/components/schemas/FundingGoalSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -11662,6 +11704,12 @@ components:
           format: uuid
         galleryTypeEq:
           type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/ImageSortEnum"
+          - "$ref": "#/components/schemas/ImageSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -12310,6 +12358,12 @@ components:
           type: array
           items:
             type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/ManufacturerSortEnum"
+          - "$ref": "#/components/schemas/ManufacturerSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -13793,6 +13847,12 @@ components:
         modelIdEq:
           type: string
           format: uuid
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/ModelModulePackageSortEnum"
+          - "$ref": "#/components/schemas/ModelModulePackageSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -14126,6 +14186,12 @@ components:
             type: string
         modelSlugEq:
           type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/ModelPaintSortEnum"
+          - "$ref": "#/components/schemas/ModelPaintSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -14309,6 +14375,12 @@ components:
           type: boolean
         positionsNeedCurationEq:
           type: boolean
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/ModelSortEnum"
+          - "$ref": "#/components/schemas/ModelSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -15280,6 +15352,12 @@ components:
           "$ref": "#/components/schemas/UnlistedModelDecisionEnum"
         decisionNull:
           type: boolean
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/ScDataUnlistedModelSortEnum"
+          - "$ref": "#/components/schemas/ScDataUnlistedModelSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -15530,6 +15608,12 @@ components:
           type: boolean
         userUsernameCont:
           type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/SupporterContributionSortEnum"
+          - "$ref": "#/components/schemas/SupporterContributionSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -15816,6 +15900,12 @@ components:
           type: array
           items:
             type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/UserSortEnum"
+          - "$ref": "#/components/schemas/UserSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -16076,6 +16166,12 @@ components:
           "$ref": "#/components/schemas/LoanerFilterEnum"
         wantedEq:
           type: boolean
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/VehicleSortEnum"
+          - "$ref": "#/components/schemas/VehicleSortEnum"
         sorts:
           anyOf:
           - type: array

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -13931,6 +13931,8 @@ components:
           type: integer
         qualityLteq:
           type: integer
+        s:
+          type: string
         sorts:
           type: string
       additionalProperties: false
@@ -14256,6 +14258,12 @@ components:
         declinedAtLteq:
           type: string
           format: date
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/FleetMembershipSortEnum"
+          - "$ref": "#/components/schemas/FleetMembershipSortEnum"
         sorts:
           anyOf:
           - type: array
@@ -15430,6 +15438,8 @@ components:
           type: integer
         qualityLteq:
           type: integer
+        s:
+          type: string
         sorts:
           type: string
       additionalProperties: false
@@ -15467,6 +15477,8 @@ components:
       type: object
       properties:
         nameCont:
+          type: string
+        s:
           type: string
         sorts:
           type: string
@@ -16372,6 +16384,8 @@ components:
           type: integer
         qualityLteq:
           type: integer
+        s:
+          type: string
         sorts:
           type: string
       additionalProperties: false
@@ -18982,6 +18996,12 @@ components:
           type: boolean
         searchCont:
           type: string
+        s:
+          anyOf:
+          - type: array
+            items:
+              "$ref": "#/components/schemas/NotificationSortEnum"
+          - "$ref": "#/components/schemas/NotificationSortEnum"
         sorts:
           anyOf:
           - type: array

--- a/test/integration/api/v1/fleets_members_index_test.rb
+++ b/test/integration/api/v1/fleets_members_index_test.rb
@@ -114,6 +114,85 @@ class Api::V1::FleetsMembersIndexTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET /fleets/:slug/members sorts by username via the s param" do
+    @admin.update!(username: "charlie")
+    @member.update!(username: "alpha")
+    @another_member.update!(username: "bravo")
+    sign_in @admin
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      params: {q: {"s" => "username asc"}} do
+      assert_equal %w[alpha bravo charlie], parsed_body["items"].map { |m| m["username"] }
+    end
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      params: {q: {"s" => "username desc"}} do
+      assert_equal %w[charlie bravo alpha], parsed_body["items"].map { |m| m["username"] }
+    end
+  end
+
+  test "GET /fleets/:slug/members sorts by rsiHandle via the s param" do
+    @admin.update!(rsi_handle: "charlie")
+    @member.update!(rsi_handle: "alpha")
+    @another_member.update!(rsi_handle: "bravo")
+    sign_in @admin
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      params: {q: {"s" => "rsiHandle asc"}} do
+      assert_equal %w[alpha bravo charlie], parsed_body["items"].map { |m| m["rsiHandle"] }
+    end
+  end
+
+  test "GET /fleets/:slug/members sorts by acceptedAt via the s param" do
+    @fleet.fleet_memberships.find_by(user: @admin).update!(accepted_at: 3.days.ago)
+    @fleet.fleet_memberships.find_by(user: @member).update!(accepted_at: 1.day.ago)
+    @fleet.fleet_memberships.find_by(user: @another_member).update!(accepted_at: 2.days.ago)
+    sign_in @admin
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      params: {q: {"s" => "acceptedAt asc"}} do
+      assert_equal [@admin.username, @another_member.username, @member.username],
+        parsed_body["items"].map { |m| m["username"] }
+    end
+  end
+
+  # Only the two members the request does not authenticate as, because
+  # `set_last_active_at` refreshes the requesting user's own timestamp.
+  test "GET /fleets/:slug/members sorts by lastActiveAt via the s param" do
+    @member.update!(last_active_at: 1.day.ago)
+    @another_member.update!(last_active_at: 2.days.ago)
+    sign_in @admin
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      params: {q: {"s" => "lastActiveAt asc"}} do
+      usernames = parsed_body["items"].map { |m| m["username"] }
+
+      assert_operator usernames.index(@another_member.username), :<,
+        usernames.index(@member.username)
+      assert_equal @admin.username, usernames.last
+    end
+  end
+
+  # An explicit `sorts` is the caller being specific, so it must not be
+  # overwritten by the `s` the table header always appends to the URL.
+  test "GET /fleets/:slug/members prefers sorts over s" do
+    @admin.update!(username: "charlie")
+    @member.update!(username: "alpha")
+    @another_member.update!(username: "bravo")
+    sign_in @admin
+
+    assert_api_response :get, 200,
+      path_params: {fleetSlug: @fleet.slug},
+      params: {q: {"s" => "username asc", "sorts" => "username desc"}} do
+      assert_equal %w[charlie bravo alpha], parsed_body["items"].map { |m| m["username"] }
+    end
+  end
+
   test "GET /fleets/:slug/members returns 404 for unknown fleet" do
     sign_in @admin
 

--- a/test/integration/api/v1/fleets_stats_members_test.rb
+++ b/test/integration/api/v1/fleets_stats_members_test.rb
@@ -48,6 +48,21 @@ class Api::V1::FleetsStatsMembersTest < ActionDispatch::IntegrationTest
     assert_api_response :get, 200, path_params: {fleetSlug: @fleet.slug}
   end
 
+  # The role breakdown is a grouped count, so a sort reaching ransack puts an
+  # ungrouped column in the ORDER BY and Postgres rejects the whole query.
+  test "GET /fleets/:slug/stats/members ignores sort params" do
+    create(:user).tap { |user| @fleet.fleet_memberships.create!(user:, fleet_role: @fleet.default_member_role, aasm_state: "accepted") }
+    sign_in @admin
+
+    ["s", "sorts"].each do |key|
+      assert_api_response :get, 200,
+        path_params: {fleetSlug: @fleet.slug},
+        params: {q: {key => "username asc"}} do
+        assert_equal 2, parsed_body["total"]
+      end
+    end
+  end
+
   test "GET /fleets/:slug/stats/members returns 401 when not signed in" do
     assert_api_response :get, 401, path_params: {fleetSlug: @fleet.slug}
   end


### PR DESCRIPTION
Sorting the fleet member list returned a **400**, not the 500 the report suggested — `FilteredList` renders any non-403 error as the generic ServerError page, which is why it read as a server error.

```
q[s]=username asc     -> 400 Request validation failed:
                             object property at `/s` is a disallowed additional property
q[sorts]=username asc -> 200
```

The table header writes the active sort into the URL as `?s=<field> <dir>`, and `useFilters.getQuery()` forwards the whole route query as `q`. `FleetMemberQuery` declared only `sorts` next to `additionalProperties: false`, so openapi-ruby request validation rejected the request before the controller ran. `410fc1971` established the fix but only applied it to three schemas.

## What's in here

- **The member list** — `FleetMemberQuery` declares `s`, the concern permits it, the controller normalizes it into `sorts`. Regression tests for all four sortable columns, plus one asserting an explicit `sorts` wins over `s`.
- **Every other sortable endpoint** — of 25 schemas that accept `sorts`, only 3 accepted `s`. Now all of them do, and the controllers behind them permit and normalize it. The same 400 was waiting on the fleet and hangar inventory logs, the ship cargo page, and the admin model and vehicle lists.
- **`normalize_sort_params`** — it deleted `s` only when `s` was the key that filled `sorts` in. With both present the `||=` short-circuited, `s` survived into ransack, and since ransack reads `s` itself the unvalidated value outranked the whitelisted `sorts`. Caught by the new precedence test.
- **A live 500 on `/fleets/:slug/stats/members`** — the role breakdown is a grouped count, so any sort param left an ungrouped column in the ORDER BY and Postgres rejected the query (`PG::GroupingError`). `sorts` alone was enough to trigger it before this change. Both stats controllers now strip the sort keys the way `model_counts` already did.
- The admin vehicle list permitted neither `s` nor `sorts`, so its sort never reached ransack. Fixed too.

## Why not fix it in `useFilters`

Translating `s` to `sorts` inside `getQuery()` would be a one-liner covering every page — but `getQuery()` also builds the browser URL via `debouncedFilter` → `router.replace`. Renaming the key there rewrites the URL to `?sorts=…`, which `useTableSorting` no longer recognises, breaking the sort indicator and every bookmarked sort link. The URL contract stays `s`; the API learns it.

## Verification

- `fleets_members_index`, `fleets_stats_members`, `public_fleets_stats_members` — 21 tests green, including the four new column sorts and the precedence case
- 127 tests across the touched v1 endpoints — green
- 358 tests across the touched admin endpoints — green
- 58 tests across filters and missions — green
- `standardrb` and `pnpm lint:ts` clean
- Schema regenerated; the diff is 116 lines of additive optional properties, so `api-schema-breaking` should stay green

Plan: `docs/exec-plans/4637-members-list-sorting-server-error.md`

Resolves #4637

🤖
