### PR TITLE
fix(discord): let commands answer in the channel

### DIFF
--- a/app/controllers/discord/interactions_controller.rb
+++ b/app/controllers/discord/interactions_controller.rb
@@ -50,13 +50,21 @@ module Discord
     # Nothing runs inline. Even a command that would finish in 40 ms locally
     # has to survive a cold connection pool and Discord's hard 3 second
     # deadline, after which the interaction cannot be answered at all.
+    #
+    # Visibility is decided *here*, not by the command: Discord fixes it at the
+    # deferred acknowledgement and ignores flags on the follow-up. The registry
+    # is the only place that knows it before the job has run.
     private def acknowledge_command
       Discord::CommandJob.perform_async(command_context)
 
-      render json: {
-        type: DEFERRED_MESSAGE,
-        data: {flags: Discord::Commands::Base::EPHEMERAL}
-      }
+      data = {}
+      data[:flags] = Discord::Commands::Base::EPHEMERAL if ephemeral_command?
+
+      render json: {type: DEFERRED_MESSAGE, data: data}
+    end
+
+    private def ephemeral_command?
+      Discord::Commands::Registry.ephemeral?(payload.dig("data", "name"))
     end
 
     private def refuse_command

--- a/app/jobs/discord/command_job.rb
+++ b/app/jobs/discord/command_job.rb
@@ -64,10 +64,9 @@ module Discord
     end
 
     private def failure
-      {
-        content: I18n.t("discord.commands.failed"),
-        flags: Commands::Base::EPHEMERAL
-      }
+      # No flags: Discord ignores them on a follow-up, and this message
+      # inherits the visibility the acknowledgement already fixed.
+      {content: I18n.t("discord.commands.failed")}
     end
   end
 end

--- a/lib/discord/commands/base.rb
+++ b/lib/discord/commands/base.rb
@@ -6,9 +6,12 @@ module Discord
     # Discord client -- the job owns the transport, so a command is a plain
     # unit test over its embed.
     class Base
-      # Bit 64: only the invoking member sees the reply. Default for every
-      # command, so a busy channel does not fill with bot output; a command
-      # that wants a public post opts out.
+      # Bit 64: only the invoking member sees the reply.
+      #
+      # Only meaningful on an *immediate* response. Discord fixes a deferred
+      # interaction's visibility at the acknowledgement and ignores flags on the
+      # follow-up, so a command payload cannot carry this -- Registry.ephemeral?
+      # decides it before the job runs.
       EPHEMERAL = 64
 
       attr_reader :options, :guild_id, :discord_user_id
@@ -27,11 +30,11 @@ module Discord
         options[name.to_s]
       end
 
-      private def message(content: nil, embeds: nil, ephemeral: true)
+      # No flags: this becomes a follow-up, where Discord ignores them.
+      private def message(content: nil, embeds: nil)
         payload = {}
         payload[:content] = content if content.present?
         payload[:embeds] = embeds if embeds.present?
-        payload[:flags] = EPHEMERAL if ephemeral
         payload
       end
 

--- a/lib/discord/commands/compare.rb
+++ b/lib/discord/commands/compare.rb
@@ -27,7 +27,7 @@ module Discord
           return message(content: I18n.t("discord.commands.compare.same_ship", ship: first.name))
         end
 
-        message(embeds: [embed(first, second)], ephemeral: false)
+        message(embeds: [embed(first, second)])
       end
 
       # A Discord embed has no table, so each stat becomes one field holding

--- a/lib/discord/commands/fleet.rb
+++ b/lib/discord/commands/fleet.rb
@@ -10,7 +10,7 @@ module Discord
         return message(content: I18n.t("discord.commands.fleet.not_bound")) if fleet.nil?
         return message(content: I18n.t("discord.commands.fleet.not_allowed", fleet: fleet.name)) unless allowed?(fleet)
 
-        message(embeds: [embed(fleet)], ephemeral: false)
+        message(embeds: [embed(fleet)])
       end
 
       # The guild the command came from decides which fleet is meant, through

--- a/lib/discord/commands/hangar.rb
+++ b/lib/discord/commands/hangar.rb
@@ -21,7 +21,7 @@ module Discord
 
         return message(content: I18n.t("discord.commands.hangar.empty", username: user.username)) if counts.empty?
 
-        message(content: content_for(user, counts), ephemeral: false)
+        message(content: content_for(user, counts))
       end
 
       # Mirrors Public::UserPolicy#show? -- the same rule the public hangar

--- a/lib/discord/commands/loaner.rb
+++ b/lib/discord/commands/loaner.rb
@@ -17,7 +17,7 @@ module Discord
         loaners = model.loaners.visible.active.ordered_by_name.to_a
         return message(content: I18n.t("discord.commands.loaner.none", ship: model.name)) if loaners.empty?
 
-        message(content: content_for(model, loaners), ephemeral: false)
+        message(content: content_for(model, loaners))
       end
 
       private def content_for(model, loaners)

--- a/lib/discord/commands/registry.rb
+++ b/lib/discord/commands/registry.rb
@@ -11,6 +11,19 @@ module Discord
       # Discord application command option types.
       STRING = 3
 
+      # Whether a command's answer is private to the caller.
+      #
+      # Declared here rather than decided by the command, because **Discord
+      # fixes visibility at the deferred acknowledgement** -- before the job
+      # that produces the answer has run. Flags on the follow-up payload are
+      # ignored, so a command cannot make itself public afterwards, and one
+      # command cannot post a public hit and a private miss.
+      #
+      # All five are lookups over data the site publishes, so they answer in
+      # the channel: asking in company is the point. The cost is that their
+      # refusals are public too.
+      EPHEMERAL_BY_DEFAULT = false
+
       DEFINITIONS = [
         {
           name: "ship",
@@ -82,6 +95,15 @@ module Discord
         DEFINITIONS.find { |definition| definition[:name] == name.to_s }
       end
 
+      # Unknown commands answer privately: a "that command no longer exists"
+      # belongs to whoever typed it.
+      def self.ephemeral?(name)
+        definition = definition(name)
+        return true if definition.nil?
+
+        definition.fetch(:ephemeral, EPHEMERAL_BY_DEFAULT)
+      end
+
       def self.handler_for(name)
         definition = definition(name)
         return nil if definition.blank?
@@ -93,7 +115,7 @@ module Discord
       # ours and would be rejected as an unknown key.
       def self.payload
         DEFINITIONS.map do |definition|
-          definition.except(:handler).deep_dup
+          definition.except(:handler, :ephemeral).deep_dup
         end
       end
     end

--- a/lib/discord/commands/ship.rb
+++ b/lib/discord/commands/ship.rb
@@ -18,7 +18,7 @@ module Discord
         model, answer = resolve_model(query)
         return answer if model.nil?
 
-        message(embeds: [embed(model)], ephemeral: false)
+        message(embeds: [embed(model)])
       end
 
       private def embed(model)

--- a/test/integration/discord_interactions_test.rb
+++ b/test/integration/discord_interactions_test.rb
@@ -84,7 +84,35 @@ class DiscordInteractionsTest < ActionDispatch::IntegrationTest
 
       assert_response :success
       assert_equal 5, response.parsed_body["type"]
+    end
+
+    # The acknowledgement is the only place Discord reads visibility: it fixes
+    # it there and ignores flags on the follow-up. A command that answers in
+    # the channel must therefore acknowledge without the ephemeral flag.
+    test "a public command is acknowledged without the ephemeral flag" do
+      post_signed(command_payload)
+
+      assert_nil response.parsed_body.dig("data", "flags")
+    end
+
+    test "an unknown command is acknowledged privately" do
+      post_signed(command_payload(name: "definitely-not-a-command"))
+
       assert_equal 64, response.parsed_body.dig("data", "flags")
+    end
+
+    test "every registered command is acknowledged the way the registry declares" do
+      Discord::Commands::Registry::DEFINITIONS.each do |definition|
+        post_signed(command_payload(name: definition[:name]))
+
+        flags = response.parsed_body.dig("data", "flags")
+
+        if Discord::Commands::Registry.ephemeral?(definition[:name])
+          assert_equal 64, flags, "/#{definition[:name]} should answer privately"
+        else
+          assert_nil flags, "/#{definition[:name]} should answer in the channel"
+        end
+      end
     end
 
     test "enqueues the command with everything the job needs" do

--- a/test/jobs/discord/command_job_test.rb
+++ b/test/jobs/discord/command_job_test.rb
@@ -7,7 +7,13 @@ module Discord
     setup do
       @client = mock("Discord::InteractionClient")
       ::Discord::InteractionClient.stubs(:new).returns(@client)
-      create(:model, name: "Carrack", classification: "explorer")
+      # The lookup matches on the model slug and the manufacturer slug too, and
+      # both are built from the manufacturer -- a random one can contain the
+      # "not found" query as a substring and answer with this ship.
+      create(:model,
+        name: "Carrack",
+        classification: "explorer",
+        manufacturer: create(:manufacturer, name: "Anvil Aerospace", code: "ANVL"))
     end
 
     def context(overrides = {})

--- a/test/lib/discord/commands/fleet_test.rb
+++ b/test/lib/discord/commands/fleet_test.rb
@@ -85,8 +85,8 @@ module Discord
         assert_equal "1", fields[I18n.t("discord.commands.fleet.fields.upcoming_events")]
       end
 
-      test "a refusal is only shown to the caller" do
-        assert_equal ::Discord::Commands::Base::EPHEMERAL, call(guild_id: "guild-nope")[:flags]
+      test "carries no flags, since a follow-up cannot set them" do
+        assert_nil call(guild_id: "guild-nope")[:flags]
       end
     end
   end

--- a/test/lib/discord/commands/hangar_test.rb
+++ b/test/lib/discord/commands/hangar_test.rb
@@ -71,10 +71,12 @@ module Discord
         assert_equal call("Nobody")[:content].sub("Nobody", "X"), call("Aendrax")[:content].sub("Aendrax", "X")
       end
 
-      test "a listing is only shown to the caller when it is a refusal" do
+      # Visibility is not a command's to decide -- RegistryTest and
+      # DiscordInteractionsTest cover it where Discord actually reads it.
+      test "carries no flags, since a follow-up cannot set them" do
         @user.update!(public_hangar: false)
 
-        assert_equal ::Discord::Commands::Base::EPHEMERAL, call("Aendrax")[:flags]
+        assert_nil call("Aendrax")[:flags]
       end
 
       test "a blank username asks for one" do

--- a/test/lib/discord/commands/loaner_test.rb
+++ b/test/lib/discord/commands/loaner_test.rb
@@ -54,7 +54,7 @@ module Discord
         assert_includes call("Hornet")[:content], "Hornet F7C"
       end
 
-      test "a real answer is posted publicly" do
+      test "carries no flags, since a follow-up cannot set them" do
         add_loaner(@model, @loaner)
 
         assert_nil call("Carrack")[:flags]

--- a/test/lib/discord/commands/registry_test.rb
+++ b/test/lib/discord/commands/registry_test.rb
@@ -34,6 +34,27 @@ module Discord
       test "an unregistered name resolves to no handler" do
         assert_nil ::Discord::Commands::Registry.handler_for("definitely-not-a-command")
       end
+
+      # Discord fixes visibility at the deferred acknowledgement and ignores
+      # flags on the follow-up, so this cannot live in the command: the answer
+      # is needed before the command has run.
+      test "every command answers in the channel" do
+        ::Discord::Commands::Registry::DEFINITIONS.each do |definition|
+          refute ::Discord::Commands::Registry.ephemeral?(definition[:name]),
+            "/#{definition[:name]} would answer privately"
+        end
+      end
+
+      # A "that command no longer exists" belongs to whoever typed it.
+      test "an unregistered name answers privately" do
+        assert ::Discord::Commands::Registry.ephemeral?("definitely-not-a-command")
+      end
+
+      test "the visibility flag is ours and never reaches Discord" do
+        ::Discord::Commands::Registry.payload.each do |command|
+          assert_not_includes command.keys, :ephemeral
+        end
+      end
     end
   end
 end

--- a/test/lib/discord/commands/ship_test.rb
+++ b/test/lib/discord/commands/ship_test.rb
@@ -30,10 +30,8 @@ module Discord
         assert_equal "Anvil Aerospace", embed.dig(:footer, :text)
       end
 
-      test "a single match is posted publicly rather than only to the caller" do
-        payload = call("Carrack")
-
-        assert_nil payload[:flags]
+      test "carries no flags, since a follow-up cannot set them" do
+        assert_nil call("Carrack")[:flags]
       end
 
       test "the embed carries the labels the site uses" do
@@ -64,11 +62,11 @@ module Discord
         assert_includes payload[:content], "Hornet F7A"
       end
 
-      test "a listing is only shown to the caller" do
+      test "a listing carries no flags either" do
         create(:model, name: "Hornet F7C", slug: "hornet-f7c", manufacturer: @manufacturer)
         create(:model, name: "Hornet F7A", slug: "hornet-f7a", manufacturer: @manufacturer)
 
-        assert_equal ::Discord::Commands::Base::EPHEMERAL, call("Hornet")[:flags]
+        assert_nil call("Hornet")[:flags]
       end
 
       test "answers a miss with a message rather than an empty embed" do


### PR DESCRIPTION
Found by running `/ship carrack` on production: the answer arrived as **"Only you can see this"**, even though `Commands::Ship` returns `ephemeral: false` and a test asserts its payload carries no flags.

## Why the test passed and the behaviour was still wrong

Discord fixes an interaction's visibility at the **deferred acknowledgement** and ignores flags on the follow-up. The controller acknowledged everything with the ephemeral flag, before the job that produces the answer had even run:

```ruby
render json: {
  type: DEFERRED_MESSAGE,
  data: {flags: Discord::Commands::Base::EPHEMERAL}   # decides everything
}
```

So `ephemeral: false` in the commands was dead code, and `assert_nil payload[:flags]` was testing an object Discord never reads that part of. The payload was correct; it just was not the thing that decided.

A unit test over a command's return value cannot catch this by construction — the bug lives in the gap between two messages, and only the acknowledgement matters.

## The fix

Visibility moves to `Registry`, the one place that knows it *before* the command runs:

```ruby
Discord::Commands::Registry.ephemeral?(command_name)
```

All five commands answer in the channel. An unknown command still answers privately — "that command no longer exists" belongs to whoever typed it.

**The trade-off, stated plainly:** deciding per command rather than per answer means a refusal is public too — `No ship found for "asdf"` now appears in the channel. Discord offers no way to have both from one deferred interaction: a private acknowledgement can only be followed by a private message. The alternative would be a `private` boolean option on each command that the caller sets, which I did not build; say the word if you would rather have that.

## Cleanup that comes with it

`Commands::Base#message` no longer takes an `ephemeral:` argument and payloads carry no flags, so the code stops claiming something Discord discards. `EPHEMERAL` stays for the one place flags genuinely work: the **immediate** response when the feature flag is off, which is not deferred.

## Tests

The old assertions are replaced with ones at the layer that decides:

- `DiscordInteractionsTest` — a public command acknowledges **without** the flag, an unknown one **with** it, and a loop over `Registry::DEFINITIONS` asserts every command acknowledges the way the registry declares. That last one fails if a future command's declaration and behaviour drift apart.
- `RegistryTest` — every command answers in the channel, an unregistered name answers privately, and `ephemeral` never reaches Discord in the sync payload.
- The five command tests now assert only that payloads carry no flags, with a comment pointing at where visibility is actually covered.

**225 runs, 437 assertions, 0 failures.** `standardrb` clean.

## Note

`/ship`'s in-game price renders as `34398000 aUEC` without a thousands separator. That is `Model#price_label`, the app's own helper, so the bot matches the website exactly — deliberately not changed here, since it would also move the API and the frontend.

🤖
