### PR TITLE
fix(tools): mark Regolith Co. as discontinued

### DIFF
--- a/app/frontend/frontend/pages/tools/index.vue
+++ b/app/frontend/frontend/pages/tools/index.vue
@@ -67,11 +67,11 @@ const featuredTools: Array<ToolEntry> = [
     category: t("tools.categories.loadouts"),
   },
   {
-    key: "regolith",
-    url: "https://regolith.rocks/",
-    name: "Regolith Co.",
-    description: t("tools.descriptions.regolith"),
-    category: t("tools.categories.mining"),
+    key: "uexCorp",
+    url: "https://uexcorp.space/",
+    name: "UEX Corp",
+    description: t("tools.descriptions.uexCorp"),
+    category: t("tools.categories.trading"),
   },
 ];
 
@@ -81,12 +81,6 @@ const tools: Array<ToolEntry> = [
     url: "https://www.spviewer.eu/",
     name: "SP Viewer",
     description: t("tools.descriptions.spviewer"),
-  },
-  {
-    key: "uexCorp",
-    url: "https://uexcorp.space/",
-    name: "UEX Corp",
-    description: t("tools.descriptions.uexCorp"),
   },
   {
     key: "itemFinder",
@@ -145,6 +139,13 @@ const tools: Array<ToolEntry> = [
 ];
 
 const discontinuedTools: Array<ToolEntry> = [
+  {
+    key: "regolith",
+    url: "https://regolith.rocks/",
+    name: "Regolith Co.",
+    description: t("tools.descriptions.regolith"),
+    disabled: true,
+  },
   {
     key: "starship42",
     url: "https://starship42.com/",

--- a/test/playwright/e2e/Tools.spec.ts
+++ b/test/playwright/e2e/Tools.spec.ts
@@ -25,8 +25,8 @@ test.describe("Tools Index", () => {
   });
 
   test("Shows disabled banner for unavailable tools", async ({ page }) => {
-    const disabledBanner = page.getByTestId("tool-card-banner");
-    await expect(disabledBanner).toBeVisible();
+    const disabledBanners = page.getByTestId("tool-card-banner");
+    await expect(disabledBanners.first()).toBeVisible();
   });
 
   test("Tool cards have external links", async ({ page }) => {


### PR DESCRIPTION
Regolith Co. has shut down, so the tools page no longer links to it.

## Changes

- **`app/frontend/frontend/pages/tools/index.vue`** — moved `regolith` from `featuredTools` into `discontinuedTools` with `disabled: true`. `ToolCard` renders disabled entries as unlinked cards with the "This project has been discontinued." banner, the same treatment Starship42 already gets. The image and description translations are unchanged and still used.
- Promoted **UEX Corp** from the regular grid into the freed featured slot, tagged with `tools.categories.trading`. That category key already existed in all seven locales but was unused, so no translation files needed touching. Without this the featured row would have shown two cards in a three-column grid.
- **`test/playwright/e2e/Tools.spec.ts`** — `getByTestId("tool-card-banner")` now matches two elements and would fail Playwright strict mode; the assertion uses `.first()`.

## Notes

- `tools.categories.mining` is now unused. Left in place for a future mining tool — happy to drop it if preferred.
- Prettier and ESLint pass on both files. The e2e spec was not run locally (needs the test server on 8280); leaving that to CI.

🤖