### PR TITLE
feat(discord): let a command carry subcommands

### DIFF
--- a/app/controllers/discord/interactions_controller.rb
+++ b/app/controllers/discord/interactions_controller.rb
@@ -64,7 +64,7 @@ module Discord
     end
 
     private def ephemeral_command?
-      Discord::Commands::Registry.ephemeral?(payload.dig("data", "name"))
+      Discord::Commands::Registry.ephemeral?(command_data["name"], invoked_subcommand&.dig("name"))
     end
 
     private def refuse_command
@@ -81,13 +81,14 @@ module Discord
     # symbols under strict args, and the job reads this back with
     # with_indifferent_access anyway.
     private def command_context
-      data = payload["data"] || {}
+      subcommand = invoked_subcommand
 
       {
         "application_id" => payload["application_id"],
         "token" => payload["token"],
-        "command" => data["name"],
-        "options" => command_options(data["options"]),
+        "command" => command_data["name"],
+        "subcommand" => subcommand&.dig("name"),
+        "options" => command_options((subcommand || command_data)["options"]),
         "guild_id" => payload["guild_id"],
         "discord_user_id" => invoking_user_id,
         # Discord tells us the invoking member's own client locale; the guild
@@ -99,6 +100,19 @@ module Discord
 
     private def command_options(options)
       Array(options).to_h { |option| [option["name"], option["value"]] }
+    end
+
+    private def command_data
+      payload["data"] || {}
+    end
+
+    # Discord nests a subcommand as an option of type 1 that carries no `value`
+    # of its own -- the arguments the caller typed are in *its* `options`. A flat
+    # read of the top level therefore loses every one of them and dispatches to
+    # the parent command.
+    private def invoked_subcommand
+      Array(command_data["options"])
+        .find { |option| option["type"] == Discord::Commands::Registry::SUB_COMMAND }
     end
 
     # In a guild the invoking user is under `member`; in a DM it is `user`.

--- a/app/jobs/discord/command_job.rb
+++ b/app/jobs/discord/command_job.rb
@@ -31,8 +31,8 @@ module Discord
     end
 
     private def payload_for(context)
-      handler = Commands::Registry.handler_for(context[:command])
-      return unknown_command(context[:command]) if handler.nil?
+      handler = Commands::Registry.handler_for(context[:command], context[:subcommand])
+      return unknown_command(command_name(context)) if handler.nil?
 
       handler.new(
         options: context[:options] || {},
@@ -44,10 +44,14 @@ module Discord
       # already showing "thinking...", and an unanswered one stays there.
       # Deterministic failures are not worth a retry, so this does not re-raise
       # -- transport failures in edit_original still do.
-      Rails.logger.error("[Discord::CommandJob] command=#{context[:command]} failed: #{e.class}: #{e.message}")
+      Rails.logger.error("[Discord::CommandJob] command=#{command_name(context)} failed: #{e.class}: #{e.message}")
       Appsignal.report_error(e)
 
       failure
+    end
+
+    private def command_name(context)
+      [context[:command], context[:subcommand]].compact_blank.join(" ")
     end
 
     private def expired?(context)

--- a/docs/exec-plans/discord-fleet-commands.md
+++ b/docs/exec-plans/discord-fleet-commands.md
@@ -1,0 +1,128 @@
+# Discord Fleet & Member Commands
+
+Continues `discord-bot.md`, whose six phases have all shipped: the interactions endpoint, five read-only commands, RSVP polling, event reminders, wishlist DMs and fleet↔Discord role sync.
+
+What exists is entirely a **catalogue** bot. Four of the five commands look ships up; `/fleet` shows counts. Nothing a fleet officer does day to day is reachable from Discord, and nothing the bot answers is ever private to the person who asked — `EPHEMERAL_BY_DEFAULT = false` and no definition overrides it.
+
+This plan adds fleet management and private answers, in five phases that each ship on their own.
+
+## Foundation
+
+Three mechanics the current plumbing either cannot express or has never exercised. All of Phase 1–5 rests on them, so they are decided here once.
+
+### Subcommands do not work today
+
+`/fleet invite` is not a new command, it is a subcommand of an existing one, and three places assume a flat namespace:
+
+- `InteractionsController#command_options` flattens exactly one level (`Array(options).to_h { |o| [o["name"], o["value"]] }`). Discord sends a subcommand as an option of type 1 carrying **no `value`** and a nested `options` array, so `/fleet invite limit:5` arrives as `{"invite" => nil}` and the limit is gone.
+- `Registry.handler_for` and `Registry.ephemeral?` key on the top-level name only, so the invite would dispatch to `Discord::Commands::Fleet`.
+- `Registry.payload` strips `:handler` and `:ephemeral` at the top level only. A nested definition carrying those keys is rejected by Discord's `PUT /applications/{id}/commands` as unknown fields — and because that endpoint is a full replacement, a rejected payload leaves the *previous* command list live, which reads as "the sync did nothing".
+
+The alternative is flat commands (`/fleet-invite`, `/fleet-events`). It needs no plumbing change, and it is the wrong choice: it puts one fleet's internals in the global command picker of every server the bot is in, and Discord's own convention for a noun with verbs is subcommands.
+
+So: the registry gains nested definitions, `handler_for(name, subcommand)` and `ephemeral?(name, subcommand)`; the controller extracts the subcommand and recurses into its options; `payload` strips our keys at every depth. New option types alongside `STRING = 3`: `SUB_COMMAND = 1`, `INTEGER = 4`, `BOOLEAN = 5`, `USER = 6`.
+
+Visibility is the reason this cannot be skipped: the fleet overview must stay public and `/fleet invite` must not be, and `ephemeral?` has to be able to tell them apart *before* the job runs.
+
+**The price, which is not optional: `/fleet` stops being callable.** Discord will not invoke a command that has subcommands — its options are either parameters or subcommands, never both — so the shipped fleet overview moves to `/fleet info`. There is no arrangement in which `/fleet` keeps answering *and* `/fleet invite` exists under the same name. Nothing resolves a bare `/fleet` to the parent either: the endpoint is public, so a hand-rolled bare call must refuse rather than dispatch to the overview.
+
+### Ephemeral is already supported, and has never been used
+
+`InteractionsController#acknowledge_command` consults `Registry.ephemeral?` and sets flag 64 on the deferred acknowledgement, and `Registry.ephemeral?` already reads a per-definition `ephemeral:` key. A definition that carries `ephemeral: true` therefore works today; nothing sets it.
+
+The consequence to design around, not to fight: **a command is wholly public or wholly private.** Discord fixes visibility at the acknowledgement and ignores flags on the follow-up, so `/fleet invite` cannot post a public "invite created" plus a private link, and `/fleet members` cannot answer a hit in the channel and a refusal privately.
+
+### Authorization: Discord roles are never authority
+
+Every command below resolves the caller the way `Discord::Commands::Fleet#member?` already does — `OmniauthConnection.find_by(provider: "discord", uid: discord_user_id)` — and then asks the fleet's own privilege system, `FleetMembership#has_access?` / `#capabilities`.
+
+A guild administrator with no Fleetyards membership gets nothing. Manage Roles in Discord does not create a `fleet:invites:create`. This is the same rule `/fleet` already applies to *reading* a fleet (sharing a server is not membership); writes only make it matter more.
+
+That produces three distinct refusals, each needing its own copy, all ephemeral:
+
+| Situation | Answer |
+| --- | --- |
+| No linked Discord account | "link your account", with the settings link |
+| Linked, not a member of this guild's fleet | the fleet's name is *not* revealed beyond what `/fleet` already does |
+| Member without the privilege | names the missing capability in plain words, not the privilege string |
+
+Writes ride a **new flag**, `discord_fleet_commands`, declared in `config/feature_flags.yml`. `discord_commands` gates dispatch as a whole and is on in production; the first path that mutates a fleet from Discord wants a switch of its own. Registry definitions stay published either way — a flagged-off command answers the existing "disabled" message rather than vanishing from the picker, which is the difference between "not yet" and "broken".
+
+## Phase 1 — `/fleet invite`
+
+The smallest useful write, and the one org admins ask for.
+
+| Option | Type | Note |
+| --- | --- | --- |
+| `limit` | INTEGER, optional | uses on the link; `FleetInviteUrl` validates `>= 0`, nil means unlimited |
+| `expires_in` | STRING choices, optional | `1h` / `24h` / `7d` / `never`, mapped to `expires_after` |
+
+Creates a `FleetInviteUrl` owned by the **resolved caller** (`user_id`), authorized against the `create_invites` capability, and answers with `invite_url.url`.
+
+- **Ephemeral, non-negotiably.** The token *is* the credential; a public answer hands the fleet to the channel, guests included.
+- **The URL comes from the model.** `FleetInviteUrl#url` picks `short_fleet_invite_url` when `short_domain` is configured and `frontend_fleet_invite_url` otherwise. A command that builds its own path via `Base#url_for_path` produces a link that works but is not the one the website hands out.
+- **The copy must not overstate what the link does.** `FleetInviteUrlsController#use` creates the membership and then calls `request!` — the invitee lands in `requested` and still needs accepting. So the answer says the link *asks to join*, and mentions where those requests appear. Phase 4 is what closes that loop from Discord.
+- `FleetInviteUrl` has no `paper_trail`, so nothing records that a link was minted from Discord beyond the row's `user_id`. Worth noting as a gap; not worth adding a versioned model here.
+
+**Deliberately not in this phase:** `/fleet invite @user`, which would create a `FleetMembership` and fire `invite!` for a mentioned Discord user. It needs a second capability (`create_members`), and a mentioned user who never linked an account cannot be invited at all — so the command would sometimes silently degrade to producing a link, which is two outcomes wearing one name. Its own step, after the roster commands make membership state visible.
+
+## Phase 2 — `/fleet events`
+
+Reads the guild's fleet through the existing `FleetNotificationSetting.discord_guild_id` binding and lists up to five upcoming events: title, start, availability, link.
+
+- **Ephemeral, which is not obvious.** `fleet:events:read` is a *member* default privilege, so events are internal data — and the guild may have guests, the same reason `/fleet` refuses non-members. A channel post would leak the schedule to exactly the people the privilege excludes.
+- Scope: `fleet_events.active_status.upcoming`, excluding `draft` — a draft is a work in progress, and listing it in Discord publishes it in every sense that matters.
+- **Availability must not be defined a second time.** `Discord::EventReminder` already computes "6 of 14 slots open", falls back to a signup count when an event has no slots (because "0 of 0 slots open" reads as full), excludes withdrawn signups, and narrows to an occurrence date. Those private methods (`availability`, `taken_slots`, `signups_scope`) move to a shared object both use. A bot that disagrees with its own reminder about how many slots are open is a bug nobody can reproduce.
+- Recurring series: occurrences live on `fleet_event_occurrence_states` and carry their own overridden titles and dates. The list is of *occurrences*, not of series rows, or a weekly op appears once and at the wrong date.
+
+## Phase 3 — `/fleet members`
+
+| Option | Type | Note |
+| --- | --- | --- |
+| `filter` | STRING choices, optional | `all` (default) / `pending` |
+
+Gated on `read_members`, always ephemeral: a roster is usernames and RSI handles, which is personal data whatever the fleet's public flag says.
+
+- `all` lists accepted members; `pending` lists `requested` — the queue Phase 4 acts on.
+- Both scopes go through `kept` (memberships are `Discard::Model`) and match the state literal the existing `/fleet` count already uses (`aasm_state: "accepted"`).
+- Capped at ten with a "+N more" line and a link to the fleet's member page, the shape `/hangar` already uses; ordering follows `FleetMembership::DEFAULT_SORTING_PARAMS`.
+
+## Phase 4 — acting on a join request from Discord
+
+Two steps, deliberately separate reviews.
+
+**Step 1 — `/fleet accept <username>` / `/fleet decline <username>`.** Same plumbing as everything above: a subcommand, a capability check (`update_members`), and the existing `accept_request` / `decline` AASM events. Ephemeral. `whiny_transitions: false` means a second caller gets `false` rather than an exception, so a repeated accept answers "already accepted" instead of an error.
+
+**Step 2 — buttons on the request notification.** This is the first interaction that is not a command, and the controller cannot receive it yet:
+
+- `MESSAGE_COMPONENT` is interaction type **3**. `InteractionsController#create` handles 1 and 2 and drops everything else to `head :no_content`, which Discord renders as "This interaction failed".
+- Components acknowledge with `DEFERRED_UPDATE_MESSAGE` (**6**) when the original message is being edited. Type 5 posts a *new* message and leaves the button spinning.
+- `custom_id` (max 100 chars, e.g. `fleet_membership:accept:<uuid>`) comes back from the client and is therefore **a parameter, not authority**. The caller is re-resolved and the capability re-checked on every click. "Only an officer can see this button" is not a security property — the id can be replayed by anyone who can craft an interaction, including for a membership in a different fleet.
+- **Where the message comes from matters.** The per-fleet path built in the previous plan posts through the encrypted `discord_webhook_url`; interactive components require a message sent by the application itself, so the button post needs `discord_channel_id` and a bot token — i.e. it only works for fleets that installed the bot, not for the webhook-only fleets Phase 4 of the old plan deliberately supported. Confirm against Discord's current component rules before building, and fall back to Step 1 for webhook-only fleets.
+
+`notify_fleet_admins` already fires on `request!`, so this hangs off an existing hook rather than a new one.
+
+## Phase 5 — private answers about yourself: `/myhangar`, `/wishlist`
+
+Both are flat commands, both `ephemeral: true`, and both need **only** the account link: no guild binding, no fleet, no privilege. `InteractionsController#invoking_user_id` already falls back to `payload["user"]["id"]`, which is the DM shape, so these work in a DM with the bot as well as in a channel. If that is not wanted, the definitions need an explicit `contexts` — global commands are DM-enabled by default.
+
+- **`/myhangar` is not `/hangar` with the username filled in.** `Discord::Commands::Hangar` exists to show a *stranger's* hangar: it requires `public_hangar?` and scopes `vehicles.purchased.public`. For the owner both layers fall away, and the command should show what the owner sees on their own hangar page — ships in private hangar groups included. Reusing the existing scope would silently omit exactly the ships the asker is most likely to be checking on.
+- **`/wishlist` is `user.vehicles.wanted`**, grouped and capped the same way. `users.public_wishlist` and `User#public_wishlist_url` already exist, so a `/wishlist <username>` variant is a later, cheap addition — and it must copy `/hangar`'s rule that a private wishlist and an unknown username get the *same* answer, or the command becomes a probe for which accounts exist.
+- The "no linked account" refusal is the most frequently hit answer in this entire plan and the only one that is also a conversion path. It gets real copy and the settings deep link, in all seven locales.
+- It pairs with the wishlist sale DMs already shipped: `/wishlist` is where a member checks what those alerts cover.
+
+## Order and why
+
+1. **Phase 5** — two read-only commands and one new key in the registry. It proves the ephemeral acknowledgement in production with nothing at stake, and it is the only phase that needs no subcommand plumbing.
+2. **Phase 1** — the subcommand foundation plus the first write, behind its own flag.
+3. **Phase 3** — cheap once subcommands exist, and it makes membership state visible before anything acts on it.
+4. **Phase 2** — no new mechanics; its only real work is extracting the shared availability logic.
+5. **Phase 4** — Step 1 with the rest, Step 2 last: it is the only piece that adds a new interaction type and the only one whose delivery constraint (`discord_channel_id`, not the webhook) can cut fleets out.
+
+## Testing
+
+- **Registry**: every definition survives `payload` with no `:handler` or `:ephemeral` at any depth, including nested subcommands; a table-driven assertion that each command intended to be private answers `Registry.ephemeral?` truthfully — visibility is decided at the acknowledgement, so no unit test over a command's payload can catch that regression.
+- **Controller**: a subcommand dispatches to the right handler with its nested options intact; interaction type 3 does not fall through to `no_content`; a `custom_id` naming a membership in another fleet is refused.
+- **Commands**: unit tests over the returned payload, no HTTP, as the existing five already are — plus one refusal test per authorization step (unlinked, non-member, under-privileged), since those three are the answers most callers will actually see.
+- **Locales**: the keys land in all seven `config/locales/*/discord.yml` in the same commit. Nothing in CI checks locale parity and `enableFallback` hides a missing key behind English, so a gap ships silently.
+- No OpenAPI surface: like the endpoint itself, none of this is public API and none of it enters the generated schema.

--- a/lib/discord/commands/registry.rb
+++ b/lib/discord/commands/registry.rb
@@ -9,7 +9,11 @@ module Discord
     # gets a timeout.
     module Registry
       # Discord application command option types.
+      SUB_COMMAND = 1
       STRING = 3
+      INTEGER = 4
+      BOOLEAN = 5
+      USER = 6
 
       # Whether a command's answer is private to the caller.
       #
@@ -19,11 +23,21 @@ module Discord
       # ignored, so a command cannot make itself public afterwards, and one
       # command cannot post a public hit and a private miss.
       #
-      # All five are lookups over data the site publishes, so they answer in
-      # the channel: asking in company is the point. The cost is that their
-      # refusals are public too.
+      # The catalogue lookups answer in the channel: asking in company is the
+      # point, and the cost is that their refusals are public too. Anything that
+      # reads or changes one fleet's own data sets `ephemeral: true`.
       EPHEMERAL_BY_DEFAULT = false
 
+      # A subcommand is an option of type SUB_COMMAND that carries a `handler`
+      # of its own. It lives in the same list Discord is sent rather than in a
+      # parallel one, so there is no second place a subcommand can be declared
+      # and forgotten.
+      #
+      # **A command with subcommands cannot be invoked bare.** Discord rejects a
+      # call to the parent, which is why the fleet overview moved from `/fleet`
+      # to `/fleet info` when the first subcommand arrived. Subcommand *groups*
+      # (type 2, a level deeper) are not supported: nothing needs them, and the
+      # controller reads exactly one level.
       DEFINITIONS = [
         {
           name: "ship",
@@ -85,9 +99,16 @@ module Discord
         },
         {
           name: "fleet",
-          description: "Show this server's fleet on Fleetyards",
-          handler: "Discord::Commands::Fleet",
-          options: []
+          description: "This server's fleet on Fleetyards",
+          options: [
+            {
+              name: "info",
+              description: "Show this server's fleet on Fleetyards",
+              type: SUB_COMMAND,
+              handler: "Discord::Commands::Fleet",
+              options: []
+            }
+          ]
         }
       ].freeze
 
@@ -95,28 +116,52 @@ module Discord
         DEFINITIONS.find { |definition| definition[:name] == name.to_s }
       end
 
+      def self.subcommands(definition)
+        Array(definition&.dig(:options)).select { |option| option[:type] == SUB_COMMAND }
+      end
+
+      # The definition a call resolves to. Nothing resolves to a parent that has
+      # subcommands: Discord cannot invoke it, so treating a bare call as one is
+      # inventing a command that does not exist.
+      def self.resolve(name, subcommand = nil)
+        definition = definition(name)
+        return nil if definition.blank?
+
+        children = subcommands(definition)
+        return children.find { |child| child[:name] == subcommand.to_s } if children.any?
+
+        subcommand.blank? ? definition : nil
+      end
+
       # Unknown commands answer privately: a "that command no longer exists"
       # belongs to whoever typed it.
-      def self.ephemeral?(name)
-        definition = definition(name)
+      def self.ephemeral?(name, subcommand = nil)
+        definition = resolve(name, subcommand)
         return true if definition.nil?
 
         definition.fetch(:ephemeral, EPHEMERAL_BY_DEFAULT)
       end
 
-      def self.handler_for(name)
-        definition = definition(name)
+      def self.handler_for(name, subcommand = nil)
+        definition = resolve(name, subcommand)
         return nil if definition.blank?
 
-        definition[:handler].constantize
+        definition[:handler]&.constantize
       end
 
-      # What Discord's PUT /applications/:id/commands accepts -- the handler is
-      # ours and would be rejected as an unknown key.
+      # What Discord's PUT /applications/:id/commands accepts. `handler` and
+      # `ephemeral` are ours and are rejected as unknown keys **at any depth** --
+      # and because the endpoint is a full replacement, a rejected payload leaves
+      # the previous command list live, which reads as a sync that did nothing.
       def self.payload
-        DEFINITIONS.map do |definition|
-          definition.except(:handler, :ephemeral).deep_dup
-        end
+        DEFINITIONS.map { |definition| publishable(definition) }
+      end
+
+      private_class_method def self.publishable(definition)
+        cleaned = definition.except(:handler, :ephemeral).deep_dup
+        return cleaned if cleaned[:options].blank?
+
+        cleaned.merge(options: cleaned[:options].map { |option| publishable(option) })
       end
     end
   end

--- a/test/integration/discord_interactions_test.rb
+++ b/test/integration/discord_interactions_test.rb
@@ -39,6 +39,15 @@ class DiscordInteractionsTest < ActionDispatch::IntegrationTest
     }
   end
 
+  # Discord nests a subcommand as an option of type 1 whose own `options` carry
+  # the arguments; there is no `value` on the subcommand itself.
+  def subcommand_payload(name: "fleet", subcommand: "info", options: [])
+    command_payload(
+      name: name,
+      options: [{"name" => subcommand, "type" => 1, "options" => options}]
+    )
+  end
+
   test "answers a ping with a pong" do
     post_signed({type: 1})
 
@@ -103,16 +112,59 @@ class DiscordInteractionsTest < ActionDispatch::IntegrationTest
 
     test "every registered command is acknowledged the way the registry declares" do
       Discord::Commands::Registry::DEFINITIONS.each do |definition|
-        post_signed(command_payload(name: definition[:name]))
+        children = Discord::Commands::Registry.subcommands(definition)
 
-        flags = response.parsed_body.dig("data", "flags")
+        calls =
+          if children.empty?
+            [[command_payload(name: definition[:name]), nil]]
+          else
+            children.map { |child| [subcommand_payload(name: definition[:name], subcommand: child[:name]), child[:name]] }
+          end
 
-        if Discord::Commands::Registry.ephemeral?(definition[:name])
-          assert_equal 64, flags, "/#{definition[:name]} should answer privately"
-        else
-          assert_nil flags, "/#{definition[:name]} should answer in the channel"
+        calls.each do |payload, subcommand|
+          post_signed(payload)
+
+          label = "/#{[definition[:name], subcommand].compact.join(" ")}"
+          flags = response.parsed_body.dig("data", "flags")
+
+          if Discord::Commands::Registry.ephemeral?(definition[:name], subcommand)
+            assert_equal 64, flags, "#{label} should answer privately"
+          else
+            assert_nil flags, "#{label} should answer in the channel"
+          end
         end
       end
+    end
+
+    test "enqueues a subcommand with the arguments nested under it" do
+      post_signed(
+        subcommand_payload(options: [{"name" => "limit", "value" => 5}])
+      )
+
+      context = Discord::CommandJob.jobs.first["args"].first
+
+      assert_equal "fleet", context["command"]
+      assert_equal "info", context["subcommand"]
+      assert_equal({"limit" => 5}, context["options"])
+    end
+
+    # A flat read of the top-level options would find the subcommand itself,
+    # which carries no value, and drop every argument the caller typed.
+    test "a subcommand does not leak into the options hash" do
+      post_signed(subcommand_payload)
+
+      context = Discord::CommandJob.jobs.first["args"].first
+
+      assert_equal({}, context["options"])
+    end
+
+    # Discord will not invoke a command that has subcommands, but the endpoint is
+    # public: a hand-rolled bare call must not dispatch to the parent.
+    test "a bare call to a command with subcommands is acknowledged privately" do
+      post_signed(command_payload(name: "fleet", options: []))
+
+      assert_equal 64, response.parsed_body.dig("data", "flags")
+      assert_nil Discord::CommandJob.jobs.first["args"].first["subcommand"]
     end
 
     test "enqueues the command with everything the job needs" do

--- a/test/jobs/discord/command_job_test.rb
+++ b/test/jobs/discord/command_job_test.rb
@@ -73,6 +73,31 @@ module Discord
       end
     end
 
+    test "a subcommand is dispatched to its own handler" do
+      ::Discord::Commands::Fleet.any_instance.expects(:call).returns({content: "the fleet"})
+      @client.expects(:edit_original).with { |payload| payload[:content] == "the fleet" }
+
+      ::Discord::CommandJob.new.perform(
+        context("command" => "fleet", "subcommand" => "info", "options" => {})
+      )
+    end
+
+    # Nothing resolves to a parent that has subcommands, so this must answer
+    # rather than dispatch to the fleet overview.
+    test "a command invoked without its subcommand answers instead of guessing" do
+      @client.expects(:edit_original).with { |payload| payload[:content] == I18n.t("discord.commands.failed") }
+
+      ::Discord::CommandJob.new.perform(context("command" => "fleet", "options" => {}))
+    end
+
+    test "an unknown subcommand answers instead of timing out" do
+      @client.expects(:edit_original).with { |payload| payload[:content] == I18n.t("discord.commands.failed") }
+
+      ::Discord::CommandJob.new.perform(
+        context("command" => "fleet", "subcommand" => "nope", "options" => {})
+      )
+    end
+
     test "an unknown command answers instead of timing out" do
       @client.expects(:edit_original).with { |payload| payload[:content] == I18n.t("discord.commands.failed") }
 

--- a/test/lib/discord/commands/registry_test.rb
+++ b/test/lib/discord/commands/registry_test.rb
@@ -9,49 +9,112 @@ module Discord
     # published to Discord but has no handler shows up in the picker and then
     # times out on the user.
     class RegistryTest < ActiveSupport::TestCase
-      test "every published command has a handler that can run" do
-        ::Discord::Commands::Registry::DEFINITIONS.each do |definition|
-          handler = ::Discord::Commands::Registry.handler_for(definition[:name])
+      Registry = ::Discord::Commands::Registry
 
-          assert handler.present?, "no handler for /#{definition[:name]}"
+      # Every leaf a caller can actually invoke: a command without subcommands,
+      # or each subcommand of one that has them.
+      def self.invocable
+        Registry::DEFINITIONS.flat_map do |definition|
+          children = Registry.subcommands(definition)
+          next [[definition[:name], nil]] if children.empty?
+
+          children.map { |child| [definition[:name], child[:name]] }
+        end
+      end
+
+      test "every published command has a handler that can run" do
+        self.class.invocable.each do |name, subcommand|
+          handler = Registry.handler_for(name, subcommand)
+          label = [name, subcommand].compact.join(" ")
+
+          assert handler.present?, "no handler for /#{label}"
           assert handler.new.respond_to?(:call), "#{handler} cannot be called"
         end
       end
 
       test "the payload sent to Discord carries no keys of ours" do
-        ::Discord::Commands::Registry.payload.each do |command|
+        Registry.payload.each do |command|
           assert_not_includes command.keys, :handler
         end
       end
 
+      # A nested definition is published too, and Discord rejects the whole
+      # payload over one unknown key -- leaving the previous command list live,
+      # which reads as a sync that did nothing.
+      test "the payload carries no keys of ours at any depth" do
+        walk = lambda do |option|
+          assert_not_includes option.keys, :handler
+          assert_not_includes option.keys, :ephemeral
+
+          Array(option[:options]).each { |child| walk.call(child) }
+        end
+
+        Registry.payload.each { |command| walk.call(command) }
+      end
+
       test "every command declares a name and a description" do
-        ::Discord::Commands::Registry.payload.each do |command|
+        Registry.payload.each do |command|
           assert command[:name].present?
           assert command[:description].present?
         end
       end
 
+      test "every subcommand declares a name and a description" do
+        Registry.payload.each do |command|
+          Array(command[:options])
+            .select { |option| option[:type] == Registry::SUB_COMMAND }
+            .each do |subcommand|
+              assert subcommand[:name].present?
+              assert subcommand[:description].present?, "/#{command[:name]} #{subcommand[:name]} has no description"
+            end
+        end
+      end
+
       test "an unregistered name resolves to no handler" do
-        assert_nil ::Discord::Commands::Registry.handler_for("definitely-not-a-command")
+        assert_nil Registry.handler_for("definitely-not-a-command")
+      end
+
+      test "a subcommand resolves to its own handler" do
+        assert_equal ::Discord::Commands::Fleet, Registry.handler_for("fleet", "info")
+      end
+
+      # Discord refuses to invoke a command that has subcommands, so resolving a
+      # bare call to the parent would be inventing a command that cannot exist.
+      test "a command with subcommands cannot be invoked bare" do
+        assert_nil Registry.handler_for("fleet")
+        assert Registry.ephemeral?("fleet"), "a bare /fleet would answer in the channel"
+      end
+
+      test "an unknown subcommand resolves to no handler" do
+        assert_nil Registry.handler_for("fleet", "definitely-not-a-subcommand")
+        assert Registry.ephemeral?("fleet", "definitely-not-a-subcommand")
+      end
+
+      test "a subcommand named on a command that has none resolves to no handler" do
+        assert_nil Registry.handler_for("ship", "info")
       end
 
       # Discord fixes visibility at the deferred acknowledgement and ignores
       # flags on the follow-up, so this cannot live in the command: the answer
       # is needed before the command has run.
-      test "every command answers in the channel" do
-        ::Discord::Commands::Registry::DEFINITIONS.each do |definition|
-          refute ::Discord::Commands::Registry.ephemeral?(definition[:name]),
-            "/#{definition[:name]} would answer privately"
+      #
+      # Named one by one rather than derived from the list: these five answer in
+      # company on purpose, and a later command turning private must not be able
+      # to make this assertion pass by widening it.
+      test "the catalogue lookups and the fleet overview answer in the channel" do
+        [["ship", nil], ["loaner", nil], ["compare", nil], ["hangar", nil], ["fleet", "info"]].each do |name, subcommand|
+          refute Registry.ephemeral?(name, subcommand),
+            "/#{[name, subcommand].compact.join(" ")} would answer privately"
         end
       end
 
       # A "that command no longer exists" belongs to whoever typed it.
       test "an unregistered name answers privately" do
-        assert ::Discord::Commands::Registry.ephemeral?("definitely-not-a-command")
+        assert Registry.ephemeral?("definitely-not-a-command")
       end
 
       test "the visibility flag is ours and never reaches Discord" do
-        ::Discord::Commands::Registry.payload.each do |command|
+        Registry.payload.each do |command|
           assert_not_includes command.keys, :ephemeral
         end
       end


### PR DESCRIPTION
## What

Lets a Discord command carry subcommands, so `/fleet invite`, `/fleet members` and the rest of the stack have somewhere to live. Pure plumbing plus the exec-plan for the five phases that follow.

Three places assumed a flat namespace:

- `InteractionsController#command_options` flattened exactly **one** level. Discord nests a subcommand as an option of type 1 that carries no `value` of its own, so `/fleet invite limit:5` arrived as `{"invite" => nil}` and the limit was gone.
- `Registry.handler_for` / `.ephemeral?` keyed on the top-level name, so an invite would have dispatched to the fleet overview.
- `Registry.payload` stripped `:handler` / `:ephemeral` at the top level only. A nested definition carrying them is rejected by `PUT /applications/{id}/commands` as an unknown field — and because that endpoint is a full replacement, a rejected payload leaves the **previous** command list live, which reads as "the sync did nothing".

## `/fleet` becomes `/fleet info`

Not a preference — Discord will not invoke a command that has subcommands; its options are either parameters or subcommands, never both. There is no arrangement where `/fleet` keeps answering *and* `/fleet invite` exists under the same name.

Nothing resolves a bare `/fleet` to the parent either. The interactions endpoint is public, so a hand-rolled bare call refuses (privately, like any unknown command) rather than dispatching to the overview.

**This needs `discord:commands:sync` after deploy**, or the picker keeps offering a `/fleet` that no longer resolves.

## Visibility

`Registry.ephemeral?` now takes the subcommand, because that is the whole reason subcommands were worth the plumbing: the overview answers in the channel and an invite link must not, and Discord fixes visibility at the deferred acknowledgement — before the job that produces the answer has run.

The registry test names the five public leaves one by one rather than deriving them, so a later command turning private cannot make the assertion pass by widening it.

## Tests

`237 tests, 499 assertions, 0 failures` across `test/lib/discord`, `test/jobs/discord` and the interactions integration test. New coverage: subcommand dispatch with its arguments intact, a subcommand that does not leak into the options hash, a bare call to a parent with subcommands, an unknown subcommand, a subcommand named on a flat command, and the payload carrying none of our keys at any depth.

## Stack

First of six. `docs/exec-plans/discord-fleet-commands.md` has the phases and the order; `feat/discord-personal-commands` is independent of this branch, the other four stack on it. 🤖
