### PR TITLE
fix(nav): show notifications on mobile only without a fleet

### DIFF
--- a/app/frontend/frontend/components/Navigation/Mobile/index.vue
+++ b/app/frontend/frontend/components/Navigation/Mobile/index.vue
@@ -76,7 +76,7 @@ const { data: publicFleetData } = usePublicFleetQuery(fleetSlug, {
 
 const currentFleet = computed(() => fleetData.value || publicFleetData.value);
 
-const { data: myFleets } = useMyFleetsQuery({
+const { data: myFleets, isPending: myFleetsPending } = useMyFleetsQuery({
   query: {
     refetchOnWindowFocus: false,
     enabled: isAuthenticated,
@@ -163,7 +163,10 @@ const primaryFleet = computed(() => myFleets.value?.[0]);
         :image="primaryFleet.logo?.smallUrl"
         icon="fa-duotone fa-users"
       />
-      <NotificationsNav v-if="isAuthenticated" icon-only />
+      <NotificationsNav
+        v-else-if="isAuthenticated && !myFleetsPending"
+        icon-only
+      />
     </template>
   </AppNavigationMobile>
 </template>


### PR DESCRIPTION
The notifications bell had a permanent slot in the mobile navigation, sitting next to the primary fleet item.

It is now the fallback for that slot instead:

- has a fleet → fleet logo, no bell
- authenticated, no fleet → bell fills the slot
- not authenticated → neither

Also gated on the `useMyFleets` query's `isPending`, so the bell does not flash and then get swapped for the fleet logo once the fleet list resolves.

Desktop navigation and the `iconOnly` prop on `NotificationsNav` are untouched.

🤖