### PR TITLE
feat(admin): decide a selection of unlisted models at once

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/sc_data_unlisted_model_bulk_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/sc_data_unlisted_model_bulk_input.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class ScDataUnlistedModelBulkInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              # The entries the decision applies to. Everything else about the
+              # decision is in the path, so the three bulk actions share this.
+              ids: {type: :array, items: {type: :string, format: :uuid}}
+            },
+            additionalProperties: false,
+            required: %w[ids]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
+++ b/app/controllers/admin/api/v1/sc_data_unlisted_models_controller.rb
@@ -9,6 +9,7 @@ module Admin
       # create, update or destroy here -- only listing them and deciding.
       class ScDataUnlistedModelsController < ::Admin::Api::BaseController
         before_action :set_entry, only: %i[ignore create_model mark_as_paint link reset]
+        before_action :set_entries, only: %i[ignore_bulk mark_as_paint_bulk reset_bulk]
 
         def index
           authorize! with: ::Admin::ScDataUnlistedModelPolicy
@@ -78,6 +79,41 @@ module Admin
         # already point at it.
         def reset
           @sc_data_unlisted_model.reset!
+        end
+
+        # A patch's entries are mostly one decision repeated -- the marker filter
+        # misses a handful of NPC copies every build -- so the three decisions
+        # that need nothing but the entry itself can be made for a selection at
+        # once. `link` and `create_model` stay per row: each needs a target the
+        # admin picks, and each can fail on its own.
+        def ignore_bulk
+          decide_selection("ignored")
+        end
+
+        def mark_as_paint_bulk
+          decide_selection("paint")
+        end
+
+        def reset_bulk
+          ScDataUnlistedModel.transaction do
+            @sc_data_unlisted_models.find_each(&:reset!)
+          end
+
+          head :no_content
+        end
+
+        private def decide_selection(decision)
+          ScDataUnlistedModel.transaction do
+            @sc_data_unlisted_models.find_each { |entry| entry.decide!(decision) }
+          end
+
+          head :no_content
+        end
+
+        private def set_entries
+          authorize! with: ::Admin::ScDataUnlistedModelPolicy
+
+          @sc_data_unlisted_models = ScDataUnlistedModel.where(id: params[:ids])
         end
 
         private def set_entry

--- a/app/frontend/admin/pages/models/unlisted.vue
+++ b/app/frontend/admin/pages/models/unlisted.vue
@@ -15,11 +15,14 @@ import { usePagination } from "@/shared/composables/usePagination";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
   useScDataUnlistedModels,
+  useScDataUnlistedModelBulkIgnore,
+  useScDataUnlistedModelBulkMarkAsPaint,
   getScDataUnlistedModelsQueryKey,
   type ScDataUnlistedModel,
   type ScDataUnlistedModelSortEnum,
 } from "@/services/fyAdminApi";
 import UnlistedModelActions from "@/admin/components/UnlistedModels/Actions/index.vue";
+import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 
 const route = useRoute();
 
@@ -55,6 +58,36 @@ watch(
     await refetch();
   },
 );
+
+const selected = ref<string[]>([]);
+
+const onSelectedChange = (ids: string[]) => {
+  selected.value = ids;
+};
+
+const deciding = ref(false);
+
+const ignoreMutation = useScDataUnlistedModelBulkIgnore();
+const markAsPaintMutation = useScDataUnlistedModelBulkMarkAsPaint();
+
+// A patch's list is mostly one decision repeated, so the two decisions that
+// need nothing but the entry are offered for the whole selection. Creating a
+// ship and linking one stay per row: each needs a target a person picks.
+const decideSelected = async (
+  mutation: typeof ignoreMutation | typeof markAsPaintMutation,
+) => {
+  deciding.value = true;
+
+  await mutation
+    .mutateAsync({ data: { ids: selected.value } })
+    .then(async () => {
+      selected.value = [];
+      await refetch();
+    })
+    .finally(() => {
+      deciding.value = false;
+    });
+};
 
 // What the export lets us work out. Not a verdict on whether the ship belongs
 // in the catalogue -- the game files never say whether a player can own one.
@@ -136,7 +169,29 @@ const { t } = useI18n();
         :loading="loading || refetching"
         :empty-visible="emptyVisible"
         default-sort="identifier asc"
+        selectable
+        :selected="selected"
+        @selected-change="onSelectedChange"
       >
+        <template #selected-actions>
+          <BtnGroup>
+            <Btn
+              v-tooltip="t('actions.unlistedModel.markAsPaintSelected')"
+              :disabled="deciding"
+              @click="decideSelected(markAsPaintMutation)"
+            >
+              <i class="fa-duotone fa-palette" />
+            </Btn>
+            <Btn
+              v-tooltip="t('actions.unlistedModel.ignoreSelected')"
+              :tone="BtnTonesEnum.DANGER"
+              :disabled="deciding"
+              @click="decideSelected(ignoreMutation)"
+            >
+              <i class="fa-duotone fa-eye-slash" />
+            </Btn>
+          </BtnGroup>
+        </template>
         <template #col-identifier="{ record }">
           <code>{{ record.identifier }}</code>
         </template>

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -381,7 +381,9 @@
         "ignore": "Ignorieren",
         "noManufacturer": "Zu diesem Identifier lässt sich kein Hersteller auflösen",
         "alreadyExists": "%{name} ist bereits im Katalog",
-        "link": "Schon im Katalog"
+        "link": "Schon im Katalog",
+        "markAsPaintSelected": "Auswahl als Lackierungen markieren",
+        "ignoreSelected": "Auswahl ignorieren"
       },
       "revert": "Zurücksetzen"
     }

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -381,7 +381,9 @@
         "ignore": "Ignore",
         "noManufacturer": "No manufacturer resolves from this identifier",
         "alreadyExists": "%{name} is already in the catalogue",
-        "link": "Already in the catalogue"
+        "link": "Already in the catalogue",
+        "markAsPaintSelected": "Mark selected as paints",
+        "ignoreSelected": "Ignore selected"
       },
       "revert": "Revert"
     }

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -381,7 +381,9 @@
         "ignore": "Ignorar",
         "noManufacturer": "Este identificador no resuelve ningún fabricante",
         "alreadyExists": "%{name} ya está en el catálogo",
-        "link": "Ya está en el catálogo"
+        "link": "Ya está en el catálogo",
+        "markAsPaintSelected": "Marcar la selección como pinturas",
+        "ignoreSelected": "Ignorar la selección"
       },
       "revert": "Revertir"
     }

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -381,7 +381,9 @@
         "ignore": "Ignorer",
         "noManufacturer": "Aucun constructeur ne correspond à cet identifiant",
         "alreadyExists": "%{name} est déjà dans le catalogue",
-        "link": "Déjà dans le catalogue"
+        "link": "Déjà dans le catalogue",
+        "markAsPaintSelected": "Marquer la sélection comme peintures",
+        "ignoreSelected": "Ignorer la sélection"
       },
       "revert": "Rétablir"
     }

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -381,7 +381,9 @@
         "ignore": "Ignora",
         "noManufacturer": "Nessun produttore corrisponde a questo identificatore",
         "alreadyExists": "%{name} è già nel catalogo",
-        "link": "Già nel catalogo"
+        "link": "Già nel catalogo",
+        "markAsPaintSelected": "Segna la selezione come livree",
+        "ignoreSelected": "Ignora la selezione"
       },
       "revert": "Ripristina"
     }

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -381,7 +381,9 @@
         "ignore": "忽略",
         "noManufacturer": "此标识符无法解析出制造商",
         "alreadyExists": "%{name} 已在目录中",
-        "link": "已在目录中"
+        "link": "已在目录中",
+        "markAsPaintSelected": "将所选标记为涂装",
+        "ignoreSelected": "忽略所选"
       },
       "revert": "还原"
     }

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -381,7 +381,9 @@
         "ignore": "忽略",
         "noManufacturer": "此識別碼無法解析出製造商",
         "alreadyExists": "%{name} 已在目錄中",
-        "link": "已在目錄中"
+        "link": "已在目錄中",
+        "markAsPaintSelected": "將所選標記為塗裝",
+        "ignoreSelected": "忽略所選"
       },
       "revert": "還原"
     }

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -105,6 +105,11 @@ v1_admin_api_routes = lambda do
   # Ships the game files describe that we have no model for. Only listed and
   # decided on -- the rows are written by the sc_data load, never by hand.
   resources :sc_data_unlisted_models, path: "unlisted-models", only: %i[index] do
+    collection do
+      post "bulk-ignore", to: "sc_data_unlisted_models#ignore_bulk"
+      post "bulk-mark-as-paint", to: "sc_data_unlisted_models#mark_as_paint_bulk"
+      post "bulk-reset", to: "sc_data_unlisted_models#reset_bulk"
+    end
     member do
       post :ignore
       post "create-model", to: "sc_data_unlisted_models#create_model"

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -6870,6 +6870,93 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/unlisted-models/bulk-ignore":
+    post:
+      summary: Ignore a selection
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModelBulkIgnore
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ScDataUnlistedModelBulkInput"
+      responses:
+        '204':
+          description: successful
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/unlisted-models/bulk-mark-as-paint":
+    post:
+      summary: Mark a selection as paints
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModelBulkMarkAsPaint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ScDataUnlistedModelBulkInput"
+      responses:
+        '204':
+          description: successful
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/unlisted-models/bulk-reset":
+    post:
+      summary: Return a selection to the list
+      tags:
+      - ScDataUnlistedModels
+      operationId: scDataUnlistedModelBulkReset
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ScDataUnlistedModelBulkInput"
+      responses:
+        '204':
+          description: successful
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/unlisted-models/{id}/create-model":
     parameters:
     - name: id
@@ -15330,6 +15417,18 @@ components:
       - createdAt
       - updatedAt
       title: ScDataUnlistedModel
+    ScDataUnlistedModelBulkInput:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+      additionalProperties: false
+      required:
+      - ids
+      title: ScDataUnlistedModelBulkInput
     ScDataUnlistedModelLinkInput:
       type: object
       properties:

--- a/test/integration/admin/api/v1/sc_data_unlisted_models_test.rb
+++ b/test/integration/admin/api/v1/sc_data_unlisted_models_test.rb
@@ -71,6 +71,33 @@ class Admin::Api::V1::ScDataUnlistedModelsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  {
+    "bulk-ignore" => "Ignore a selection",
+    "bulk-mark-as-paint" => "Mark a selection as paints",
+    "bulk-reset" => "Return a selection to the list"
+  }.each do |action, summary|
+    api_path "/unlisted-models/#{action}" do
+      post(summary) do
+        operationId "scDataUnlistedModel#{action.tr("-", "_").camelize}"
+        tags "ScDataUnlistedModels"
+        consumes "application/json"
+        produces "application/json"
+
+        request_body required: true, schema: ::Admin::V1::Schemas::Inputs::ScDataUnlistedModelBulkInput
+
+        response(204, "successful")
+
+        response(403, "forbidden") do
+          schema ::Shared::V1::Schemas::StandardError
+        end
+
+        response(401, "unauthorized") do
+          schema ::Shared::V1::Schemas::StandardError
+        end
+      end
+    end
+  end
+
   %w[ignore mark-as-paint create-model reset].each do |action|
     api_path "/unlisted-models/{id}/#{action}" do
       parameter name: "id", in: :path, description: "Unlisted model id",
@@ -339,5 +366,72 @@ class Admin::Api::V1::ScDataUnlistedModelsTest < ActionDispatch::IntegrationTest
     assert_api_response :post, 404,
       path_params: {id: @entry.id}, api_path: "/unlisted-models/{id}/link",
       body: {modelId: SecureRandom.uuid}
+  end
+
+  # A patch's list is mostly one decision repeated, so the working list is
+  # cleared a selection at a time rather than a row at a time.
+  test "POST bulk-ignore decides every entry in the selection" do
+    others = create_list(:sc_data_unlisted_model, 2)
+    untouched = create(:sc_data_unlisted_model)
+
+    sign_in @user
+
+    assert_api_response :post, 204,
+      api_path: "/unlisted-models/bulk-ignore",
+      body: {ids: [@entry.id, *others.map(&:id)]}
+
+    assert_equal ["ignored"], [@entry, *others].map { |entry| entry.reload.decision }.uniq
+    assert_nil untouched.reload.decision
+  end
+
+  test "POST bulk-mark-as-paint decides every entry in the selection" do
+    other = create(:sc_data_unlisted_model)
+
+    sign_in @user
+
+    assert_api_response :post, 204,
+      api_path: "/unlisted-models/bulk-mark-as-paint",
+      body: {ids: [@entry.id, other.id]}
+
+    assert_equal ["paint"], [@entry, other].map { |entry| entry.reload.decision }.uniq
+  end
+
+  test "POST bulk-reset returns the selection to the list" do
+    decided = create_list(:sc_data_unlisted_model, 2, :decided)
+
+    sign_in @user
+
+    assert_api_response :post, 204,
+      api_path: "/unlisted-models/bulk-reset",
+      body: {ids: decided.map(&:id)}
+
+    assert_equal [nil], decided.map { |entry| entry.reload.decision }.uniq
+  end
+
+  # An id nobody has is skipped rather than failing the decision for the rest --
+  # the selection is a list the client held, and a row may have been decided
+  # elsewhere since.
+  test "POST bulk-ignore ignores ids that are not there" do
+    sign_in @user
+
+    assert_api_response :post, 204,
+      api_path: "/unlisted-models/bulk-ignore",
+      body: {ids: [@entry.id, SecureRandom.uuid]}
+
+    assert_equal "ignored", @entry.reload.decision
+  end
+
+  test "POST bulk-ignore needs the models privilege" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :post, 403, api_path: "/unlisted-models/bulk-ignore", body: {ids: [@entry.id]}
+
+    assert_nil @entry.reload.decision
+  end
+
+  test "POST bulk-ignore is not public" do
+    assert_api_response :post, 401, api_path: "/unlisted-models/bulk-ignore", body: {ids: [@entry.id]}
+
+    assert_nil @entry.reload.decision
   end
 end


### PR DESCRIPTION
Item 4 of the SC Data live-and-PTU plan: triage a patch's unlisted ships in one pass rather than row by row.

A patch's list is mostly one decision repeated — the marker filter misses a handful of NPC copies every build — so the decisions that need nothing but the entry itself are offered for a selection.

**Endpoints** (`{ids}` in, 204 out):

- `POST /unlisted-models/bulk-ignore`
- `POST /unlisted-models/bulk-mark-as-paint`
- `POST /unlisted-models/bulk-reset`

`link` and `create-model` stay per row: each needs a target a person picks, and each can fail on its own. An id that is not there is skipped rather than failing the decision for the rest — the selection is a list the client held, and a row may have been decided elsewhere since.

**UI**: selection checkboxes on the unlisted ships list, with mark-as-paint and ignore in the bulk bar. `BaseTable` already had `selectable` and a `selected-actions` slot, so this follows the module list rather than inventing a pattern.

**Verification**: 6 new integration tests; the file's 26 pass. `standardrb`, `pnpm lint:ts` and `bin/vite build` clean.

🤖