### PR TITLE
fix(forms): move the input hover from the fill to the edge

### DIFF
--- a/app/frontend/entrypoints/tailwind.css
+++ b/app/frontend/entrypoints/tailwind.css
@@ -56,6 +56,14 @@
    */
   --color-field: rgb(18 20 23 / 0.96);
 
+  /*
+   * The hover step for a field's frame. The first of the edge family to go up
+   * rather than down, and deliberately short of --color-endcap: taking the edge
+   * all the way to full opacity made it the cap's colour, which read as the
+   * frame collapsing into one line instead of the edge answering the cursor.
+   */
+  --color-edge-strong: rgb(122 130 136 / 0.7);
+
   --color-edge: rgb(122 130 136 / 0.5);
   --color-edge-soft: rgb(122 130 136 / 0.28);
   --color-edge-faint: rgb(122 130 136 / 0.16);

--- a/app/frontend/shared/components/base/FormInput/index.scss
+++ b/app/frontend/shared/components/base/FormInput/index.scss
@@ -96,10 +96,21 @@
     background-color: var(--color-field, rgb(18 20 23 / 0.96));
     border: 1px solid var(--color-edge, rgb(122 130 136 / 0.5));
     border-radius: var(--radius-control, 8px);
-    transition: background-color ease-in-out 0.15s;
+    transition: border-color ease-in-out 0.15s;
 
+    /*
+     * The edge is the one channel no state uses -- focus and error both live on
+     * the caps -- so it is free to carry the hover without competing with
+     * either. It stops at --color-edge-strong rather than reaching the cap's
+     * own grey, which is loud enough to read as a state rather than a pointer
+     * answer. The fill stays put: a field is recessed, and lifting it to
+     * --color-control-hover made it read as a button.
+     *
+     * No --disabled or --clean override needed: both set border-color further
+     * down the file at equal specificity, so they win over this.
+     */
     &:hover {
-      background-color: var(--color-control-hover, rgb(52 58 64 / 0.95));
+      border-color: var(--color-edge-strong, rgb(122 130 136 / 0.7));
     }
 
     /*
@@ -189,10 +200,6 @@
    * no cap at all, the edge dropped to --color-edge-faint, and the control
    * dimmed. The label above keeps its opacity -- a form still has to be
    * readable when half of it is locked.
-   *
-   * Killing the hover lift matters as much as the dimming. Without it a disabled
-   * field brightens under the cursor, which is worse than looking enabled: it
-   * answers.
    */
   &--disabled {
     --field-cap: transparent;
@@ -200,10 +207,6 @@
     .base-input__wrapper {
       border-color: var(--color-edge-faint, rgb(122 130 136 / 0.16));
       opacity: 0.5;
-
-      &:hover {
-        background-color: var(--color-field, rgb(18 20 23 / 0.96));
-      }
     }
 
     input {
@@ -253,10 +256,6 @@
       background-color: transparent;
       border: none;
       border-radius: 0;
-
-      &:hover {
-        background-color: transparent;
-      }
 
       &::before,
       &::after {

--- a/app/frontend/shared/components/base/FormTextarea/index.scss
+++ b/app/frontend/shared/components/base/FormTextarea/index.scss
@@ -57,10 +57,21 @@
     background-color: var(--color-field, rgb(18 20 23 / 0.96));
     border: 1px solid var(--color-edge, rgb(122 130 136 / 0.5));
     border-radius: var(--radius-control, 8px);
-    transition: background-color ease-in-out 0.15s;
+    transition: border-color ease-in-out 0.15s;
 
+    /*
+     * The edge is the one channel no state uses -- focus and error both live on
+     * the caps -- so it is free to carry the hover without competing with
+     * either. It stops at --color-edge-strong rather than reaching the cap's
+     * own grey, which is loud enough to read as a state rather than a pointer
+     * answer. The fill stays put: a field is recessed, and lifting it to
+     * --color-control-hover made it read as a button.
+     *
+     * No --disabled or --clean override needed: both set border-color further
+     * down the file at equal specificity, so they win over this.
+     */
     &:hover {
-      background-color: var(--color-control-hover, rgb(52 58 64 / 0.95));
+      border-color: var(--color-edge-strong, rgb(122 130 136 / 0.7));
     }
 
     &::before,
@@ -152,10 +163,6 @@
    * no cap at all, the edge dropped to --color-edge-faint, and the control
    * dimmed. The label above keeps its opacity -- a form still has to be
    * readable when half of it is locked.
-   *
-   * Killing the hover lift matters as much as the dimming. Without it a disabled
-   * field brightens under the cursor, which is worse than looking enabled: it
-   * answers.
    */
   &--disabled {
     --field-cap: transparent;
@@ -163,10 +170,6 @@
     .base-textarea__wrapper {
       border-color: var(--color-edge-faint, rgb(122 130 136 / 0.16));
       opacity: 0.5;
-
-      &:hover {
-        background-color: var(--color-field, rgb(18 20 23 / 0.96));
-      }
     }
 
     textarea {
@@ -181,10 +184,6 @@
       background-color: transparent;
       border: none;
       border-radius: 0;
-
-      &:hover {
-        background-color: transparent;
-      }
 
       &::before,
       &::after {


### PR DESCRIPTION
## Was

Ein gehovertes Textfeld hob seine Fläche auf `--color-control-hover` — dasselbe Token, das `Btn` für seinen eigenen Hover benutzt. Damit landete das Feld auf `#343a40`, **heller als ein Button im Ruhezustand** (`--color-control`, `#272b30`), und kippte genau die Achse um, für die `--color-field` überhaupt existiert:

> The fill is the only axis that separates them — a field is recessed, a button sits on top.
> — `tailwind.css:44-56`

Ein Textfeld hat von dem Zustand außerdem wenig: der Caret-Cursor beantwortet „kann ich hier tippen" bereits, und der Zustand, der zählt, ist Fokus — der hat sein eigenes Signal in den End-Caps. Die laute Fläche trug also die leise Bedeutung.

## Wie

Der Hover wandert auf die Kante, den einzigen Kanal, den kein anderer Zustand belegt (Fokus und Fehler laufen beide über `--field-cap`). Neues Token `--color-edge-strong`: derselbe Grauton wie die Ruhekante, bei `0.7` statt `0.5`.

Bewusst **nicht** `--color-endcap` (volle Deckung): das ist exakt die Cap-Farbe, und der Rahmen las sich dann als eine einzige geschlossene Linie statt als Kante, die auf den Cursor antwortet.

| | Border | Fill |
|---|---|---|
| Ruhe | `rgba(122, 130, 136, 0.5)` | `rgba(18, 20, 23, 0.96)` |
| Hover | `rgba(122, 130, 136, 0.7)` | *unverändert* |

Nebenbei fallen die `--disabled`- und `--clean`-Overrides weg, die es nur gab, um den Fill-Lift wieder einzufangen. Beide setzen `border-color` bzw. `border: none` weiter unten in derselben Datei bei gleicher Spezifität (`0,2,0`), gewinnen also ohnehin über die Hover-Regel — ein gesperrtes Feld bleibt auf `--color-edge-faint`, ein `--clean`-Feld rahmenlos.

## Nicht angefasst

`Select`, `FormCheckbox`, `RadioList`, `FormToggle`, `FormFileInput`, `FormDatePicker` und `FormDateTime` behalten ihren Fill-Hover. Das sind Klickziele — ein Datumsfeld öffnet beim Klick einen Picker —, und dort ist der Hover echte Information. Die Linie ist damit: **tippen → Kante, klicken → Fläche.**

Die Styles von `FormInput`/`FormTextarea` sind `scoped`, es leckt also nichts über die geteilte Klasse `.base-input__wrapper` zu `FormDatePicker` hinüber.

## Getestet

- Live auf `/login` gegen die echte `.base-input__wrapper` gemessen: Border wechselt, Fill steht still. (Diese Messung lief noch gegen die erste, lautere Variante — der Mechanismus ist derselbe, nur der Zielwert ist inzwischen niedriger.)
- Die Abstufungen `0.5 / 0.65 / 0.7 / 0.8 / 1.0` als statische Swatches nebeneinander gerendert, um den Abstand zur Cap-Farbe zu wählen.
- Kein Test hing am alten Hover — `FormStates.spec.ts` erwähnt „hover" nur in einem Kommentar über Tooltip-Fehlermeldungen.

🤖