### PR TITLE
fix(cleanup): pass Supacode the worktree ID it prints

### DIFF
--- a/.claude/skills/cleanup/audit.rb
+++ b/.claude/skills/cleanup/audit.rb
@@ -124,14 +124,19 @@ end
 # worktrees that exist, and everything outside that set is what gets swept.
 def sanitize_worktree_name(name) = name.gsub(/[^a-zA-Z0-9]/, "_")[0, 20]
 
+# Supacode identifies a worktree by the percent-encoded form of its path, which
+# is what `worktree list` prints and what `worktree delete` expects back. Keep
+# that identifier verbatim rather than re-deriving it: a decoded path handed to
+# --worktree builds a deeplink with raw slashes in it, which Supacode rejects.
 def supacode_worktrees
-  return [] unless tool?("supacode")
+  return {} unless tool?("supacode")
 
-  capture("supacode", "worktree", "list").lines.filter_map do |line|
-    decoded = URI.decode_www_form_component(line.strip)
+  capture("supacode", "worktree", "list").lines.each_with_object({}) do |line, ids|
+    id = line.strip
+    decoded = URI.decode_www_form_component(id)
     next if decoded.empty?
 
-    decoded.chomp("/")
+    ids[decoded.chomp("/")] = id
   end
 end
 
@@ -156,7 +161,8 @@ def worktrees
   entries.each do |entry|
     path = entry[:path]
     entry[:main] = File.identical?(path, MAIN_ROOT)
-    entry[:supacode] = supacode.include?(path.chomp("/"))
+    entry[:supacode_id] = supacode[path.chomp("/")]
+    entry[:supacode] = !entry[:supacode_id].nil?
     entry[:dirty] = capture("git", "-C", path, "status", "--porcelain").lines.size
     entry[:suffix] =
       if entry[:main]
@@ -423,7 +429,7 @@ def apply_worktrees(rows)
   rows.each do |entry|
     path = entry[:path]
     if entry[:supacode]
-      _out, err, ok = sh("supacode", "worktree", "delete", "--worktree", path, "--background")
+      _out, err, ok = sh("supacode", "worktree", "delete", "--worktree", entry[:supacode_id], "--background")
       puts(ok ? "  removed #{path} (supacode)" : "  FAILED #{path}: #{err.strip}")
       next
     end


### PR DESCRIPTION
`supacode worktree list` prints each worktree as the percent-encoded form of its path, and `supacode worktree delete --worktree` expects that same identifier back. The audit decoded it to a plain path so it could match against `git worktree list`, then handed the *decoded* path to delete — which built a deeplink with raw slashes in it:

```
Invalid deeplink: supacode://worktree//Users/…/.worktrees/tab-rail/delete?background=true&timeout=180
```

Every Supacode-managed worktree failed to remove. Since Supacode manages effectively all of them here, `--apply --only=worktrees` swept nothing and reported 16 `FAILED` lines, while the branch, database and Redis sweeps in the same run succeeded — so the failure read as partial rather than total.

## Fix

Keep the encoded identifier alongside the decoded path rather than re-deriving the encoding, so the value sent back is byte-for-byte the one Supacode handed over. `supacode_worktrees` now returns a `{decoded_path => id}` hash instead of an array, and each entry carries `:supacode_id`.

Re-deriving it would have worked too, but only by matching Supacode's escaping exactly — `CGI.escape` encodes a space as `+`, and the trailing slash matters. Round-tripping the original string has no such trap.

## Verification

Found while sweeping 20 merged worktrees. After the change all 20 removed cleanly through Supacode, and the follow-up passes reclaimed what they orphaned: 97 Postgres databases and 15 Redis bands.

Not covered by CI — `.claude/` is outside RuboCop's target files, so `bin/ruby-lint` never sees this file. The 3 pre-existing offenses in it are untouched.

🤖
