### PR TITLE
fix(rsi-loader): fetch manufacturer logos again

### DIFF
--- a/app/api_components/admin/v1/schemas/manufacturer.rb
+++ b/app/api_components/admin/v1/schemas/manufacturer.rb
@@ -9,9 +9,10 @@ module Admin
         schema({
           properties: {
             id: {type: :string, format: "uuid"},
-            iconOverridden: {type: :boolean}
+            iconOverridden: {type: :boolean},
+            logoOverridden: {type: :boolean}
           },
-          required: %w[id iconOverridden]
+          required: %w[id iconOverridden logoOverridden]
         })
       end
     end

--- a/app/controllers/admin/api/v1/manufacturers_controller.rb
+++ b/app/controllers/admin/api/v1/manufacturers_controller.rb
@@ -43,7 +43,7 @@ module Admin
         end
 
         def create
-          @manufacturer = Manufacturer.new(manufacturer_params.merge(icon_override))
+          @manufacturer = Manufacturer.new(manufacturer_params.merge(icon_override).merge(logo_override))
 
           authorize! @manufacturer, with: ::Admin::ManufacturerPolicy
 
@@ -53,7 +53,7 @@ module Admin
         end
 
         def update
-          return if @manufacturer.update(manufacturer_params.merge(icon_override))
+          return if @manufacturer.update(manufacturer_params.merge(icon_override).merge(logo_override))
 
           render json: ValidationError.new("manufacturer.update", errors: @manufacturer.errors), status: :bad_request
         end
@@ -79,6 +79,15 @@ module Admin
           return {} unless params.key?(:icon)
 
           {icon_overridden: params[:icon].present?}
+        end
+
+        # The same for the logo, whose other source is RSI's ship matrix:
+        # sending a file claims it, clearing it hands it back to the matrix
+        # loader, which refills it on the next sync.
+        private def logo_override
+          return {} unless params.key?(:logo)
+
+          {logo_overridden: params[:logo].present?}
         end
 
         private def manufacturer_params

--- a/app/frontend/admin/pages/manufacturers/[id]/edit.vue
+++ b/app/frontend/admin/pages/manufacturers/[id]/edit.vue
@@ -69,6 +69,13 @@ const iconLabel = computed(() =>
     : t("labels.manufacturer.icon"),
 );
 
+// The same for the logo, whose other source is RSI's ship matrix.
+const logoLabel = computed(() =>
+  props.manufacturer.logoOverridden
+    ? t("labels.manufacturer.logoOverridden")
+    : t("labels.manufacturer.logo"),
+);
+
 const submitting = ref(false);
 
 const updateMutation = useUpdateManufacturer({
@@ -140,7 +147,7 @@ const handleCancel = async () => {
           v-model="logo"
           v-bind="logoProps"
           :file="manufacturer.logo"
-          translation-key="manufacturer.logo"
+          :label="logoLabel"
           name="logo"
           :allowed-types="AllowedFileTypes.IMAGE"
           avatar

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -902,6 +902,7 @@
         "longName": "Vollständiger Name",
         "code": "Code",
         "logo": "Logo",
+        "logoOverridden": "Logo (überschrieben)",
         "icon": "Icon (Spieldateien)",
         "iconOverridden": "Icon (überschrieben)",
         "scRef": "SC Ref"

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -898,6 +898,7 @@
         "longName": "Long Name",
         "code": "Code",
         "logo": "Logo",
+        "logoOverridden": "Logo (overridden)",
         "icon": "Icon (game files)",
         "iconOverridden": "Icon (overridden)",
         "scRef": "SC Ref"

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -902,6 +902,7 @@
         "longName": "Nombre completo",
         "code": "Código",
         "logo": "Logo",
+        "logoOverridden": "Logo (sobrescrito)",
         "icon": "Icono (archivos del juego)",
         "iconOverridden": "Icono (sobrescrito)",
         "scRef": "SC Ref"

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -902,6 +902,7 @@
         "longName": "Nom complet",
         "code": "Code",
         "logo": "Logo",
+        "logoOverridden": "Logo (remplacé)",
         "icon": "Icône (fichiers du jeu)",
         "iconOverridden": "Icône (remplacée)",
         "scRef": "SC Ref"

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -902,6 +902,7 @@
         "longName": "Nome completo",
         "code": "Codice",
         "logo": "Logo",
+        "logoOverridden": "Logo (sovrascritto)",
         "icon": "Icona (file di gioco)",
         "iconOverridden": "Icona (sovrascritta)",
         "scRef": "SC Ref"

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -902,6 +902,7 @@
         "longName": "全名",
         "code": "代码",
         "logo": "标志",
+        "logoOverridden": "标识（已覆盖）",
         "icon": "图标（游戏文件）",
         "iconOverridden": "图标（已覆盖）",
         "scRef": "SC Ref"

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -902,6 +902,7 @@
         "longName": "全名",
         "code": "代碼",
         "logo": "標誌",
+        "logoOverridden": "標誌（已覆寫）",
         "icon": "圖示（遊戲檔案）",
         "iconOverridden": "圖示（已覆寫）",
         "scRef": "SC Ref"

--- a/app/lib/rsi/base_loader.rb
+++ b/app/lib/rsi/base_loader.rb
@@ -9,6 +9,25 @@ module Rsi
       @graphql_client = Graphlient::Client.new("#{base_url}/graphql")
     end
 
+    # A load runs against a fixture in the test environment, where the site is
+    # not reachable and an attachment would be written per example. Named
+    # rather than asked inline so a test that is about the fetch can allow it.
+    private def fetch_images?
+      !Rails.env.test?
+    end
+
+    # RSI's media entries are not consistent about it: most `source_url`s are
+    # paths off the site root, but some name the media host outright. Prefixing
+    # an absolute one yielded the host `robertsspaceindustries.comhttps`, which
+    # `URI.parse` accepts and nothing serves, so the fetch failed for those --
+    # invisibly, because `attach_image_from_url` only logs.
+    private def media_url(source_url)
+      return if source_url.blank?
+      return source_url if source_url.start_with?("http")
+
+      "#{base_url}#{source_url}"
+    end
+
     private def attach_image_from_url(record, attachment_name, url)
       return if url.blank?
 
@@ -16,14 +35,33 @@ module Rsi
       tempfile = uri.open # rubocop:disable Security/Open
       filename = File.basename(uri.path)
       content_type = Marcel::MimeType.for(name: filename)
+      attachment = record.send(attachment_name)
 
-      record.send(attachment_name).attach(
+      # Nothing is written when the remote file is the one already attached, so
+      # a loader may follow a source on every run without minting a blob per
+      # pass. Digested in chunks because the same method carries store images,
+      # which are megabytes where a logo is kilobytes.
+      return if attachment.attached? && attachment.blob.checksum == digest(tempfile)
+
+      attachment.attach(
         io: tempfile,
         filename: filename,
         content_type: content_type
       )
     rescue => e
       Rails.logger.error "Failed to attach image #{attachment_name} for #{record.class}##{record.id}: #{e.message}"
+    end
+
+    private def digest(io)
+      digest = Digest::MD5.new
+
+      while (chunk = io.read(16.kilobytes))
+        digest << chunk
+      end
+
+      io.rewind
+
+      digest.base64digest
     end
 
     private def fetch_remote(url)

--- a/app/lib/rsi/manufacturers_loader.rb
+++ b/app/lib/rsi/manufacturers_loader.rb
@@ -1,30 +1,74 @@
 module Rsi
   class ManufacturersLoader < ::Rsi::BaseLoader
     def one(manufacturer_data)
-      manufacturer = Manufacturer.find_by(rsi_id: manufacturer_data["id"])
-      manufacturer = Manufacturer.find_by(code: manufacturer_data["code"], rsi_id: nil) if manufacturer.blank?
-      manufacturer = Manufacturer.find_by(name: manufacturer_data["name"], rsi_id: nil) if manufacturer.blank?
-      if manufacturer.blank?
-        manufacturer = Manufacturer.create!(
-          name: manufacturer_data["name"],
-          rsi_id: manufacturer_data["id"],
-          code: manufacturer_data["code"]
-        )
-      end
+      manufacturer = find(manufacturer_data) || create(manufacturer_data)
 
-      manufacturer.update!(
-        rsi_id: manufacturer_data["id"],
-        name: manufacturer_data["name"],
-        code: manufacturer_data["code"].presence,
-        known_for: manufacturer_data["known_for"].presence,
-        description: manufacturer_data["description"].presence
-      )
+      # A matrix run calls this once per ship, and the same nineteen
+      # manufacturers come round again on every one of them. Without the guard
+      # each logo would be fetched a couple of hundred times a sync, since
+      # deciding against writing one needs the file in hand.
+      return manufacturer unless synced.add?(manufacturer.id)
 
-      if !Rails.env.test? && !manufacturer.logo.attached? && manufacturer_data["media"].present? && manufacturer_data["media"][0]["source_url"].present?
-        attach_image_from_url(manufacturer, :logo, "#{base_url}#{manufacturer_data["media"][0]["source_url"]}")
+      manufacturer.update!(update_params(manufacturer, manufacturer_data))
+
+      # Only where an admin has not put their own picture there. The flag is
+      # what separates the two, because the attachment alone cannot: a checksum
+      # that differs from RSI's file means either that RSI reworked the artwork
+      # or that somebody overrode it, and guessing wrong in either direction
+      # loses work.
+      if fetch_images? && !manufacturer.logo_overridden?
+        attach_image_from_url(manufacturer, :logo, logo_url(manufacturer_data))
       end
 
       manufacturer
+    end
+
+    private def synced
+      @synced ||= Set.new
+    end
+
+    private def find(manufacturer_data)
+      manufacturer = Manufacturer.find_by(rsi_id: manufacturer_data["id"])
+      manufacturer = Manufacturer.find_by(code: manufacturer_data["code"], rsi_id: nil) if manufacturer.blank?
+      manufacturer = Manufacturer.find_by(name: manufacturer_data["name"], rsi_id: nil) if manufacturer.blank?
+
+      manufacturer
+    end
+
+    private def create(manufacturer_data)
+      Manufacturer.create!(
+        name: manufacturer_data["name"],
+        rsi_id: manufacturer_data["id"],
+        code: manufacturer_data["code"],
+        known_for: manufacturer_data["known_for"].presence,
+        description: manufacturer_data["description"].presence
+      )
+    end
+
+    # `rsi_id` is the identity this loader matches on, so it follows the matrix.
+    # The rest is filled only where the record has nothing, matching what the
+    # sc_data loader does with the same columns: these are editable in admin,
+    # and this runs for every ship on every sync rather than only when a model
+    # is created, so overwriting would revert a correction on the next pass --
+    # and with `nil` wherever the matrix carries no value.
+    private def update_params(manufacturer, manufacturer_data)
+      params = {rsi_id: manufacturer_data["id"]}
+
+      %w[name code known_for description].each do |attr|
+        next if manufacturer.send(attr).present? || manufacturer_data[attr].blank?
+
+        params[attr.to_sym] = manufacturer_data[attr]
+      end
+
+      params
+    end
+
+    private def logo_url(manufacturer_data)
+      media = manufacturer_data["media"]
+
+      return if media.blank?
+
+      media_url(media[0]["source_url"])
     end
   end
 end

--- a/app/lib/rsi/models_loader.rb
+++ b/app/lib/rsi/models_loader.rb
@@ -47,7 +47,12 @@ module Rsi
       unless paint?(data)
         sleep 5 unless Rails.env.test?
         pledge_store_loader.run(model)
-        model.manufacturer = manufacturers_loader.one(data["manufacturer"]) if model.manufacturer.blank?
+        # Called for every ship, not only for one whose manufacturer is unset:
+        # the loader is the only thing that fills a manufacturer's logo and its
+        # RSI metadata, and guarding the call on `model.manufacturer.blank?`
+        # meant it was reached for a newly created model and never again.
+        manufacturer = manufacturers_loader.one(data["manufacturer"])
+        model.manufacturer = manufacturer if model.manufacturer.blank?
         hardpoints_loader.all(model, data["compiled"])
       end
 
@@ -178,13 +183,12 @@ module Rsi
 
     # rubocop:disable Metrics/CyclomaticComplexity
     private def load_store_image(model, media_data)
-      return if Rails.env.test?
+      return unless fetch_images?
 
       updated_at = store_images_updated_at(media_data)
       up_to_date = updated_at.present? && model.store_images_updated_at.present? && model.store_images_updated_at >= updated_at
 
-      store_image_url = media_data["images"]["store_hub_large"]
-      store_image_url = "#{base_url}#{store_image_url}" unless store_image_url.starts_with?("https")
+      store_image_url = media_url(media_data["images"]["store_hub_large"])
 
       return if store_image_url.blank?
 

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -11,6 +11,7 @@
 #  icon_overridden :boolean          default(FALSE), not null
 #  icon_path       :string
 #  known_for       :string(255)
+#  logo_overridden :boolean          default(FALSE), not null
 #  long_name       :string
 #  name            :string(255)
 #  sc_ref          :string

--- a/app/views/admin/api/v1/manufacturers/_base.jbuilder
+++ b/app/views/admin/api/v1/manufacturers/_base.jbuilder
@@ -12,5 +12,6 @@ json.icon do
   json.partial! "api/v1/shared/file", record: manufacturer, attr: :icon
 end
 json.icon_overridden manufacturer.icon_overridden
+json.logo_overridden manufacturer.logo_overridden
 
 json.partial! "api/shared/dates", record: manufacturer

--- a/db/migrate/20260831200000_add_logo_overridden_to_manufacturers.rb
+++ b/db/migrate/20260831200000_add_logo_overridden_to_manufacturers.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLogoOverriddenToManufacturers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :manufacturers, :logo_overridden, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_180000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_31_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -885,6 +885,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_180000) do
     t.boolean "icon_overridden", default: false, null: false
     t.string "icon_path"
     t.string "known_for", limit: 255
+    t.boolean "logo_overridden", default: false, null: false
     t.string "long_name"
     t.string "name", limit: 255
     t.integer "rsi_id"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -12266,6 +12266,8 @@ components:
           format: uuid
         iconOverridden:
           type: boolean
+        logoOverridden:
+          type: boolean
       additionalProperties: false
       required:
       - name
@@ -12274,6 +12276,7 @@ components:
       - updatedAt
       - id
       - iconOverridden
+      - logoOverridden
       title: Manufacturer
     ManufacturerInput:
       type: object

--- a/test/factories/manufacturers.rb
+++ b/test/factories/manufacturers.rb
@@ -9,6 +9,7 @@
 #  icon_overridden :boolean          default(FALSE), not null
 #  icon_path       :string
 #  known_for       :string(255)
+#  logo_overridden :boolean          default(FALSE), not null
 #  long_name       :string
 #  name            :string(255)
 #  sc_ref          :string

--- a/test/integration/admin/api/v1/manufacturers_test.rb
+++ b/test/integration/admin/api/v1/manufacturers_test.rb
@@ -313,13 +313,38 @@ class Admin::Api::V1::ManufacturersTest < ActionDispatch::IntegrationTest
     end
   end
 
-  # Clearing sends a null -- that is what the file input emits -- so the request
-  # schema has to accept one, or the admin UI cannot remove a picture at all.
-  test "PUT /manufacturers/:id clears the logo" do
-    manufacturer = create(:manufacturer, :with_logo)
+  # The same for the logo, whose other source is RSI's ship matrix.
+  test "PUT /manufacturers/:id claims the logo when one is uploaded" do
+    manufacturer = create(:manufacturer)
     sign_in @user
 
-    assert_api_response :put, 200, path_params: {id: manufacturer.id}, body: {logo: nil}
+    assert_api_response :put, 200, path_params: {id: manufacturer.id}, body: {logo: uploaded_icon.signed_id} do
+      assert parsed_body["logoOverridden"]
+    end
+
+    assert_equal "by-hand.png", manufacturer.reload.logo.filename.to_s
+  end
+
+  test "PUT /manufacturers/:id leaves the override alone when the logo is not part of the request" do
+    manufacturer = create(:manufacturer, logo_overridden: true)
+    sign_in @user
+
+    assert_api_response :put, 200, path_params: {id: manufacturer.id}, body: {name: "Renamed"} do
+      assert parsed_body["logoOverridden"]
+    end
+  end
+
+  # Clearing sends a null -- that is what the file input emits -- so the request
+  # schema has to accept one, or the admin UI cannot remove a picture at all.
+  # It also hands the logo back to the matrix loader, which refills it on the
+  # next sync.
+  test "PUT /manufacturers/:id clears the logo" do
+    manufacturer = create(:manufacturer, :with_logo, logo_overridden: true)
+    sign_in @user
+
+    assert_api_response :put, 200, path_params: {id: manufacturer.id}, body: {logo: nil} do
+      assert_not parsed_body["logoOverridden"]
+    end
 
     assert_not_predicate manufacturer.reload.logo, :attached?
   end

--- a/test/loaders/rsi/manufacturers_loader_test.rb
+++ b/test/loaders/rsi/manufacturers_loader_test.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "webmock/minitest"
+require "support/hangar_import_fixtures"
+
+module Rsi
+  class ManufacturersLoaderTest < ActiveSupport::TestCase
+    include HangarImportFixtures
+
+    LOGO = File.binread("test/fixtures/files/test.png")
+
+    setup do
+      clean_loader_tables
+      @loader = ::Rsi::ManufacturersLoader.new
+      @matrix = JSON.parse(File.read("test/fixtures/rsi/matrix.json")).fetch("data")
+    end
+
+    test "#one creates a manufacturer from the matrix entry" do
+      manufacturer = @loader.one(data_for("RSI"))
+
+      assert_equal 1, manufacturer.rsi_id
+      assert_equal "RSI", manufacturer.code
+      assert_equal "the Aurora and the Constellation", manufacturer.known_for
+      assert_predicate manufacturer.description, :present?
+    end
+
+    test "#one fills only what the record is missing" do
+      existing = create(
+        :manufacturer,
+        name: "Roberts Space Industries",
+        code: "RSI",
+        rsi_id: nil,
+        known_for: nil,
+        description: "Curated"
+      )
+
+      assert_no_difference -> { Manufacturer.count } do
+        @loader.one(data_for("RSI"))
+      end
+
+      existing.reload
+
+      assert_equal 1, existing.rsi_id
+      assert_equal "the Aurora and the Constellation", existing.known_for
+      assert_equal "Curated", existing.description
+    end
+
+    test "#one attaches the logo for a relative source url" do
+      @loader.stubs(:fetch_images?).returns(true)
+
+      stub_request(:get, "https://robertsspaceindustries.com/media/tb6ui8j38wwscr/source/RSI.png")
+        .to_return(status: 200, body: LOGO)
+
+      manufacturer = @loader.one(data_for("RSI"))
+
+      assert_predicate manufacturer.logo, :attached?
+      assert_equal "RSI.png", manufacturer.logo.blob.filename.to_s
+    end
+
+    # The matrix names the media host outright for five of its nineteen
+    # manufacturers, which used to be prefixed with the site root.
+    test "#one attaches the logo for an absolute source url" do
+      @loader.stubs(:fetch_images?).returns(true)
+
+      stub_request(:get, "https://media.robertsspaceindustries.com/s5p49a11la7y6/source.png")
+        .to_return(status: 200, body: LOGO)
+
+      manufacturer = @loader.one(data_for("ESPR"))
+
+      assert_predicate manufacturer.logo, :attached?
+    end
+
+    test "#one leaves an overridden logo alone" do
+      create(:manufacturer, name: "Roberts Space Industries", code: "RSI", rsi_id: 1, logo_overridden: true)
+
+      @loader.stubs(:fetch_images?).returns(true)
+
+      request = stub_request(:get, "https://robertsspaceindustries.com/media/tb6ui8j38wwscr/source/RSI.png")
+        .to_return(status: 200, body: LOGO)
+
+      manufacturer = @loader.one(data_for("RSI"))
+
+      assert_not_requested request
+      assert_not_predicate manufacturer.logo, :attached?
+    end
+
+    test "#one does not re-attach an unchanged logo" do
+      stub_request(:get, "https://robertsspaceindustries.com/media/tb6ui8j38wwscr/source/RSI.png")
+        .to_return(status: 200, body: LOGO)
+
+      @loader.stubs(:fetch_images?).returns(true)
+      manufacturer = @loader.one(data_for("RSI"))
+      blob_id = manufacturer.logo.blob.id
+
+      # A second run, where the file the site serves is the one already
+      # attached.
+      later = ::Rsi::ManufacturersLoader.new
+      later.stubs(:fetch_images?).returns(true)
+      later.one(data_for("RSI"))
+
+      assert_equal blob_id, manufacturer.reload.logo.blob.id
+    end
+
+    # A matrix run reaches this once per ship, so the fetch has to happen once
+    # per run rather than once per ship.
+    test "#one fetches the logo once per run" do
+      @loader.stubs(:fetch_images?).returns(true)
+
+      request = stub_request(:get, "https://robertsspaceindustries.com/media/tb6ui8j38wwscr/source/RSI.png")
+        .to_return(status: 200, body: LOGO)
+
+      3.times { @loader.one(data_for("RSI")) }
+
+      assert_requested request, times: 1
+    end
+
+    private def data_for(code)
+      @matrix.find { |model| model.dig("manufacturer", "code") == code }.fetch("manufacturer")
+    end
+  end
+end

--- a/test/loaders/rsi/models_loader_test.rb
+++ b/test/loaders/rsi/models_loader_test.rb
@@ -147,5 +147,21 @@ module Rsi
       assert_in_delta 181.0, polaris.length.to_f
       assert_equal "2026-06-25T15:03:13Z", polaris.last_updated_at.utc.iso8601
     end
+
+    # The manufacturer loader is the only thing that fills a manufacturer's
+    # logo and its RSI metadata, and it used to be reached only for a model
+    # whose manufacturer was unset -- so a sync over ships that all had one
+    # never ran it.
+    test "#syncs the manufacturer of a model that already has one" do
+      manufacturer = create(:manufacturer, name: "Origin Jumpworks", code: "ORIG", rsi_id: nil, known_for: nil)
+      create(:model, name: "300i", rsi_id: 7, rsi_chassis_id: 1, manufacturer: manufacturer)
+
+      @loader.one(7)
+
+      manufacturer.reload
+
+      assert_equal 6, manufacturer.rsi_id
+      assert_predicate manufacturer.known_for, :present?
+    end
   end
 end

--- a/test/models/manufacturer_test.rb
+++ b/test/models/manufacturer_test.rb
@@ -13,6 +13,7 @@ require "test_helper"
 #  icon_overridden :boolean          default(FALSE), not null
 #  icon_path       :string
 #  known_for       :string(255)
+#  logo_overridden :boolean          default(FALSE), not null
 #  long_name       :string
 #  name            :string(255)
 #  sc_ref          :string


### PR DESCRIPTION
The matrix sync downloaded no manufacturer logos at all. Three things were wrong at once, and each on its own was enough.

## Why nothing was downloaded

**The loader was never called.** `ManufacturersLoader#one` — the only thing that fills a manufacturer's logo and its RSI metadata — was guarded on `model.manufacturer.blank?`, so it was reached when a model was created and never again. A sync over ships that all have a manufacturer skipped it entirely. That guard arrived with the Vue 3 migration (`5cc1365a3`); before it, the call was unconditional.

**Absolute media URLs were mangled.** Five of the nineteen manufacturers in the matrix (XNAA, ESPR, ARGO, MRAI, GAMA) name the media host in `source_url` outright where the rest give a path off the site root. `"#{base_url}#{source_url}"` turned those into the host `robertsspaceindustries.comhttps`, which `URI.parse` accepts and nothing resolves — and the failure only reached the log, because attaching swallows it.

**An attached logo was never reconsidered.** `!logo.attached?` meant a logo was filled once and then frozen, so RSI reworking its artwork never landed. All twenty matrix manufacturers already had one, so even a reached loader was a no-op.

## What changed

`ManufacturersLoader#one` runs for every ship now, which is why its field updates only fill what the record is missing: `name`, `code`, `known_for` and `description` are editable in admin, and overwriting them on every pass would revert a correction — with `nil` wherever the matrix carries no value. `rsi_id` still follows the matrix. This is the same rule the sc_data loader applies to the same columns, and the one the `max_speed`/`pitch`/`yaw`/`roll` comment in `models_loader.rb` describes.

A new `media_url` helper passes an absolute `source_url` through and prefixes only a relative one. `load_store_image` uses it too — its own `starts_with?` would have raised on a missing `store_hub_large`.

The logo now follows RSI by checksum rather than by emptiness, and a new `logo_overridden` flag is what keeps an admin's picture out of it — mirroring `icon_overridden`, and derived from the upload rather than sent: uploading claims the logo, clearing hands it back to the loader. The flag is surfaced in the admin edit form as a changed field label, the way the icon's is.

Fetched once per run rather than once per ship: `one` is reached ~240 times a sync and deciding against a write needs the file in hand, so without the cache each logo would be downloaded a couple of hundred times.

## Effect of the first sync after this lands

`logo_overridden` starts out `false` for every row — nothing is backfilled, since a logo whose provenance nobody recorded cannot be told apart from ours. So the twenty matrix manufacturers get RSI's current artwork written over their existing logo wherever the checksum differs, including files that look hand-made (`aegis_256.png`, `rsi_256.png`). From then on every admin upload protects itself. The nine empty `known_for` and five empty `description` values get filled as well.

## Verified

- 53 tests across the affected loader, integration and model suites pass; rubocop and `lint:ts` clean.
- Both URL forms fetched against the live site through the new helper (10,605 and 9,705 bytes). The old concatenation dies with `Socket::ResolutionError: Failed to open TCP connection to robertsspaceindustries.comhttps:443`.
- New coverage: relative and absolute logo URLs, an overridden logo left alone, an unchanged logo not re-attached, one fetch per run, and a manufacturer synced through a model that already has one.

🤖
