### PR TITLE
feat(discord): answer privately about your own hangar and wishlist

### DIFF
--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -2,6 +2,7 @@
 de:
   discord:
     commands:
+      account_not_linked: 'Verknüpfe zuerst deinen Discord-Account auf Fleetyards: %{url}'
       disabled: Fleetyards-Befehle sind noch nicht verfügbar.
       failed: Beim Abrufen ist etwas schiefgelaufen. Bitte versuche es erneut.
       compare:
@@ -26,6 +27,14 @@ de:
         heading: '[%{ship}](%{url}) kommt mit %{count} Leihschiff(en):'
         missing_query: Bitte gib einen Schiffsnamen an.
         none: 'Für %{ship} gibt es keine Leihschiffe.'
+      my_hangar:
+        empty: 'Du hast noch keine Schiffe in [deinem Hangar](%{url}).'
+        heading: '[Dein Hangar](%{url}) — %{count} Schiffe, %{models} Typen'
+        more: '…und %{count} weitere.'
+      my_wishlist:
+        empty: 'Auf [deiner Wunschliste](%{url}) steht noch nichts.'
+        heading: '[Deine Wunschliste](%{url}) — %{count} Schiffe, %{models} Typen'
+        more: '…und %{count} weitere.'
       ship:
         ambiguous: '%{count} Schiffe passen zu „%{query}“:'
         fields:

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -2,6 +2,7 @@
 en:
   discord:
     commands:
+      account_not_linked: 'Link your Discord account on Fleetyards first: %{url}'
       disabled: Fleetyards commands are not available yet.
       failed: Something went wrong while looking that up. Please try again.
       compare:
@@ -26,6 +27,14 @@ en:
         heading: '[%{ship}](%{url}) comes with %{count} loaner(s):'
         missing_query: Please provide a ship name.
         none: '%{ship} has no loaners.'
+      my_hangar:
+        empty: 'You have no ships in [your hangar](%{url}) yet.'
+        heading: '[Your hangar](%{url}) — %{count} ships, %{models} types'
+        more: '…and %{count} more.'
+      my_wishlist:
+        empty: 'There is nothing on [your wishlist](%{url}) yet.'
+        heading: '[Your wishlist](%{url}) — %{count} ships, %{models} types'
+        more: '…and %{count} more.'
       ship:
         ambiguous: '%{count} ships match "%{query}":'
         fields:

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -2,6 +2,7 @@
 es:
   discord:
     commands:
+      account_not_linked: 'Vincula primero tu cuenta de Discord en Fleetyards: %{url}'
       disabled: Los comandos de Fleetyards aún no están disponibles.
       failed: Algo ha fallado durante la búsqueda. Inténtalo de nuevo.
       compare:
@@ -26,6 +27,14 @@ es:
         heading: '[%{ship}](%{url}) incluye %{count} nave(s) de préstamo:'
         missing_query: Indica el nombre de una nave.
         none: '%{ship} no tiene naves de préstamo.'
+      my_hangar:
+        empty: 'Todavía no tienes naves en [tu hangar](%{url}).'
+        heading: '[Tu hangar](%{url}) — %{count} naves, %{models} tipos'
+        more: '…y %{count} más.'
+      my_wishlist:
+        empty: 'Todavía no hay nada en [tu lista de deseos](%{url}).'
+        heading: '[Tu lista de deseos](%{url}) — %{count} naves, %{models} tipos'
+        more: '…y %{count} más.'
       ship:
         ambiguous: '%{count} naves coinciden con «%{query}»:'
         fields:

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -2,6 +2,7 @@
 fr:
   discord:
     commands:
+      account_not_linked: 'Associe d''abord ton compte Discord sur Fleetyards : %{url}'
       disabled: Les commandes Fleetyards ne sont pas encore disponibles.
       failed: "Une erreur est survenue lors de la recherche. Merci de réessayer."
       compare:
@@ -26,6 +27,14 @@ fr:
         heading: '[%{ship}](%{url}) donne accès à %{count} vaisseau(x) de prêt :'
         missing_query: Merci d'indiquer le nom d'un vaisseau.
         none: '%{ship} ne donne accès à aucun vaisseau de prêt.'
+      my_hangar:
+        empty: 'Tu n''as encore aucun vaisseau dans [ton hangar](%{url}).'
+        heading: '[Ton hangar](%{url}) — %{count} vaisseaux, %{models} types'
+        more: '…et %{count} de plus.'
+      my_wishlist:
+        empty: 'Il n''y a encore rien dans [ta liste de souhaits](%{url}).'
+        heading: '[Ta liste de souhaits](%{url}) — %{count} vaisseaux, %{models} types'
+        more: '…et %{count} de plus.'
       ship:
         ambiguous: '%{count} vaisseaux correspondent à « %{query} » :'
         fields:

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -2,6 +2,7 @@
 it:
   discord:
     commands:
+      account_not_linked: 'Collega prima il tuo account Discord su Fleetyards: %{url}'
       disabled: I comandi Fleetyards non sono ancora disponibili.
       failed: Qualcosa è andato storto durante la ricerca. Riprova.
       compare:
@@ -26,6 +27,14 @@ it:
         heading: '[%{ship}](%{url}) include %{count} nave(i) in prestito:'
         missing_query: Indica il nome di una nave.
         none: '%{ship} non ha navi in prestito.'
+      my_hangar:
+        empty: 'Non hai ancora navi nel [tuo hangar](%{url}).'
+        heading: '[Il tuo hangar](%{url}) — %{count} navi, %{models} tipi'
+        more: '…e altre %{count}.'
+      my_wishlist:
+        empty: 'Non c''è ancora nulla nella [tua lista dei desideri](%{url}).'
+        heading: '[La tua lista dei desideri](%{url}) — %{count} navi, %{models} tipi'
+        more: '…e altre %{count}.'
       ship:
         ambiguous: '%{count} navi corrispondono a «%{query}»:'
         fields:

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -2,6 +2,7 @@
 zh-CN:
   discord:
     commands:
+      account_not_linked: '请先在 Fleetyards 上关联你的 Discord 账号：%{url}'
       disabled: Fleetyards 命令尚不可用。
       failed: 查询时出错，请重试。
       compare:
@@ -26,6 +27,14 @@ zh-CN:
         heading: '[%{ship}](%{url}) 附带 %{count} 艘替代飞船：'
         missing_query: 请提供飞船名称。
         none: '%{ship} 没有替代飞船。'
+      my_hangar:
+        empty: '[你的机库](%{url})中还没有飞船。'
+        heading: '[你的机库](%{url}) — %{count} 艘飞船，%{models} 种型号'
+        more: '…还有 %{count} 种。'
+      my_wishlist:
+        empty: '[你的心愿单](%{url})中还没有内容。'
+        heading: '[你的心愿单](%{url}) — %{count} 艘飞船，%{models} 种型号'
+        more: '…还有 %{count} 种。'
       ship:
         ambiguous: '有 %{count} 艘飞船匹配“%{query}”：'
         fields:

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -2,6 +2,7 @@
 zh-TW:
   discord:
     commands:
+      account_not_linked: '請先在 Fleetyards 上連結你的 Discord 帳號：%{url}'
       disabled: Fleetyards 指令尚未開放。
       failed: 查詢時發生錯誤，請重試。
       compare:
@@ -26,6 +27,14 @@ zh-TW:
         heading: '[%{ship}](%{url}) 附帶 %{count} 艘替代船艦：'
         missing_query: 請提供船艦名稱。
         none: '%{ship} 沒有替代船艦。'
+      my_hangar:
+        empty: '[你的機庫](%{url})中還沒有飛船。'
+        heading: '[你的機庫](%{url}) — %{count} 艘飛船，%{models} 種型號'
+        more: '…還有 %{count} 種。'
+      my_wishlist:
+        empty: '[你的心願單](%{url})中還沒有內容。'
+        heading: '[你的心願單](%{url}) — %{count} 艘飛船，%{models} 種型號'
+        more: '…還有 %{count} 種。'
       ship:
         ambiguous: '有 %{count} 艘船艦符合「%{query}」：'
         fields:

--- a/lib/discord/commands/fleet.rb
+++ b/lib/discord/commands/fleet.rb
@@ -3,6 +3,8 @@
 module Discord
   module Commands
     class Fleet < Base
+      include LinkedAccount
+
       EMBED_COLOR = 0x2d9cdb
 
       def call
@@ -30,7 +32,7 @@ module Discord
       end
 
       private def member?(fleet)
-        user = ::OmniauthConnection.find_by(provider: "discord", uid: discord_user_id)&.user
+        user = linked_user
         return false if user.blank?
 
         user.fleet_memberships.exists?(fleet_id: fleet.id, aasm_state: "accepted")

--- a/lib/discord/commands/hangar.rb
+++ b/lib/discord/commands/hangar.rb
@@ -3,7 +3,7 @@
 module Discord
   module Commands
     class Hangar < Base
-      MAX_SHIPS = 10
+      include VehicleCounts
 
       def call
         username = option("username").to_s.strip
@@ -16,8 +16,7 @@ module Discord
         # for whether an account exists.
         return message(content: I18n.t("discord.commands.hangar.not_available", username: username)) unless visible?(user)
 
-        vehicles = user.vehicles.purchased.public
-        counts = vehicles.joins(:model).group("models.name").order("count_all desc, models.name asc").count
+        counts = model_counts(user.vehicles.purchased.public)
 
         return message(content: I18n.t("discord.commands.hangar.empty", username: user.username)) if counts.empty?
 
@@ -31,17 +30,14 @@ module Discord
       end
 
       private def content_for(user, counts)
-        shown = counts.first(MAX_SHIPS)
-        lines = shown.map { |name, count| (count > 1) ? "• #{count}× #{name}" : "• #{name}" }
-
         [
           I18n.t("discord.commands.hangar.heading",
             username: user.username,
             url: user.public_hangar_url,
             count: counts.values.sum,
             models: counts.size),
-          lines.join("\n"),
-          (I18n.t("discord.commands.hangar.more", count: counts.size - shown.size) if counts.size > shown.size)
+          count_lines(counts).join("\n"),
+          (I18n.t("discord.commands.hangar.more", count: omitted_count(counts)) if omitted_count(counts).positive?)
         ].compact.join("\n")
       end
     end

--- a/lib/discord/commands/linked_account.rb
+++ b/lib/discord/commands/linked_account.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # Resolves the Discord user behind an interaction to a Fleetyards account.
+    #
+    # This link is the only identity the bot has. A guild permission says
+    # nothing about who someone is on Fleetyards, so a member who never
+    # connected their account is simply unknown here -- and that refusal is the
+    # most frequently seen answer of any command that needs a person.
+    module LinkedAccount
+      private def linked_user
+        return nil if discord_user_id.blank?
+
+        ::OmniauthConnection.find_by(provider: "discord", uid: discord_user_id)&.user
+      end
+
+      # One answer for every command that needs a person, because it is also the
+      # only refusal that is a conversion path: it names where to fix it.
+      private def account_not_linked
+        I18n.t("discord.commands.account_not_linked", url: url_for_path("/settings/connections"))
+      end
+    end
+  end
+end

--- a/lib/discord/commands/my_hangar.rb
+++ b/lib/discord/commands/my_hangar.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # The caller's own hangar, privately.
+    #
+    # Deliberately not `/hangar` with the username filled in: that command
+    # exists to show a *stranger's* hangar and enforces `public_hangar?` plus the
+    # per-ship `public` flag. For the owner both layers fall away, and reusing
+    # them would silently omit exactly the ships someone is most likely checking
+    # on -- the ones they never made public.
+    class MyHangar < Base
+      include LinkedAccount
+      include VehicleCounts
+
+      def call
+        user = linked_user
+        return message(content: account_not_linked) if user.nil?
+
+        # `visible` drops the duplicate loaner rows the loaner setup marks
+        # hidden; nothing a user can edit writes that flag, so this is about not
+        # counting the same loaner twice rather than about privacy.
+        counts = model_counts(user.vehicles.purchased.visible)
+        return message(content: I18n.t("discord.commands.my_hangar.empty", url: url_for_path("/hangar"))) if counts.empty?
+
+        message(content: content_for(counts))
+      end
+
+      private def content_for(counts)
+        [
+          I18n.t("discord.commands.my_hangar.heading",
+            url: url_for_path("/hangar"),
+            count: counts.values.sum,
+            models: counts.size),
+          count_lines(counts).join("\n"),
+          (I18n.t("discord.commands.my_hangar.more", count: omitted_count(counts)) if omitted_count(counts).positive?)
+        ].compact.join("\n")
+      end
+    end
+  end
+end

--- a/lib/discord/commands/my_wishlist.rb
+++ b/lib/discord/commands/my_wishlist.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # The caller's own wishlist, privately.
+    #
+    # Named `/mywishlist` rather than `/wishlist` on purpose: visibility is fixed
+    # per command at the deferred acknowledgement, so one name cannot answer
+    # privately about yourself and publicly about someone else. Leaving
+    # `/wishlist` free keeps the public lookup that mirrors `/hangar` possible.
+    class MyWishlist < Base
+      include LinkedAccount
+      include VehicleCounts
+
+      def call
+        user = linked_user
+        return message(content: account_not_linked) if user.nil?
+
+        counts = model_counts(user.vehicles.wanted.visible)
+        return message(content: I18n.t("discord.commands.my_wishlist.empty", url: url_for_path("/hangar/wishlist/"))) if counts.empty?
+
+        message(content: content_for(counts))
+      end
+
+      private def content_for(counts)
+        [
+          I18n.t("discord.commands.my_wishlist.heading",
+            url: url_for_path("/hangar/wishlist/"),
+            count: counts.values.sum,
+            models: counts.size),
+          count_lines(counts).join("\n"),
+          (I18n.t("discord.commands.my_wishlist.more", count: omitted_count(counts)) if omitted_count(counts).positive?)
+        ].compact.join("\n")
+      end
+    end
+  end
+end

--- a/lib/discord/commands/registry.rb
+++ b/lib/discord/commands/registry.rb
@@ -24,8 +24,9 @@ module Discord
       # command cannot post a public hit and a private miss.
       #
       # The catalogue lookups answer in the channel: asking in company is the
-      # point, and the cost is that their refusals are public too. Anything that
-      # reads or changes one fleet's own data sets `ephemeral: true`.
+      # point, and the cost is that their refusals are public too. A command
+      # about one person's own data, or about one fleet's, sets
+      # `ephemeral: true` instead.
       EPHEMERAL_BY_DEFAULT = false
 
       # A subcommand is an option of type SUB_COMMAND that carries a `handler`
@@ -109,6 +110,20 @@ module Discord
               options: []
             }
           ]
+        },
+        {
+          name: "myhangar",
+          description: "Show your own hangar, only to you",
+          handler: "Discord::Commands::MyHangar",
+          ephemeral: true,
+          options: []
+        },
+        {
+          name: "mywishlist",
+          description: "Show your own wishlist, only to you",
+          handler: "Discord::Commands::MyWishlist",
+          ephemeral: true,
+          options: []
         }
       ].freeze
 

--- a/lib/discord/commands/vehicle_counts.rb
+++ b/lib/discord/commands/vehicle_counts.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # Ships grouped by model name, the shape every hangar answer takes. An embed
+    # caps out long before a large hangar does, so the list is truncated and the
+    # link carries the rest.
+    module VehicleCounts
+      MAX_SHIPS = 10
+
+      private def model_counts(scope)
+        scope.joins(:model).group("models.name").order("count_all desc, models.name asc").count
+      end
+
+      private def shown_counts(counts)
+        counts.first(MAX_SHIPS)
+      end
+
+      private def count_lines(counts)
+        shown_counts(counts).map { |name, count| (count > 1) ? "• #{count}× #{name}" : "• #{name}" }
+      end
+
+      private def omitted_count(counts)
+        counts.size - shown_counts(counts).size
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/my_hangar_test.rb
+++ b/test/lib/discord/commands/my_hangar_test.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/my_hangar"
+
+module Discord
+  module Commands
+    class MyHangarTest < ActiveSupport::TestCase
+      DISCORD_UID = "424242424242"
+
+      setup do
+        @user = create(:user, username: "Aendrax", public_hangar: false)
+        create(:omniauth_connection, user: @user, provider: :discord, uid: DISCORD_UID)
+        @carrack = create(:model, name: "Carrack")
+      end
+
+      def call(uid: DISCORD_UID)
+        ::Discord::Commands::MyHangar.new(discord_user_id: uid).call
+      end
+
+      def add_ship(model, count: 1, public: true, wanted: false, hidden: false)
+        count.times { create(:vehicle, user: @user, model: model, public: public, wanted: wanted, hidden: hidden) }
+      end
+
+      test "lists your own ships" do
+        add_ship(@carrack)
+
+        assert_includes call[:content], "Carrack"
+      end
+
+      # The whole reason this is not `/hangar` with the username filled in: the
+      # owner's own answer must not be filtered by the flags that exist to keep
+      # strangers out.
+      test "a private hangar is still shown to its owner" do
+        add_ship(@carrack, public: false)
+
+        assert_includes call[:content], "Carrack"
+      end
+
+      test "a private ship in a public hangar is still shown to its owner" do
+        @user.update!(public_hangar: true)
+        add_ship(@carrack, public: false)
+
+        assert_includes call[:content], "Carrack"
+      end
+
+      test "counts duplicates rather than repeating them" do
+        add_ship(@carrack, count: 3)
+
+        assert_includes call[:content], "3× Carrack"
+      end
+
+      # `hidden` is written only by the loaner setup, to mark a duplicate loaner
+      # row. Counting those would report ships the owner does not have twice.
+      test "a hidden duplicate loaner row is not counted" do
+        add_ship(@carrack)
+        add_ship(@carrack, hidden: true)
+
+        assert_includes call[:content], "Carrack"
+        assert_not_includes call[:content], "2× Carrack"
+      end
+
+      test "a wishlist entry is not in the hangar" do
+        add_ship(@carrack, wanted: true)
+
+        assert_includes call[:content], I18n.t("discord.commands.my_hangar.empty", url: "https://#{Rails.configuration.app.domain}/hangar")
+      end
+
+      test "links your own hangar rather than the public one" do
+        add_ship(@carrack)
+
+        assert_includes call[:content], "/hangar"
+        assert_not_includes call[:content], @user.public_hangar_url
+      end
+
+      # The most frequently seen answer of the command, and the only one that is
+      # also a conversion path.
+      test "an unlinked Discord account is told where to link it" do
+        assert_equal(
+          I18n.t("discord.commands.account_not_linked", url: "https://#{Rails.configuration.app.domain}/settings/connections"),
+          call(uid: "not-linked-at-all")[:content]
+        )
+      end
+
+      test "a linked account belonging to another provider does not resolve" do
+        ::OmniauthConnection.find_by(uid: DISCORD_UID).update!(provider: :twitch)
+
+        assert_includes call[:content], I18n.t("discord.commands.account_not_linked", url: "https://#{Rails.configuration.app.domain}/settings/connections")
+      end
+
+      # Visibility is fixed at the acknowledgement; RegistryTest and
+      # DiscordInteractionsTest cover it where Discord actually reads it.
+      test "carries no flags, since a follow-up cannot set them" do
+        assert_nil call[:flags]
+      end
+
+      test "caps a long hangar and says how many were left out" do
+        (::Discord::Commands::MyHangar::MAX_SHIPS + 3).times do |i|
+          add_ship(create(:model, name: "Ship #{i.to_s.rjust(2, "0")}"))
+        end
+
+        assert_includes call[:content], I18n.t("discord.commands.my_hangar.more", count: 3)
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/my_wishlist_test.rb
+++ b/test/lib/discord/commands/my_wishlist_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/my_wishlist"
+
+module Discord
+  module Commands
+    class MyWishlistTest < ActiveSupport::TestCase
+      DISCORD_UID = "515151515151"
+
+      setup do
+        @user = create(:user, username: "Aendrax", public_wishlist: false)
+        create(:omniauth_connection, user: @user, provider: :discord, uid: DISCORD_UID)
+        @carrack = create(:model, name: "Carrack")
+      end
+
+      def call(uid: DISCORD_UID)
+        ::Discord::Commands::MyWishlist.new(discord_user_id: uid).call
+      end
+
+      def add_ship(model, count: 1, wanted: true, public: false)
+        count.times { create(:vehicle, user: @user, model: model, wanted: wanted, public: public) }
+      end
+
+      test "lists what is on your wishlist" do
+        add_ship(@carrack)
+
+        assert_includes call[:content], "Carrack"
+      end
+
+      test "a private wishlist is still shown to its owner" do
+        add_ship(@carrack)
+
+        refute @user.reload.public_wishlist
+        assert_includes call[:content], "Carrack"
+      end
+
+      test "counts duplicates rather than repeating them" do
+        add_ship(@carrack, count: 2)
+
+        assert_includes call[:content], "2× Carrack"
+      end
+
+      # The scope is the only thing separating this from /myhangar, so it is the
+      # thing worth pinning.
+      test "a ship you already own is not on the wishlist" do
+        add_ship(@carrack, wanted: false)
+
+        assert_includes call[:content], I18n.t("discord.commands.my_wishlist.empty", url: "https://#{Rails.configuration.app.domain}/hangar/wishlist/")
+      end
+
+      test "links your own wishlist page" do
+        add_ship(@carrack)
+
+        assert_includes call[:content], "/hangar/wishlist/"
+      end
+
+      test "an unlinked Discord account is told where to link it" do
+        assert_equal(
+          I18n.t("discord.commands.account_not_linked", url: "https://#{Rails.configuration.app.domain}/settings/connections"),
+          call(uid: "not-linked-at-all")[:content]
+        )
+      end
+
+      test "carries no flags, since a follow-up cannot set them" do
+        assert_nil call[:flags]
+      end
+
+      test "caps a long wishlist and says how many were left out" do
+        (::Discord::Commands::MyWishlist::MAX_SHIPS + 2).times do |i|
+          add_ship(create(:model, name: "Ship #{i.to_s.rjust(2, "0")}"))
+        end
+
+        assert_includes call[:content], I18n.t("discord.commands.my_wishlist.more", count: 2)
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/registry_test.rb
+++ b/test/lib/discord/commands/registry_test.rb
@@ -108,6 +108,15 @@ module Discord
         end
       end
 
+      # The point of these two commands. A public answer would post someone's
+      # private hangar into the channel they typed it in.
+      test "a command about your own data answers privately" do
+        ["myhangar", "mywishlist"].each do |name|
+          assert Registry.ephemeral?(name),
+            "/#{name} would answer in the channel"
+        end
+      end
+
       # A "that command no longer exists" belongs to whoever typed it.
       test "an unregistered name answers privately" do
         assert Registry.ephemeral?("definitely-not-a-command")


### PR DESCRIPTION
## What

Two commands that answer only to the person who typed them: `/myhangar` and `/mywishlist`.

They are the first commands in the tree to set `ephemeral: true`. The mechanism was already built — `InteractionsController#acknowledge_command` reads `Registry.ephemeral?` and sets flag 64 on the deferred acknowledgement — and no definition had ever used it.

## `/myhangar` is not `/hangar` with the username filled in

`Discord::Commands::Hangar` exists to show a **stranger's** hangar: it enforces `public_hangar?` and scopes `vehicles.purchased.public`. For the owner both layers fall away, and reusing that scope would silently omit exactly the ships someone is most likely checking on — the ones they never made public.

It does keep `visible`. That flag is written only by the loaner setup, to mark a duplicate loaner row, and is not in `vehicle_params` — so this is about not counting the same loaner twice, not about privacy. There is a test for it.

Links point at `/hangar` and `/hangar/wishlist/`, the owner's own pages, rather than the public URLs: a private hangar has no public page to send its owner to.

## Why `/mywishlist` and not `/wishlist`

Visibility is fixed **per command** at the acknowledgement, so one name cannot answer privately about yourself and publicly about someone else. Taking `/wishlist` for the private answer would have burned the name for the public lookup that mirrors `/hangar`. This leaves it free.

## Reuse

Two things every command about a person repeated, now shared and applied to the existing commands:

- `LinkedAccount#linked_user` — the Discord uid → account lookup `/fleet` had its own copy of.
- `VehicleCounts` — grouping ships by model name into a capped list, which `/hangar` had inline.

## Notes

- Neither command needs a guild. `invoking_user_id` already reads the DM shape (`payload["user"]["id"]`), so both work in a DM with the bot.
- The "link your account first" refusal is one shared key: it is the most frequently seen answer here and the only one that is also a conversion path, so it names where to fix it.
- Copy landed in all seven `discord.yml` files. `i18n-tasks normalize` was **not** run — it reformats the entire locale tree (133 files), which the repo is not in.
- Needs `discord:commands:sync` after deploy for the two new commands to appear in the picker.

## Tests

`245 tests, 496 assertions, 0 failures` across `test/lib/discord`, `test/jobs/discord` and the interactions integration test. The registry test now names the public commands one by one instead of asserting all of them are public, so a later command turning private cannot make it pass by widening it.

## Stack

Independent of the rest — this is the only phase that needs no subcommand plumbing. Expect a small conflict in `Registry::DEFINITIONS` and `registry_test.rb` with #4663, whichever merges second. `docs/exec-plans/discord-fleet-commands.md` (in #4663) has the full plan. 🤖
