### PR TITLE
fix(cargo-grids): space the container filter actions apart

### DIFF
--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -15,6 +15,7 @@
   &__actions {
     display: flex;
     align-items: flex-end;
+    gap: 0.5rem;
     margin-bottom: 1rem;
   }
 }


### PR DESCRIPTION
The "Filter Ships by Container Size" and "Clear" buttons on `/tools/cargo-grids` sat flush against each other: `.container-fields__actions` is its own flex container and had no `gap`, so the `0.5rem` gap on the surrounding `.container-fields` never applied between them.

Added `gap: 0.5rem` to `.container-fields__actions`, matching the spacing used by the other toolbar rows on the page.

🤖