### PR TITLE
feat(btn): carry the loading state on the end-caps

### DIFF
--- a/app/frontend/admin/components/Models/Actions/Items.vue
+++ b/app/frontend/admin/components/Models/Actions/Items.vue
@@ -148,7 +148,6 @@ const destroy = () => {
   <Btn
     v-tooltip="!withLabels && t('actions.models.syncMatrix')"
     :loading="isSyncingMatrix"
-    spinner
     @click="syncMatrix"
   >
     <i class="fa-duotone fa-rotate" />
@@ -157,7 +156,6 @@ const destroy = () => {
   <Btn
     v-tooltip="!withLabels && t('actions.models.syncScData')"
     :loading="isSyncingScData"
-    spinner
     @click="syncScData"
   >
     <i class="fa-duotone fa-database" />

--- a/app/frontend/admin/pages/maintenance/imports.vue
+++ b/app/frontend/admin/pages/maintenance/imports.vue
@@ -180,7 +180,6 @@ const columns: BaseTableCol<Import>[] = [
       :confirm="t('messages.confirm.model.reloadMatrix')"
       :aria-label="t('actions.admin.dashboard.reloadModels')"
       mobile-icon-only
-      spinner
       @click="reloadModels"
     >
       <i class="fa fa-rotate" />
@@ -192,7 +191,6 @@ const columns: BaseTableCol<Import>[] = [
       :confirm="t('messages.confirm.model.reloadScData')"
       :aria-label="t('actions.admin.dashboard.reloadScData')"
       mobile-icon-only
-      spinner
       @click="reloadScData"
     >
       <i class="fa fa-database" />
@@ -204,7 +202,6 @@ const columns: BaseTableCol<Import>[] = [
       :confirm="t('messages.confirm.model.reloadModules')"
       :aria-label="t('actions.admin.dashboard.reloadModules')"
       mobile-icon-only
-      spinner
       @click="reloadModules"
     >
       <i class="fa fa-puzzle" />
@@ -216,7 +213,6 @@ const columns: BaseTableCol<Import>[] = [
       :confirm="t('messages.confirm.model.reloadPaints')"
       :aria-label="t('actions.admin.dashboard.reloadPaints')"
       mobile-icon-only
-      spinner
       @click="reloadPaints"
     >
       <i class="fa fa-palette" />
@@ -228,7 +224,6 @@ const columns: BaseTableCol<Import>[] = [
       :confirm="t('messages.confirm.model.reloadLoaners')"
       :aria-label="t('actions.admin.dashboard.reloadLoaners')"
       mobile-icon-only
-      spinner
       @click="reloadLoaners"
     >
       <i class="fa fa-handshake" />

--- a/app/frontend/admin/pages/models/[id]/edit.vue
+++ b/app/frontend/admin/pages/models/[id]/edit.vue
@@ -130,7 +130,6 @@ const syncScData = () => {
       <Btn
         v-tooltip="t('actions.models.syncMatrix')"
         :loading="isSyncingMatrix"
-        spinner
         @click="syncMatrix"
       >
         <i class="fa-duotone fa-rotate" />
@@ -139,7 +138,6 @@ const syncScData = () => {
       <Btn
         v-tooltip="t('actions.models.syncScData')"
         :loading="isSyncingScData"
-        spinner
         @click="syncScData"
       >
         <i class="fa-duotone fa-database" />

--- a/app/frontend/admin/pages/models/[id]/edit/paints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/paints.vue
@@ -225,7 +225,6 @@ const bulkCopy = (selectedIds: string[]) => {
       <Btn
         v-tooltip="t('actions.models.importPaints')"
         :loading="isImportingPaints"
-        spinner
         @click="importPaints"
       >
         <i class="fa-duotone fa-palette" />

--- a/app/frontend/admin/pages/models/index.vue
+++ b/app/frontend/admin/pages/models/index.vue
@@ -227,7 +227,6 @@ watch(
       :confirm="t('messages.confirm.model.reloadMatrix')"
       :aria-label="t('actions.admin.dashboard.reloadModels')"
       mobile-icon-only
-      spinner
       @click="reloadModels"
     >
       <i class="fa fa-rotate" />
@@ -239,7 +238,6 @@ watch(
       :confirm="t('messages.confirm.model.reloadScData')"
       :aria-label="t('actions.admin.dashboard.reloadScData')"
       mobile-icon-only
-      spinner
       @click="reloadScData"
     >
       <i class="fa fa-database" />

--- a/app/frontend/frontend/pages/visual-tests/buttons.vue
+++ b/app/frontend/frontend/pages/visual-tests/buttons.vue
@@ -80,6 +80,15 @@ const colour = ref(true);
 const toggleLoading = () => {
   loading.value = !loading.value;
 };
+
+// The showcase below starts loading rather than waiting for a click: the scan is
+// the whole point of the section, and a row that has to be armed first shows
+// nothing to anyone who lands here to look at it.
+const loadingShowcase = ref(true);
+
+const toggleLoadingShowcase = () => {
+  loadingShowcase.value = !loadingShowcase.value;
+};
 </script>
 
 <template>
@@ -137,11 +146,86 @@ const toggleLoading = () => {
       <Btn>Rest</Btn>
       <Btn active>Active</Btn>
       <Btn disabled>Disabled</Btn>
-      <Btn :loading="loading" spinner @click="toggleLoading">
-        Toggle loading
-      </Btn>
-      <Btn :loading="loading" @click="toggleLoading">Loading, no spinner</Btn>
+      <Btn :loading="loading" @click="toggleLoading">Toggle loading</Btn>
       <Btn confirm="Really?" @click="toggleLoading">With confirm</Btn>
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Loading — the caps carry it</Heading>
+  <p>
+    One fill travels around the outside: left to right along the top cap, on
+    along the bottom cap right to left, and the top clears behind it as soon as
+    the bottom picks the run up — so the lit run is one cap long and neither cap
+    waits. Nothing is inserted beside the label, so the button neither grows nor
+    reflows when it starts working. It also needs no opt-in: the
+    <code>spinner</code> prop this replaces was passed at 12 of 51 loading call
+    sites, so most of them showed nothing at all. A fill is always one run
+    anchored to an edge, which is what makes it hold on a 23px icon-button cap
+    where a travelling marker read as two nubs in the corners. Where there are
+    no caps the surface takes the same run in the one direction it has, in from
+    the left and out to the right, at half the pace: it is the whole control
+    rather than a 2px edge, and at the cap's speed it reads as the button
+    flashing. Neutral borrows the hover accent, since its resting cap is already
+    grey.
+  </p>
+  <div class="row">
+    <div class="col-12 vt-row" data-test="loading-showcase">
+      <Btn @click="toggleLoadingShowcase">
+        {{ loadingShowcase ? "Stop" : "Start" }} the row below
+      </Btn>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 vt-row" data-test="loading-variants">
+      <template v-for="tone in tones" :key="`loading-${tone}`">
+        <Btn
+          v-for="variant in variants"
+          :key="`loading-${tone}-${variant}`"
+          :variant="variant"
+          :tone="tone"
+          :loading="loadingShowcase"
+        >
+          {{ variant }} / {{ tone }}
+        </Btn>
+      </template>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 vt-row" data-test="loading-sizes">
+      <!-- xs carries no caps at any state, so its surface fills instead. -->
+      <Btn
+        v-for="size in sizes"
+        :key="`loading-${size}`"
+        :size="size"
+        :loading="loadingShowcase"
+      >
+        {{ size }}
+      </Btn>
+      <Btn :loading="loadingShowcase" aria-label="Sync hangar">
+        <i class="fa-solid fa-rotate" />
+      </Btn>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 vt-row" data-test="loading-containers">
+      <!-- A member and a menu row have no caps either: the group draws one pair
+           for the whole control, and the edges are the group's, not theirs. -->
+      <BtnGroup>
+        <Btn :loading="loadingShowcase">Syncing</Btn>
+        <Btn>Cancel</Btn>
+      </BtnGroup>
+      <BtnDropdown>
+        <template #label>Menu</template>
+        <Btn :loading="loadingShowcase">Importing</Btn>
+        <Btn :tone="BtnTonesEnum.DANGER" :loading="loadingShowcase">
+          Deleting
+        </Btn>
+      </BtnDropdown>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <Btn block :loading="loadingShowcase">Block, working</Btn>
     </div>
   </div>
 

--- a/app/frontend/shared/components/base/Btn/index.spec.ts
+++ b/app/frontend/shared/components/base/Btn/index.spec.ts
@@ -26,7 +26,7 @@ const mountBtn = (
     slots: { default: "Label" },
     global: {
       provide,
-      stubs: { "router-link": RouterLinkStub, SmallLoader: true },
+      stubs: { "router-link": RouterLinkStub },
     },
   });
 
@@ -83,9 +83,10 @@ describe("BaseBtn", () => {
     expect(wrapper.get(".btn__status").text()).toBe("baseBtn.labels.loading");
   });
 
-  it("announces loading even without a visible spinner", () => {
-    // `spinner` is opt-in and was passed at only 11 of 51 loading call sites.
-    const wrapper = mountBtn({ loading: true, spinner: false });
+  it("announces loading, which nothing visual is required for", () => {
+    // The caps carry it visually, and they are decoration as far as assistive
+    // technology is concerned - this is the only thing that announces it.
+    const wrapper = mountBtn({ loading: true });
 
     expect(wrapper.find(".btn__status").exists()).toBe(true);
   });

--- a/app/frontend/shared/components/base/Btn/index.vue
+++ b/app/frontend/shared/components/base/Btn/index.vue
@@ -5,8 +5,6 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import SmallLoader from "@/shared/components/SmallLoader/index.vue";
-import { type SpinnerAlignment } from "@/shared/components/SmallLoader/index.vue";
 import { type RouterLinkProps } from "vue-router";
 import {
   BtnTypesEnum,
@@ -24,7 +22,6 @@ export type Props = {
   target?: HTMLAnchorElement["target"];
   type?: `${BtnTypesEnum}`;
   loading?: boolean;
-  spinner?: boolean | `${SpinnerAlignment}`;
   variant?: `${BtnVariantsEnum}`;
   tone?: `${BtnTonesEnum}`;
   /** Defaults to `sm`, or to the size set by a containing BtnGroup. */
@@ -48,7 +45,6 @@ const props = withDefaults(defineProps<Props>(), {
   target: undefined,
   type: BtnTypesEnum.BUTTON,
   loading: false,
-  spinner: false,
   variant: BtnVariantsEnum.SOLID,
   tone: BtnTonesEnum.NEUTRAL,
   size: undefined,
@@ -160,10 +156,6 @@ const cssClasses = computed(() => [
   },
 ]);
 
-const spinnerAlignment = computed(() =>
-  typeof props.spinner === "boolean" ? "right" : props.spinner,
-);
-
 const { displayConfirm } = useAppNotifications();
 
 const handleClick = (event: MouseEvent) => {
@@ -208,14 +200,8 @@ const handleClick = (event: MouseEvent) => {
     <span class="btn__content">
       <slot />
     </span>
-    <SmallLoader
-      v-if="loading && spinner"
-      class="btn__loader"
-      :loading="loading"
-      :alignment="spinnerAlignment"
-    />
-    <!-- Announced for every loading button, not just the 11 that opt into a
-         visible spinner. The visible label is never replaced. -->
+    <!-- Announced for every loading button - the caps are visual only. The
+         visible label is never replaced. -->
     <span v-if="loading" class="btn__status" role="status">
       {{ t("baseBtn.labels.loading") }}
     </span>
@@ -648,12 +634,181 @@ const handleClick = (event: MouseEvent) => {
 /* ---------- loading ---------- */
 /* The label is kept. The old component replaced it with "Loading", which
    changed the accessible name mid-interaction. */
-.btn__loader {
-  @apply pointer-events-none;
-}
-
 .btn__status {
   @apply sr-only;
+}
+
+/*
+ * The two caps carry the state, as one run travelling around the outside: it
+ * fills the top cap left to right, carries on along the bottom cap right to
+ * left, and the tail follows the same way round. One direction, so the eye
+ * follows it rather than watching two things meet. Nothing is inserted next to
+ * the label, so the button neither grows nor reflows on the frame it starts
+ * working.
+ *
+ * This is the state the component had no answer for. It used to depend on an
+ * opt-in `spinner`, which was passed at 12 of 51 loading call sites - the other
+ * 39 showed nothing at all and only read as a button that had gone dead. The
+ * caps answer for every one of them, so that prop is gone: the caps are already
+ * this component's signature, the same call the hover and tone rules above make,
+ * and a rhombus dropped into the content row cost a reflow besides.
+ *
+ * A marker travelling along the cap was the first shape of this and it does not
+ * survive the narrow case: an icon-only sm button leaves a 23px cap, where the
+ * segment read as two nubs parked in the corners rather than as motion. A fill
+ * is always one run anchored to an edge, so it still reads at that length.
+ *
+ * Two legs of 0.9s, and neither cap ever waits: the moment the head moves onto
+ * the bottom cap, the top starts clearing behind it, so the lit run is one cap
+ * long and always moving. That also means each cap only ever travels one way -
+ * the top rightwards whether it is filling or clearing, the bottom leftwards -
+ * which is what lets two bars read as one thing going round. The anchor swaps
+ * once per leg, always while the cap is full or empty, where it cannot be seen.
+ */
+.btn.is-loading::before,
+.btn.is-loading::after {
+  /* The empty cap, dimmer than at rest, so a cap the run has left is visibly the
+     same cap rather than one that went missing. */
+  background-color: rgb(122 130 136 / 0.35);
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  /* Linear, not eased: an ease per leg puts a hesitation at each corner, and
+     this is one run going round at one speed. */
+  animation-duration: 1.8s;
+  animation-timing-function: linear;
+  animation-iteration-count: infinite;
+  /* A loading button renders disabled, and the disabled rule halves the caps.
+     The part carrying the state has to stay at full strength - this has to sit
+     below that rule, which it ties with on specificity. */
+  opacity: 1;
+}
+
+/* The leading edge fades rather than ending on a hard line: a solid edge reads
+   as a progress bar reporting a percentage, and there is nothing to report. */
+.btn.is-loading::before {
+  background-image: linear-gradient(
+    to right,
+    var(--btn-cap, var(--color-endcap, #7a8288)) 80%,
+    transparent 100%
+  );
+  background-position: left center;
+  animation-name: btn-fill-rightward;
+}
+
+.btn.is-loading::after {
+  background-image: linear-gradient(
+    to left,
+    var(--btn-cap, var(--color-endcap, #7a8288)) 80%,
+    transparent 100%
+  );
+  background-position: right center;
+  animation-name: btn-fill-leftward;
+}
+
+/* In from the left, then out to the right: the fill grows from the left edge,
+   and once it covers the whole run the anchor moves to the right edge so the
+   second half clears it in the same direction rather than retreating. The top
+   cap and every cap-less surface run on this one. */
+@keyframes btn-fill-rightward {
+  0% {
+    background-position: left center;
+    background-size: 0% 100%;
+  }
+  50% {
+    background-position: left center;
+    background-size: 100% 100%;
+  }
+  50.01% {
+    background-position: right center;
+    background-size: 100% 100%;
+  }
+  100% {
+    background-position: right center;
+    background-size: 0% 100%;
+  }
+}
+
+/* The same run mirrored, and half a cycle into it: the bottom cap clears
+   leftwards while the top fills, and fills from the right while the top clears.
+   That is the hand-over at each corner. */
+@keyframes btn-fill-leftward {
+  0% {
+    background-position: left center;
+    background-size: 100% 100%;
+  }
+  50% {
+    background-position: left center;
+    background-size: 0% 100%;
+  }
+  50.01% {
+    background-position: right center;
+    background-size: 0% 100%;
+  }
+  100% {
+    background-position: right center;
+    background-size: 100% 100%;
+  }
+}
+
+/* Neutral has no colour of its own to fill with - its resting cap is the same
+   grey as the empty state - so it borrows the hover accent. Two classes, so
+   danger and warning keep filling in their own tone. */
+.btn--tone-neutral.is-loading {
+  --btn-cap: var(--color-primary, #428bca);
+}
+
+/*
+ * Busy is not unavailable. The disabled rule dims the content to 45%, which for
+ * a working button says the wrong thing - it reads as a control you cannot use
+ * rather than one that is already doing what you asked. The caps say it instead.
+ */
+.btn.is-loading .btn__content {
+  @apply opacity-100;
+  /* Above the wash below. Both are positioned boxes at z-index auto, and the
+     pseudo-element comes after the label in tree order, so without this the
+     wash paints over the text and tints it. */
+  position: relative;
+  z-index: 1;
+}
+
+/*
+ * The contexts that drop their caps - chip scale, bare, and the two container
+ * ones - have nothing to fill, and the edges are not theirs to use: a rail along
+ * a group member's bottom lands directly under the group's own cap and reads as
+ * a dirty edge, clipped by the track's rounding at that. So the surface fills
+ * instead, in the tone colour and on the top cap's own keyframes: head in from
+ * the left, tail out to the right, always that way. There is no circuit to run
+ * on a surface, so it takes the one leg rather than doubling back. The fill is
+ * the language; only the thing being filled changes with the context.
+ */
+.btn.is-loading.btn--xs::after,
+.btn.is-loading.btn--bare::after,
+.btn.is-loading.btn--grouped::after,
+.btn.is-loading.btn--menu-item::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  /* The cap rules above set a 2px height on a solid xs; this box is the whole
+     control, so it takes its height from the inset. */
+  height: auto;
+  border-radius: inherit;
+  background-color: transparent;
+  background-image: linear-gradient(
+    var(--btn-cap, var(--color-primary, #428bca)),
+    var(--btn-cap, var(--color-primary, #428bca))
+  );
+  background-repeat: no-repeat;
+  background-size: 0% 100%;
+  /* The strength of a hover tint, and well under the grouped active tint of
+     0.26, so a working member never reads as louder than a chosen one. At 0.2 a
+     bare button - the quietest variant there is - became a solid block of
+     tone. */
+  opacity: 0.16;
+  z-index: 0;
+  /* The top cap's run, but at half its pace. A surface is the whole control
+     rather than a 2px edge, so the same speed reads as the button flashing;
+     slower, it reads as the same idea kept quiet. */
+  animation: btn-fill-rightward 3.6s linear infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -663,6 +818,26 @@ const handleClick = (event: MouseEvent) => {
   .btn--ghost::before,
   .btn--ghost::after {
     transition-duration: 1ms;
+  }
+
+  /* Nothing fills. Both caps hold steady at the tone colour, and the wash holds
+     at its lit end, so the state is still marked where motion was the only
+     thing carrying it. */
+  .btn.is-loading::before,
+  .btn.is-loading::after {
+    animation-name: none;
+    background-image: none;
+    background-color: var(--btn-cap, var(--color-endcap, #7a8288));
+  }
+
+  .btn.is-loading.btn--xs::after,
+  .btn.is-loading.btn--bare::after,
+  .btn.is-loading.btn--grouped::after,
+  .btn.is-loading.btn--menu-item::after {
+    animation-name: none;
+    /* Filled, not empty: without the animation the base size is 0 and the
+       surface would carry no marker at all. */
+    background-size: 100% 100%;
   }
 }
 

--- a/test/playwright/e2e/Buttons.spec.ts
+++ b/test/playwright/e2e/Buttons.spec.ts
@@ -84,6 +84,94 @@ test.describe("Buttons", () => {
     }
   });
 
+  test("a loading button runs one fill around both caps", async ({ page }) => {
+    // The state used to be carried by an opt-in spinner, so 40 of 51 loading
+    // call sites showed nothing at all and read as a button gone dead.
+    const btn = page
+      .getByTestId("loading-variants")
+      .locator(".btn--solid.is-loading")
+      .first();
+
+    const caps = await btn.evaluate((el) =>
+      ["::before", "::after"].map((pseudo) => {
+        const cs = getComputedStyle(el, pseudo);
+        return {
+          content: cs.content,
+          animationName: cs.animationName,
+          animationDelay: cs.animationDelay,
+          opacity: cs.opacity,
+        };
+      }),
+    );
+
+    for (const cap of caps) {
+      expect(cap.content).not.toBe("none");
+      // A loading button renders disabled, and the disabled rule halves the
+      // caps - the part carrying the state has to stay at full strength.
+      expect(cap.opacity).toBe("1");
+      expect(cap.animationDelay).toBe("0s");
+    }
+
+    // One run around the outside: the top only ever travels rightwards and the
+    // bottom leftwards, filling or clearing, which is what lets two bars read as
+    // one thing going round. Scoped styles suffix the keyframes name, so match
+    // the stem. The anchors are animated, so they are not assertable from a
+    // computed value at an arbitrary moment - the two names carry the direction.
+    expect(caps[0].animationName).toMatch(/^btn-fill-rightward/);
+    expect(caps[1].animationName).toMatch(/^btn-fill-leftward/);
+  });
+
+  test("a loading button keeps its label at full strength", async ({
+    page,
+  }) => {
+    // Busy is not unavailable: the disabled rule dims content to 45%, which on a
+    // working button reads as one that cannot be used.
+    const content = page
+      .getByTestId("loading-variants")
+      .locator(".is-loading .btn__content")
+      .first();
+
+    expect(await style(content, "opacity")).toBe("1");
+  });
+
+  test("a loading group member fills its surface, not a cap", async ({
+    page,
+  }) => {
+    // The group draws one pair of caps for the whole control, and a rail along
+    // the member's bottom edge lands directly under the group's own cap - it
+    // read as a dirty edge, clipped by the track's rounding. The surface fills
+    // instead, in the same motion, touching no edge the group owns.
+    const member = page
+      .getByTestId("loading-containers")
+      .locator(".btn--grouped.is-loading")
+      .first();
+
+    const wash = await member.evaluate((el) => {
+      const after = getComputedStyle(el, "::after");
+      const box = el.getBoundingClientRect();
+      return {
+        cap: getComputedStyle(el, "::before").content,
+        content: after.content,
+        animationName: after.animationName,
+        animationDuration: after.animationDuration,
+        width: parseFloat(after.width),
+        height: parseFloat(after.height),
+        elementWidth: box.width,
+        elementHeight: box.height,
+      };
+    });
+
+    expect(wash.cap).toBe("none");
+    expect(wash.content).not.toBe("none");
+    // The top cap's run, at half its pace: the surface is the whole control, so
+    // the cap's speed on it reads as the button flashing.
+    expect(wash.animationName).toMatch(/^btn-fill-rightward/);
+    expect(wash.animationDuration).toBe("3.6s");
+    // The whole member, not a strip along one edge of it.
+    expect(Math.abs(wash.width - wash.elementWidth)).toBeLessThanOrEqual(1);
+    expect(Math.abs(wash.height - wash.elementHeight)).toBeLessThanOrEqual(1);
+  });
+
   test("a group shares the standalone button surface", async ({ page }) => {
     // A group used an opaque fill while standalone buttons are translucent, so
     // it read as a different material against a bright backdrop.


### PR DESCRIPTION
## What

A loading `Btn` showed nothing at all unless it opted into `spinner`, which 12 of 51 loading call sites did. The other 39 rendered as a disabled button and read as one that had gone dead.

The end-caps carry it now. One fill travels around the outside — left to right along the top cap, on along the bottom cap right to left — and each cap clears in the direction it filled, so the lit run is one cap long and neither cap ever waits. Nothing is inserted beside the label, so the button no longer reflows on the frame it starts working, and the run wears the tone: a destructive button works in red.

## Contexts without caps

Chip scale, `bare`, and members of a group or a dropdown drop their caps, and their edges belong to the container — a rail along a member's bottom edge lands directly under the group's own cap and reads as a dirty edge, clipped by the track's rounding. Those fill their surface instead, on the same keyframes at half the pace: a surface is the whole control rather than a 2px edge, and at the cap's speed it reads as the button flashing.

## Also in here

- `spinner`, its `SmallLoader`, and the prop at all 12 call sites are gone. The state no longer needs opting into.
- Two fixes that fall out of the state being visible: the caps keep full opacity where the disabled rule halved them, and the label keeps full strength — busy is not unavailable.
- `prefers-reduced-motion` holds the caps lit and the surface filled rather than animating.

## Verification

- `CI=1 playwright test e2e/Buttons.spec.ts` — 16 passed, including three new assertions: the two caps run opposite-direction keyframes at full opacity, the label is not dimmed, and a group member fills its whole surface rather than a strip along one edge.
- `Btn/index.spec.ts` — 13 passed. `vue-tsc` clean.
- Phases measured against the running build via `currentTime` on the animations, not eyeballed: at 25 % the top cap is full and the bottom empty; at 62.5 % the top is lit only on its right half while the bottom is full.

The motion is on `/visual-tests/buttons/` under "Loading — the caps carry it", live rather than as a still. 🤖