### PR TITLE
fix(metrics): keep both crew tiles on one row

### DIFF
--- a/app/frontend/shared/components/metricsCard.scss
+++ b/app/frontend/shared/components/metricsCard.scss
@@ -31,24 +31,24 @@
       // A tile count that is not a multiple of the track count leaves the hero's
       // own background showing through as an empty cell - cards drop tiles for
       // stats a model has no value for - so a lone last tile fills the free
-      // tracks instead.
-      .metrics-card__tile:last-child:nth-child(3n + 1) {
-        grid-column: span 3;
-      }
+      // tracks instead. The two-track variant is excluded rather than
+      // overriding: its own `:last-child` rule carries one class fewer, so a
+      // second tile would match `3n + 2` here and span the whole hero.
+      &:not(.metrics-card__hero--grid-2) {
+        .metrics-card__tile:last-child:nth-child(3n + 1) {
+          grid-column: span 3;
+        }
 
-      .metrics-card__tile:last-child:nth-child(3n + 2) {
-        grid-column: span 2;
+        .metrics-card__tile:last-child:nth-child(3n + 2) {
+          grid-column: span 2;
+        }
       }
 
       &-2 {
         grid-template-columns: repeat(2, 1fr);
 
-        .metrics-card__tile:last-child {
-          grid-column: auto;
-
-          &:nth-child(odd) {
-            grid-column: span 2;
-          }
+        .metrics-card__tile:last-child:nth-child(odd) {
+          grid-column: span 2;
         }
       }
 


### PR DESCRIPTION
## What

The crew card on a ship page drew MIN. CREW at half width, MAX. CREW wrapped onto a second row spanning the whole card, and the free track in row one showed through as an empty grey cell.

## Why

Not a missing tile — a specificity collision in `metricsCard.scss`. The three-track fill rules sat directly under `&--grid`:

```scss
.metrics-card__hero--grid .metrics-card__tile:last-child:nth-child(3n + 2) { grid-column: span 2; }
```

A two-track hero carries `--grid` as well, and its second tile *is* `nth-child(3n + 2)` (n = 0). That selector has one class-level component more than the two-track override (`.metrics-card__hero--grid-2 .metrics-card__tile:last-child`), so `span 2` won and the last tile spanned both tracks.

The rules now exclude the two-track variant rather than relying on being overridden, so specificity no longer decides it:

```scss
&:not(.metrics-card__hero--grid-2) {
  .metrics-card__tile:last-child:nth-child(3n + 1) { grid-column: span 3; }
  .metrics-card__tile:last-child:nth-child(3n + 2) { grid-column: span 2; }
}
```

The now-redundant `grid-column: auto` drops out of the `-2` block, which keeps only the lone-tile case (`:last-child:nth-child(odd)`).

## Testing

SCSS is not linted in this repo, so this was checked by eye against the running dev server at `/visual-tests/metrics`, measuring the tile boxes:

- crew hero (2 tiles): both at x 336 / 851, 514px each, one row — was one tile plus an empty cell
- base-metrics hero (6 tiles, 3 tracks): unchanged, 342px each across two full rows

🤖