### PR TITLE
feat(logistics): open a loaded ship inventory in the cargo grid viewer

### DIFF
--- a/app/frontend/frontend/components/CargoGridViewer/constants.spec.ts
+++ b/app/frontend/frontend/components/CargoGridViewer/constants.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  containersForVolume,
+  encodeContainerCounts,
+  parseContainerCounts,
+} from "./constants";
+
+describe("containersForVolume", () => {
+  it("carries a volume in the fewest crates", () => {
+    expect(containersForVolume(12)).toEqual({ 8: 1, 4: 1 });
+    expect(containersForVolume(70)).toEqual({ 32: 2, 4: 1, 2: 1 });
+  });
+
+  it("repeats the largest crate rather than stopping at one", () => {
+    expect(containersForVolume(96)).toEqual({ 32: 3 });
+  });
+
+  it("drops what is too little to fill the smallest crate", () => {
+    expect(containersForVolume(4.6)).toEqual({ 4: 1 });
+    expect(containersForVolume(0.4)).toEqual({});
+  });
+});
+
+describe("container counts in a URL", () => {
+  it("round-trips a load", () => {
+    const counts = containersForVolume(37);
+
+    expect(encodeContainerCounts(counts)).toBe("32x1,4x1,1x1");
+    expect(parseContainerCounts(encodeContainerCounts(counts))).toEqual(counts);
+  });
+
+  it("leaves out the sizes nothing was asked for", () => {
+    expect(encodeContainerCounts({ 32: 0, 8: 2 })).toBe("8x2");
+  });
+
+  // The query is as editable as the page's own inputs, so it is read rather
+  // than trusted: a size the viewer cannot draw would only pack into nothing.
+  it("keeps only the crates the viewer draws", () => {
+    expect(parseContainerCounts("32x2,7x3,16xmany,8x0,4x-1,nonsense")).toEqual({
+      32: 2,
+    });
+  });
+
+  it("has nothing to read without a query", () => {
+    expect(parseContainerCounts(undefined)).toEqual({});
+    expect(parseContainerCounts(["32x1"])).toEqual({});
+  });
+});

--- a/app/frontend/frontend/components/CargoGridViewer/constants.ts
+++ b/app/frontend/frontend/components/CargoGridViewer/constants.ts
@@ -84,6 +84,54 @@ function tryPlaceInGrid(
   return false;
 }
 
+// A hold is loaded in whole crates, so a measured volume becomes the fewest
+// containers that carry it: the largest that fits, then the remainder. What is
+// left under the smallest crate has nothing to travel in and is dropped.
+export function containersForVolume(scu: number): Record<number, number> {
+  const counts: Record<number, number> = {};
+  let remaining = Math.floor(scu);
+
+  for (const def of CONTAINER_DEFS) {
+    if (remaining < def.size) continue;
+
+    const quantity = Math.floor(remaining / def.size);
+    counts[def.size] = quantity;
+    remaining -= quantity * def.size;
+  }
+
+  return counts;
+}
+
+// Ordered by the crates rather than by the object's keys, which JavaScript
+// hands back smallest first - the viewer reads the load largest first.
+export const encodeContainerCounts = (counts: Record<number, number>): string =>
+  CONTAINER_DEFS.filter((def) => Number(counts[def.size]) > 0)
+    .map((def) => `${def.size}x${counts[def.size]}`)
+    .join(",");
+
+// Anything the URL carries that is not a container this viewer draws is
+// dropped rather than trusted: the query is as editable as the page's inputs.
+export const parseContainerCounts = (
+  value: unknown,
+): Record<number, number> => {
+  const counts: Record<number, number> = {};
+
+  if (typeof value !== "string") return counts;
+
+  for (const pair of value.split(",")) {
+    const [rawSize, rawQuantity] = pair.split("x");
+    const size = Number(rawSize);
+    const quantity = Math.floor(Number(rawQuantity));
+
+    if (!CONTAINER_DEFS.some((def) => def.size === size)) continue;
+    if (!Number.isFinite(quantity) || quantity <= 0) continue;
+
+    counts[size] = quantity;
+  }
+
+  return counts;
+};
+
 export function computeGreedyFill(
   cargoHolds: CargoHold[],
 ): Record<number, number> {

--- a/app/frontend/frontend/components/Logistics/InventoryPanel/index.spec.ts
+++ b/app/frontend/frontend/components/Logistics/InventoryPanel/index.spec.ts
@@ -1,7 +1,17 @@
 import { mountWithDefaults } from "@/shared/utils/TestUtils";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRouter, createWebHashHistory } from "vue-router";
 import Component from "./index.vue";
 import type { InventoryPanelRecord } from "@/frontend/types/logistics";
+
+const enabledFeatures = vi.hoisted(() => ({ value: [] as string[] }));
+
+vi.mock("@/frontend/composables/useFeatures", () => ({
+  useFeatures: () => ({
+    isFeatureEnabled: (feature: string) =>
+      enabledFeatures.value.includes(feature),
+  }),
+}));
 
 // The panel carries a background image, and jsdom has no IntersectionObserver
 // for useLazyBackground to hand it to.
@@ -16,6 +26,10 @@ beforeAll(() => {
   );
 });
 
+beforeEach(() => {
+  enabledFeatures.value = ["tools_cargo_grids"];
+});
+
 const inventory = (
   overrides: Partial<InventoryPanelRecord> = {},
 ): InventoryPanelRecord => ({
@@ -27,10 +41,37 @@ const inventory = (
   ...overrides,
 });
 
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: "/tools/cargo-grids",
+      name: "cargo-grids",
+      component: { template: "<div />" },
+    },
+  ],
+});
+
 const mount = (record: InventoryPanelRecord) =>
   mountWithDefaults<typeof Component>(Component, {
     props: { inventory: record, to: "/hangar/inventories" },
+    plugins: [router],
   });
+
+const shipInventory = (
+  overrides: Partial<InventoryPanelRecord> = {},
+): InventoryPanelRecord =>
+  inventory({
+    totalVolumeScu: 12,
+    vehicle: {
+      id: "v1",
+      name: "Ironclad",
+      model: { slug: "ironclad", cargo: 400 },
+    },
+    ...overrides,
+  });
+
+const cargoGridsLink = "[data-test='inventory-panel-cargo-grids']";
 
 describe("InventoryPanel", () => {
   it("names the ship an inventory rides in", async () => {
@@ -60,6 +101,43 @@ describe("InventoryPanel", () => {
 
     expect(wrapper.text()).toContain("312 / 400 SCU");
     expect(wrapper.find(".inventory-panel-count-over").exists()).toBe(false);
+  });
+
+  it("opens the viewer on the ship and the load it carries", async () => {
+    const wrapper = await mount(shipInventory());
+
+    const link = wrapper.find(cargoGridsLink);
+
+    expect(link.exists()).toBe(true);
+
+    const href = decodeURIComponent(link.attributes("href") || "");
+
+    expect(href).toContain("ship=ironclad");
+    expect(href).toContain("containers=8x1,4x1");
+  });
+
+  it("waits for a full SCU before offering the viewer", async () => {
+    const wrapper = await mount(shipInventory({ totalVolumeScu: 0.4 }));
+
+    expect(wrapper.find(cargoGridsLink).exists()).toBe(false);
+  });
+
+  // A hold the viewer cannot draw, and a tool the viewer cannot reach, both
+  // leave the link pointing at nothing.
+  it("keeps the viewer to ships with a grid and the feature on", async () => {
+    const gridless = await mount(
+      shipInventory({
+        vehicle: { id: "v1", name: "Vulture", model: { slug: "vulture" } },
+      }),
+    );
+
+    expect(gridless.find(cargoGridsLink).exists()).toBe(false);
+
+    enabledFeatures.value = [];
+
+    const disabled = await mount(shipInventory());
+
+    expect(disabled.find(cargoGridsLink).exists()).toBe(false);
   });
 
   it("flags an overfilled hold without hiding the numbers", async () => {

--- a/app/frontend/frontend/components/Logistics/InventoryPanel/index.vue
+++ b/app/frontend/frontend/components/Logistics/InventoryPanel/index.vue
@@ -12,6 +12,12 @@ import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import PanelUserTag from "@/frontend/components/base/PanelUserTag/index.vue";
 import { BtnVariantsEnum } from "@/shared/components/base/Btn/types";
+import {
+  containersForVolume,
+  encodeContainerCounts,
+} from "@/frontend/components/CargoGridViewer/constants";
+import { useFeatures } from "@/frontend/composables/useFeatures";
+import { FeatureFlagName } from "@/services/fyApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import type { InventoryPanelRecord } from "@/frontend/types/logistics";
@@ -36,6 +42,7 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits<{ edit: [] }>();
 
 const { t } = useI18n();
+const { isFeatureEnabled } = useFeatures();
 
 const totalScu = computed(() => props.inventory.totalScu ?? 0);
 
@@ -55,6 +62,28 @@ const cargoCapacity = computed(
 
 const overCapacity = computed(
   () => cargoCapacity.value > 0 && totalScu.value > cargoCapacity.value,
+);
+
+// The viewer opens on what the ship is actually carrying: the measured volume
+// counted out into the crates it would travel in.
+const cargoGridsRoute = computed(() => ({
+  name: "cargo-grids",
+  query: {
+    ship: props.inventory.vehicle?.model?.slug,
+    containers: encodeContainerCounts(
+      containersForVolume(props.inventory.totalVolumeScu ?? 0),
+    ),
+  },
+}));
+
+// It packs the hold it is given, so it is only worth offering once the ship
+// both has a grid and carries something to put in it.
+const showCargoGridsLink = computed(
+  () =>
+    isFeatureEnabled(FeatureFlagName.TOOLS_CARGO_GRIDS) &&
+    !!props.inventory.vehicle?.model?.slug &&
+    (props.inventory.vehicle?.model?.cargo ?? 0) > 0 &&
+    (props.inventory.totalVolumeScu ?? 0) >= 1,
 );
 
 const fallbackIndex = computed(() => {
@@ -85,8 +114,20 @@ const image = computed(
       <template v-if="subtitle" #subtitle>
         {{ subtitle }}
       </template>
-      <template v-if="editable" #actions>
+      <template v-if="editable || showCargoGridsLink" #actions>
         <Btn
+          v-if="showCargoGridsLink"
+          v-tooltip="t('actions.logistics.viewCargoGrid')"
+          :variant="BtnVariantsEnum.BARE"
+          :to="cargoGridsRoute"
+          :aria-label="t('actions.logistics.viewCargoGrid')"
+          class="inventory-panel-cargo-grids"
+          data-test="inventory-panel-cargo-grids"
+        >
+          <i class="fa-light fa-cube" />
+        </Btn>
+        <Btn
+          v-if="editable"
           :variant="BtnVariantsEnum.BARE"
           class="inventory-panel-edit"
           @click.prevent="emit('edit')"
@@ -144,7 +185,8 @@ const image = computed(
     min-height: 60px;
   }
 
-  &-edit {
+  &-edit,
+  &-cargo-grids {
     font-size: 18px;
 
     > :first-child {

--- a/app/frontend/frontend/pages/hangar/[id]/cargo.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/cargo.vue
@@ -13,6 +13,7 @@ import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import InventoryItemFilterForm from "@/frontend/components/Logistics/InventoryItemFilterForm/index.vue";
 import InventoryLedgerTables from "@/frontend/components/Logistics/InventoryLedgerTables/index.vue";
 import {
+  FeatureFlagName,
   type InventoryItem,
   type Vehicle,
   useVehicleInventory,
@@ -21,12 +22,17 @@ import {
   useDestroyVehicleInventory,
   useDestroyVehicleInventoryItem,
 } from "@/services/fyApi";
+import {
+  containersForVolume,
+  encodeContainerCounts,
+} from "@/frontend/components/CargoGridViewer/constants";
 import { useInventoryItemFilters } from "@/frontend/composables/useInventoryItemFilters";
 import { useInventoryStockList } from "@/frontend/composables/useInventoryStockList";
 import type {
   InventoryStockRecord,
   InventoryTarget,
 } from "@/frontend/types/logistics";
+import { useFeatures } from "@/frontend/composables/useFeatures";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useComlink } from "@/shared/composables/useComlink";
@@ -41,6 +47,7 @@ const props = defineProps<Props>();
 const { t } = useI18n();
 const comlink = useComlink();
 const mobile = useMobile();
+const { isFeatureEnabled } = useFeatures();
 const { displaySuccess, displayAlert, displayConfirm } = useAppNotifications();
 
 const vehicleId = computed(() => props.vehicle.id);
@@ -118,6 +125,26 @@ const remainingScu = computed(() =>
 );
 const overCapacity = computed(
   () => totalCapacity.value > 0 && storedScu.value > totalCapacity.value,
+);
+
+// The viewer opens on what the ship is actually carrying: the measured volume
+// counted out into the crates it would travel in.
+const cargoGridsRoute = computed(() => ({
+  name: "cargo-grids",
+  query: {
+    ship: props.vehicle.model?.slug,
+    containers: encodeContainerCounts(containersForVolume(storedScu.value)),
+  },
+}));
+
+// It packs the hold it is given, so it is only worth opening once the ship both
+// has a grid and carries something to put in it.
+const showCargoGridsLink = computed(
+  () =>
+    isFeatureEnabled(FeatureFlagName.TOOLS_CARGO_GRIDS) &&
+    !!props.vehicle.model?.slug &&
+    cargoCapacity.value > 0 &&
+    storedScu.value >= 1,
 );
 
 const openItemModal = (initialEntryType: "deposit" | "withdrawal") => {
@@ -240,6 +267,15 @@ onMounted(() => {
         {{ t("actions.logistics.importCsv") }}
       </Btn>
       <Btn
+        v-if="showCargoGridsLink"
+        :size="BtnSizesEnum.MD"
+        :to="cargoGridsRoute"
+        data-test="vehicle-cargo-grids-link"
+      >
+        <i class="fa-light fa-cube" />
+        {{ t("actions.logistics.viewCargoGrid") }}
+      </Btn>
+      <Btn
         v-if="hasCargo"
         :size="BtnSizesEnum.MD"
         :tone="BtnTonesEnum.DANGER"
@@ -275,6 +311,15 @@ onMounted(() => {
           <Btn :size="BtnSizesEnum.SM" @click="openCsvImportModal">
             <i class="fa-duotone fa-file-csv" />
             <span>{{ t("actions.logistics.importCsv") }}</span>
+          </Btn>
+          <Btn
+            v-if="showCargoGridsLink"
+            :size="BtnSizesEnum.SM"
+            :to="cargoGridsRoute"
+            data-test="vehicle-cargo-grids-link"
+          >
+            <i class="fa-light fa-cube" />
+            <span>{{ t("actions.logistics.viewCargoGrid") }}</span>
           </Btn>
           <Btn v-if="hasCargo" :size="BtnSizesEnum.SM" @click="clearCargo">
             <i class="fa-duotone fa-trash" />

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -10,6 +10,9 @@ import Heading from "@/shared/components/base/Heading/index.vue";
 import CargoGridViewer from "@/frontend/components/CargoGridViewer/index.vue";
 import {
   SHIP_COLORS,
+  encodeContainerCounts,
+  parseContainerCounts,
+  type ContainerRequest,
   type ShipEntry,
 } from "@/frontend/components/CargoGridViewer/constants";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
@@ -35,7 +38,6 @@ import {
   InputAlignmentsEnum,
 } from "@/shared/components/base/FormInput/types";
 
-import type { ContainerRequest } from "@/frontend/components/CargoGridViewer/constants";
 import { useSessionStore } from "@/frontend/stores/session";
 import FeatureGuard from "@/frontend/components/FeatureGuard.vue";
 import { FeatureFlagName } from "@/services/fyApi";
@@ -144,10 +146,12 @@ const singleShipCargoHolds = computed(() => {
   return shipSlots[0].combinedCargoHolds.value;
 });
 
-// Container requests: how many of each size the user wants to load
-const containerRequests = ref<Record<number, number>>(
-  Object.fromEntries(CONTAINER_SIZES.map((s) => [s, 0])),
-);
+// Container requests: how many of each size the user wants to load. A link may
+// arrive with a load already counted out - a ship inventory sends what it holds.
+const containerRequests = ref<Record<number, number>>({
+  ...Object.fromEntries(CONTAINER_SIZES.map((s) => [s, 0])),
+  ...parseContainerCounts(route.query.containers),
+});
 
 const hasContainerRequests = computed(() =>
   Object.values(containerRequests.value).some((v) => Number(v) > 0),
@@ -234,6 +238,11 @@ const syncUrl = () => {
     query.ships = slugs.join(",");
   }
 
+  const containers = encodeContainerCounts(containerRequests.value);
+  if (containers) {
+    query.containers = containers;
+  }
+
   // Per-ship modules
   for (let i = 0; i < slugs.length; i++) {
     const slug = slugs[i];
@@ -245,6 +254,10 @@ const syncUrl = () => {
 
   void router.replace({ query });
 };
+
+// The counts are typed into the form rather than routed through an action, so
+// the URL follows them instead of being rewritten only when a ship changes.
+watch(containerRequests, () => syncUrl(), { deep: true });
 
 // Ship management
 const handleShipSelect = (value: ValueType<Model> | undefined) => {

--- a/app/frontend/frontend/types/logistics.ts
+++ b/app/frontend/frontend/types/logistics.ts
@@ -54,6 +54,7 @@ export type InventoryPanelRecord = {
   entriesCount: number;
   totalScu?: number;
   totalUnits?: number;
+  totalVolumeScu?: number;
   image?: { mediumUrl?: string };
   vehicle?: InventoryVehicleReference | null;
 };

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -286,7 +286,8 @@
         "editStockItem": "Edit Item",
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
-        "clearCargo": "Fracht leeren"
+        "clearCargo": "Fracht leeren",
+        "viewCargoGrid": "Frachtraster ansehen"
       },
       "adminNotifications": {
         "unread": "Als ungelesen markieren",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -286,7 +286,8 @@
         "editStockItem": "Edit Item",
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
-        "clearCargo": "Clear Cargo"
+        "clearCargo": "Clear Cargo",
+        "viewCargoGrid": "View Cargo Grid"
       },
       "adminNotifications": {
         "unread": "Mark as unread",

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -286,7 +286,8 @@
         "editStockItem": "Edit Item",
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
-        "clearCargo": "Vaciar carga"
+        "clearCargo": "Vaciar carga",
+        "viewCargoGrid": "Ver cuadrícula de carga"
       },
       "adminNotifications": {
         "unread": "Marcar como no leída",

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -286,7 +286,8 @@
         "editStockItem": "Edit Item",
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
-        "clearCargo": "Vider la cargaison"
+        "clearCargo": "Vider la cargaison",
+        "viewCargoGrid": "Voir la grille de cargaison"
       },
       "adminNotifications": {
         "unread": "Marquer comme non lu",

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -286,7 +286,8 @@
         "editStockItem": "Edit Item",
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
-        "clearCargo": "Svuota carico"
+        "clearCargo": "Svuota carico",
+        "viewCargoGrid": "Vedi griglia di carico"
       },
       "adminNotifications": {
         "unread": "Segna come non letta",

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -286,7 +286,8 @@
         "editStockItem": "Edit Item",
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
-        "clearCargo": "清空货物"
+        "clearCargo": "清空货物",
+        "viewCargoGrid": "查看货物网格"
       },
       "adminNotifications": {
         "unread": "标记为未读",

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -286,7 +286,8 @@
         "editStockItem": "Edit Item",
         "destroyStockItem": "Delete Item",
         "editInventory": "Edit Inventory",
-        "clearCargo": "清空貨物"
+        "clearCargo": "清空貨物",
+        "viewCargoGrid": "檢視貨艙網格"
       },
       "adminNotifications": {
         "unread": "標示為未讀",


### PR DESCRIPTION
## What

A ship inventory knows what it carries, but there was nowhere to see it in the hold. Both places a ship inventory appears now link into the cargo grid viewer, carrying the load with them:

- the inventory panel on `/hangar/inventories`
- the ship's own cargo page, `/hangar/:id/cargo`

The link sends the ship and the inventory's measured volume counted out into the crates it would travel in — 12 SCU opens the viewer with one 8 and one 4 SCU container already placed.

## Why the link is gated

It appears once the inventory holds **at least 1 SCU** — below that there is no crate to fill. It also stays hidden for a ship whose model has no cargo grid, and for a viewer without the `tools_cargo_grids` flag: both would only lead to an empty page.

The figure it reads is `totalVolumeScu`, the same number the cargo page headlines as `x / y SCU` — everything aboard measured, not only what was entered in SCU.

## Container counts in the URL

The counts previously lived only in the page's own state, so a link could name the ship but never its load, and `syncUrl` rewrote the query only when a ship or module changed — typed counts survived neither a reload nor a share.

They now round-trip through `containers=32x1,4x1`, and the URL follows the inputs as they are typed. Sizes the viewer cannot draw, and non-positive quantities, are dropped on the way in rather than trusted — the query is as editable as the form itself.

## Notes

- If a hold caps container size below what the load decomposes into, the viewer already reports those crates as not placed. The link cannot know the hold's `maxContainerSize` before the page fetches the model.
- A remainder under 1 SCU is dropped: the smallest container the viewer draws is 1 SCU.
- `actions.logistics.viewCargoGrid` added across all seven locales.

## Testing

- `constants.spec.ts` — new: the volume decomposition, the URL round-trip, and a hostile query
- `InventoryPanel/index.spec.ts` — the link renders with ship and containers, hides below 1 SCU, hides without a grid or without the flag
- 14/14 passing, `lint:ts` clean, eslint and prettier clean

🤖
