### PR TITLE
fix(base-select): keep the popover in place while it closes

### DIFF
--- a/app/frontend/shared/components/base/Select/index.spec.ts
+++ b/app/frontend/shared/components/base/Select/index.spec.ts
@@ -7,6 +7,7 @@
  * against rather than being verified by eye.
  */
 import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { flushPromises } from "@vue/test-utils";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import Component from "./index.vue";
 
@@ -379,6 +380,74 @@ describe("BaseSelect", () => {
       await wrapper.trigger("keydown", { key: "b" });
 
       expect(wrapper.find(".base-select-item--focused").exists()).toBe(false);
+    });
+  });
+
+  /*
+   * The popover opens in one of two positioning modes, and the coordinates only
+   * mean what they say in the mode they were measured for. These pin the two
+   * places the mode and the coordinates could drift apart.
+   */
+  describe("the popover's positioning mode", () => {
+    const ESCAPES_CLIP = "base-select-items-wrapper--escapes-clip";
+
+    // jsdom reports every ancestor as `overflow: visible`, so the clipping the
+    // fixed mode exists for has to be put there.
+    const clip = (wrapper: Wrapper) => {
+      const host = wrapper.element.parentElement as HTMLElement;
+      host.style.overflow = "hidden";
+
+      return host;
+    };
+
+    const popoverIn = (wrapper: Wrapper) =>
+      wrapper.find(".base-select-items-wrapper");
+
+    const openWith = async (wrapper: Wrapper) => {
+      await wrapper.find('[data-test="base-select-title"]').trigger("click");
+      await flushPromises();
+    };
+
+    const closeWith = async (wrapper: Wrapper) => {
+      await wrapper.trigger("keydown", { key: "Escape" });
+      await flushPromises();
+    };
+
+    it("holds the fixed mode through the closing animation", async () => {
+      const wrapper = await mount();
+      clip(wrapper);
+
+      await openWith(wrapper);
+
+      expect(popoverIn(wrapper).classes()).toContain(ESCAPES_CLIP);
+
+      await closeWith(wrapper);
+
+      // Collapsed animates the close over half a second with the element still
+      // shown. Dropping the class here handed a popover still carrying viewport
+      // coordinates back to `position: absolute`, which reads them against the
+      // group's box -- and threw it into the bottom-right corner until the
+      // animation finished.
+      expect(popoverIn(wrapper).classes()).toContain(ESCAPES_CLIP);
+    });
+
+    it("takes stale fixed coordinates off when it opens unclipped", async () => {
+      const wrapper = await mount();
+      const popover = popoverIn(wrapper).element as HTMLElement;
+
+      // What an earlier open in the fixed mode leaves on the element. The same
+      // select is measured in both modes over its life -- one inside a modal
+      // escapes the clip while the modal is open and not once it has gone.
+      popover.style.top = "120px";
+      popover.style.left = "340px";
+      popover.style.width = "200px";
+
+      await openWith(wrapper);
+
+      expect(popoverIn(wrapper).classes()).not.toContain(ESCAPES_CLIP);
+      expect(popover.style.top).toBe("");
+      expect(popover.style.left).toBe("");
+      expect(popover.style.width).toBe("");
     });
   });
 });

--- a/app/frontend/shared/components/base/Select/index.vue
+++ b/app/frontend/shared/components/base/Select/index.vue
@@ -664,7 +664,17 @@ const placePopover = (decideSide = false) => {
      * the element's own place in the flow. Only opening upwards needs saying,
      * and it is said as an offset from the group's box -- which is what the
      * containing block is -- rather than as a coordinate.
+     *
+     * The other mode's coordinates come off first. They are viewport offsets and
+     * they mean something else entirely against the group's box, and a select is
+     * measured in both modes over its life -- one inside a modal escapes the clip
+     * while the modal is open and not once it has gone. Left on, they open the
+     * popover far down and to the right of its trigger.
      */
+    popover.style.removeProperty("top");
+    popover.style.removeProperty("left");
+    popover.style.removeProperty("width");
+
     if (opensAbove.value && triggerRect) {
       popover.style.bottom = `${root.getBoundingClientRect().bottom - triggerRect.top}px`;
     } else {
@@ -682,6 +692,10 @@ const placePopover = (decideSide = false) => {
    * between -- an earlier version awaited a tick in the middle, which showed as
    * a frame in the top-left corner on every scroll event.
    */
+  // Set only by the absolute mode, and a fixed box given both ends stretches
+  // between them instead of taking its height from its content.
+  popover.style.removeProperty("bottom");
+
   popover.style.top = "0px";
   popover.style.left = "0px";
 
@@ -745,14 +759,22 @@ const stopFollowing = () => {
 watch(visible, async (isVisible) => {
   if (!isVisible) {
     stopFollowing();
-    escapesClip.value = false;
-    opensAbove.value = false;
 
+    /*
+     * The mode is deliberately left standing. Collapsed animates the close over
+     * its own duration, and dropping --escapes-clip here handed a popover still
+     * carrying fixed coordinates back to `position: absolute`, which read them
+     * against the group's box and threw it into the bottom-right corner for the
+     * length of the animation. Both flags are recomputed on open below.
+     */
     return;
   }
 
   const root = baseSelect.value;
 
+  // Reset here rather than on close, where it would flip the mode out from under
+  // the closing animation. placePopover() settles it again a tick from now.
+  opensAbove.value = false;
   escapesClip.value = root != null && clippingAncestor(root) != null;
 
   await nextTick();

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,12 +16,10 @@ Rails.application.configure do
     admin_endpoint = "#{admin_uri.scheme}://#{admin_uri.host}"
     cdn_endpoint = Rails.configuration.app.cdn_endpoint || FRONTEND_ENDPOINT
     legacy_cdn_endpoint = Rails.configuration.app.legacy_cdn_endpoint || FRONTEND_ENDPOINT
-    s3_endpoint = [
-      "#{Rails.application.credentials.s3_protocol}://",
-      Rails.application.credentials.s3_bucket,
-      ".",
-      Rails.application.credentials.s3_endpoint
-    ].compact.join("")
+    s3_protocol = Rails.application.credentials.s3_protocol
+    s3_bucket = Rails.application.credentials.s3_bucket
+    s3_host = Rails.application.credentials.s3_endpoint
+    s3_endpoint = "#{s3_protocol}://#{s3_bucket}.#{s3_host}" if s3_protocol && s3_bucket && s3_host
     storage_cdn_endpoint = Rails.configuration.app.storage_cdn_endpoint
 
     docs_uri = URI.parse(DOCS_ENDPOINT)


### PR DESCRIPTION
Two independent fixes, one commit each, both found while chasing an empty-page report on the forms page.

## fix(base-select): keep the popover in place while it closes

Closing any BaseSelect that opens in the **fixed** positioning mode threw its popover into the bottom-right corner for the length of the close animation. Not specific to the affix variant — it just happened to be the one under the cursor.

The popover has two positioning modes. Fixed (`--escapes-clip`, taken when a clipping ancestor would otherwise cut the options off — a modal body, for instance) writes inline `top`/`left` as viewport offsets. Absolute lets the stylesheet own `left`/`right` and positions against the group's box.

On close the watcher reset `escapesClip` to `false` immediately, which dropped `--escapes-clip` and flipped the element back to `position: absolute` — but nothing ever removed the inline `top`/`left`. Those viewport offsets then got read against the group's box. `Collapsed` animates the close over half a second with the element still shown (`v-show`), so the misplaced popover sits on screen for the whole animation.

What changed:

- the close branch no longer resets the mode flags, so the geometry stays coherent for the length of the leave — both are recomputed on open anyway
- `opensAbove` resets at the *start* of open instead, which keeps the previous first-tick class sequence rather than letting the old side leak into the new open
- each branch of `placePopover` now takes off the coordinates the other branch owns: absolute drops `top`/`left`/`width`, fixed drops `bottom`

That last point also covers a second, latent instance of the same bug that the original report wouldn't have surfaced: a select measured in the fixed mode and later opened in the absolute one — the same select inside a modal, after the modal has gone — kept the stale fixed coordinates and opened misplaced *while open*. The old code had no path that cleared them.

Two regression tests added, both verified to fail against the unfixed component and pass with it.

## fix(csp): drop the invalid source when S3 is unconfigured

> The source list for the Content Security Policy directive 'connect-src' contains an invalid source: '://.'. It will be ignored.

The endpoint was assembled by joining an always-present `"#{scheme}://"` string and a literal `"."`, so `compact` could never drop it. With no S3 credentials it collapsed to a bare `://.`, which browsers reject in `connect-src`, `img-src` and `prefetch-src`. It is now built only when all three parts are present, letting the existing `compact` drop the `nil`. Production is unaffected — the credentials are set there.

## Verification

- `vitest` — 29/29 in `Select/index.spec.ts`, 55/55 across `components/base`
- `eslint` and `vue-tsc` — clean
- `rubocop` on the initializer — clean
- built CSP header in development re-checked: no `://.` left in any directive

## Not in scope

`Unrecognized Content-Security-Policy directive 'prefetch-src'` is still there. Chrome removed `prefetch-src`, so prefetches fall back to `default-src`, which is `:none` — a behaviour change to decide on rather than noise to tidy, so it is left alone here.

🤖
