### PR TITLE
feat(discord): create a fleet invite link from Discord

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -21,6 +21,12 @@
 discord_commands:
   description: "Discord slash commands answered by the interactions endpoint"
 
+# Gates only the commands that change a fleet. discord_commands is on in
+# production and covers dispatch as a whole; the first path that writes from
+# Discord wants a switch of its own.
+discord_fleet_commands:
+  description: "Discord commands that create or change something in a fleet"
+
 fleet_logistics:
   description: "Fleet logistics — fleet inventories with a deposit/withdrawal ledger"
 

--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -15,6 +15,14 @@ de:
           models: Schiffstypen
           ships: Schiffe
           upcoming_events: Kommende Events
+        invite:
+          expires: 'läuft in %{time} ab'
+          failed: Der Einladungslink konnte nicht erstellt werden. Bitte versuche es erneut.
+          heading: 'Einladungslink für %{fleet}:'
+          limit: '%{count} Verwendung(en)'
+          limit_too_low: Ein Einladungslink braucht mindestens eine Verwendung.
+          needs_approval: Wer ihn öffnet, stellt eine Beitrittsanfrage — die muss noch bestätigt werden.
+          not_allowed: Du darfst für diese Flotte keine Einladungslinks erstellen.
         not_allowed: '%{fleet} hat seine Seite nicht öffentlich gemacht.'
         not_bound: Dieser Server ist mit keiner Flotte auf Fleetyards verknüpft.
       hangar:

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -15,6 +15,14 @@ en:
           models: Ship types
           ships: Ships
           upcoming_events: Upcoming events
+        invite:
+          expires: 'expires in %{time}'
+          failed: The invite link could not be created. Please try again.
+          heading: 'Invite link for %{fleet}:'
+          limit: '%{count} use(s)'
+          limit_too_low: An invite link needs at least one use.
+          needs_approval: Whoever opens it asks to join — the request still needs accepting.
+          not_allowed: You are not allowed to create invite links for this fleet.
         not_allowed: '%{fleet} has not made its page public.'
         not_bound: This server is not linked to a fleet on Fleetyards.
       hangar:

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -15,6 +15,14 @@ es:
           models: Tipos de nave
           ships: Naves
           upcoming_events: Próximos eventos
+        invite:
+          expires: 'caduca en %{time}'
+          failed: No se pudo crear el enlace de invitación. Inténtalo de nuevo.
+          heading: 'Enlace de invitación para %{fleet}:'
+          limit: '%{count} uso(s)'
+          limit_too_low: Un enlace de invitación necesita al menos un uso.
+          needs_approval: Quien lo abra solicitará unirse — la solicitud aún debe aceptarse.
+          not_allowed: No tienes permiso para crear enlaces de invitación para esta flota.
         not_allowed: '%{fleet} no ha hecho pública su página.'
         not_bound: Este servidor no está vinculado a ninguna flota en Fleetyards.
       hangar:

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -15,6 +15,14 @@ fr:
           models: Types de vaisseau
           ships: Vaisseaux
           upcoming_events: Événements à venir
+        invite:
+          expires: 'expire dans %{time}'
+          failed: 'Le lien d''invitation n''a pas pu être créé. Réessaie.'
+          heading: 'Lien d''invitation pour %{fleet} :'
+          limit: '%{count} utilisation(s)'
+          limit_too_low: 'Un lien d''invitation nécessite au moins une utilisation.'
+          needs_approval: 'Celui qui l''ouvre demande à rejoindre — la demande doit encore être acceptée.'
+          not_allowed: 'Tu n''as pas le droit de créer des liens d''invitation pour cette flotte.'
         not_allowed: "%{fleet} n'a pas rendu sa page publique."
         not_bound: "Ce serveur n'est lié à aucune flotte sur Fleetyards."
       hangar:

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -15,6 +15,14 @@ it:
           models: Tipi di nave
           ships: Navi
           upcoming_events: Prossimi eventi
+        invite:
+          expires: 'scade tra %{time}'
+          failed: Non è stato possibile creare il link di invito. Riprova.
+          heading: 'Link di invito per %{fleet}:'
+          limit: '%{count} utilizzo/i'
+          limit_too_low: Un link di invito richiede almeno un utilizzo.
+          needs_approval: Chi lo apre chiede di entrare — la richiesta deve ancora essere accettata.
+          not_allowed: Non puoi creare link di invito per questa flotta.
         not_allowed: '%{fleet} non ha reso pubblica la propria pagina.'
         not_bound: Questo server non è collegato a nessuna flotta su Fleetyards.
       hangar:

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -15,6 +15,14 @@ zh-CN:
           models: 飞船类型
           ships: 飞船
           upcoming_events: 即将开始的活动
+        invite:
+          expires: '%{time}后过期'
+          failed: 无法创建邀请链接，请重试。
+          heading: '%{fleet} 的邀请链接：'
+          limit: '可使用 %{count} 次'
+          limit_too_low: 邀请链接至少需要一次使用次数。
+          needs_approval: 打开链接的人会提交加入申请 — 申请仍需批准。
+          not_allowed: 你没有为这支舰队创建邀请链接的权限。
         not_allowed: '%{fleet} 未公开其页面。'
         not_bound: 此服务器尚未与 Fleetyards 上的舰队关联。
       hangar:

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -15,6 +15,14 @@ zh-TW:
           models: 船艦類型
           ships: 船艦
           upcoming_events: 即將開始的活動
+        invite:
+          expires: '%{time}後過期'
+          failed: 無法建立邀請連結，請重試。
+          heading: '%{fleet} 的邀請連結：'
+          limit: '可使用 %{count} 次'
+          limit_too_low: 邀請連結至少需要一次使用次數。
+          needs_approval: 開啟連結的人會送出加入申請 — 申請仍需核准。
+          not_allowed: 你沒有為這支艦隊建立邀請連結的權限。
         not_allowed: '%{fleet} 未公開其頁面。'
         not_bound: 此伺服器尚未與 Fleetyards 上的艦隊連結。
       hangar:

--- a/lib/discord/commands/fleet.rb
+++ b/lib/discord/commands/fleet.rb
@@ -3,24 +3,16 @@
 module Discord
   module Commands
     class Fleet < Base
-      include LinkedAccount
+      include FleetContext
 
       EMBED_COLOR = 0x2d9cdb
 
       def call
-        fleet = resolve_fleet
+        fleet = guild_fleet
         return message(content: I18n.t("discord.commands.fleet.not_bound")) if fleet.nil?
         return message(content: I18n.t("discord.commands.fleet.not_allowed", fleet: fleet.name)) unless allowed?(fleet)
 
         message(embeds: [embed(fleet)])
-      end
-
-      # The guild the command came from decides which fleet is meant, through
-      # the binding the fleet's own notification settings already carry.
-      private def resolve_fleet
-        return nil if guild_id.blank?
-
-        ::FleetNotificationSetting.find_by(discord_guild_id: guild_id)&.fleet
       end
 
       # A member of the fleet may always see it; anyone else only if the fleet

--- a/lib/discord/commands/fleet_context.rb
+++ b/lib/discord/commands/fleet_context.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # Which fleet is this server? Every fleet command answers that before it can
+    # do anything, and it answers "who is asking" right after -- so this carries
+    # LinkedAccount rather than making each command include both.
+    module FleetContext
+      include LinkedAccount
+
+      # The guild decides which fleet is meant, through the binding the fleet's
+      # own notification settings already carry.
+      #
+      # Nothing Discord says about the caller enters here: Manage Roles in a
+      # guild does not create a privilege in a fleet.
+      private def guild_fleet
+        return nil if guild_id.blank?
+
+        ::FleetNotificationSetting.find_by(discord_guild_id: guild_id)&.fleet
+      end
+    end
+  end
+end

--- a/lib/discord/commands/fleet_invite.rb
+++ b/lib/discord/commands/fleet_invite.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # Mints an invite link for the guild's fleet.
+    #
+    # Ephemeral without exception: the token *is* the credential, and a public
+    # answer hands the fleet to everyone in the channel, guests included.
+    class FleetInvite < Base
+      include FleetContext
+
+      # Discord sends the choice's value, so these are the only strings that can
+      # arrive. `never` is a real option rather than an omission, because "no
+      # expiry" should be something someone picked.
+      EXPIRES_IN = {
+        "1h" => 1.hour,
+        "24h" => 24.hours,
+        "7d" => 7.days,
+        "never" => nil
+      }.freeze
+
+      def call
+        return message(content: I18n.t("discord.commands.disabled")) unless enabled?
+
+        fleet = guild_fleet
+        return message(content: I18n.t("discord.commands.fleet.not_bound")) if fleet.nil?
+
+        user = linked_user
+        return message(content: account_not_linked) if user.nil?
+
+        invite = build_invite(fleet, user)
+        return message(content: I18n.t("discord.commands.fleet.invite.not_allowed")) unless allowed?(invite, user)
+        return message(content: I18n.t("discord.commands.fleet.invite.limit_too_low")) unless limit_usable?
+
+        return message(content: I18n.t("discord.commands.fleet.invite.failed")) unless invite.save
+
+        message(content: content_for(invite))
+      end
+
+      private def enabled?
+        Flipper.enabled?(:discord_fleet_commands)
+      end
+
+      private def build_invite(fleet, user)
+        fleet.fleet_invite_urls.new(
+          user_id: user.id,
+          limit: limit,
+          expires_after: expires_after
+        )
+      end
+
+      # The fleet's own privilege system decides, through the very policy the
+      # HTTP endpoint authorizes against -- not a second copy of the privilege
+      # list, and not anything Discord says about the caller. The policy already
+      # requires an accepted, undiscarded membership.
+      private def allowed?(invite, user)
+        ::FleetInviteUrlPolicy.new(invite, user: user).apply(:create?)
+      end
+
+      private def limit
+        value = option("limit")
+        return nil if value.blank?
+
+        value.to_i
+      end
+
+      # A limit of zero passes the model's validation and is then excluded by
+      # `FleetInviteUrl.active`, so it would hand out a link that is dead on
+      # arrival. Discord's own `min_value` covers the picker; this covers a
+      # hand-rolled interaction.
+      private def limit_usable?
+        limit.nil? || limit.positive?
+      end
+
+      private def expires_after
+        duration = EXPIRES_IN[option("expires_in").to_s]
+        return nil if duration.nil?
+
+        Time.zone.now + duration
+      end
+
+      # The link creates a join *request*, not a membership: FleetInviteUrl#use
+      # puts the new membership straight into `requested`. Saying "they're in"
+      # would be wrong.
+      private def content_for(invite)
+        [
+          I18n.t("discord.commands.fleet.invite.heading", fleet: invite.fleet.name),
+          invite.url,
+          I18n.t("discord.commands.fleet.invite.needs_approval"),
+          conditions(invite)
+        ].compact_blank.join("\n")
+      end
+
+      private def conditions(invite)
+        parts = []
+        parts << I18n.t("discord.commands.fleet.invite.limit", count: invite.limit) if invite.limit.present?
+        parts << I18n.t("discord.commands.fleet.invite.expires", time: invite.expires_after_label) if invite.expires_after.present?
+
+        return nil if parts.empty?
+
+        parts.join(" · ")
+      end
+    end
+  end
+end

--- a/lib/discord/commands/registry.rb
+++ b/lib/discord/commands/registry.rb
@@ -108,6 +108,34 @@ module Discord
               type: SUB_COMMAND,
               handler: "Discord::Commands::Fleet",
               options: []
+            },
+            {
+              name: "invite",
+              description: "Create an invite link for this server's fleet",
+              type: SUB_COMMAND,
+              handler: "Discord::Commands::FleetInvite",
+              ephemeral: true,
+              options: [
+                {
+                  name: "limit",
+                  description: "How many people may use the link",
+                  type: INTEGER,
+                  required: false,
+                  min_value: 1
+                },
+                {
+                  name: "expires_in",
+                  description: "How long the link stays valid",
+                  type: STRING,
+                  required: false,
+                  choices: [
+                    {name: "1 hour", value: "1h"},
+                    {name: "24 hours", value: "24h"},
+                    {name: "7 days", value: "7d"},
+                    {name: "Never", value: "never"}
+                  ]
+                }
+              ]
             }
           ]
         },

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -12534,6 +12534,7 @@ components:
       type: string
       enum:
       - discord_commands
+      - discord_fleet_commands
       - fleet_logistics
       - fleet_mission_builder
       - fleet_starmap
@@ -12551,6 +12552,7 @@ components:
       - tools_travel_times
       x-enumNames:
       - DISCORD_COMMANDS
+      - DISCORD_FLEET_COMMANDS
       - FLEET_LOGISTICS
       - FLEET_MISSION_BUILDER
       - FLEET_STARMAP

--- a/test/lib/discord/commands/fleet_invite_test.rb
+++ b/test/lib/discord/commands/fleet_invite_test.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/fleet_invite"
+
+module Discord
+  module Commands
+    class FleetInviteTest < ActiveSupport::TestCase
+      setup do
+        Flipper.enable(:discord_fleet_commands)
+
+        @fleet = create(:fleet, :private, name: "Test Wing")
+        @fleet.create_fleet_notification_setting!(discord_guild_id: "guild-1")
+
+        @user = create(:user)
+        create(:omniauth_connection, user: @user, provider: "discord", uid: "officer-uid")
+        @fleet.fleet_memberships
+          .create!(user: @user, fleet_role: role_named("Officer"))
+          .update!(aasm_state: "accepted")
+      end
+
+      # Looked up by privilege rather than by rank position: the ranked order is
+      # not what this test is about.
+      def role_named(name)
+        @fleet.fleet_roles.find_by(name: name)
+      end
+
+      def call(guild_id: "guild-1", discord_user_id: "officer-uid", options: {})
+        ::Discord::Commands::FleetInvite.new(
+          guild_id: guild_id,
+          discord_user_id: discord_user_id,
+          options: options
+        ).call
+      end
+
+      test "creates an invite link for the guild's fleet" do
+        content = call[:content]
+
+        invite = @fleet.fleet_invite_urls.sole
+
+        assert_includes content, invite.url
+        assert_equal @user.id, invite.user_id
+      end
+
+      test "names the fleet the link belongs to" do
+        assert_includes call[:content], "Test Wing"
+      end
+
+      # FleetInviteUrl#use puts the new membership straight into `requested`, so
+      # the answer must not read as "they are in".
+      test "says the link still needs accepting" do
+        assert_includes call[:content], I18n.t("discord.commands.fleet.invite.needs_approval")
+      end
+
+      test "passes the limit through" do
+        call(options: {"limit" => 5})
+
+        assert_equal 5, @fleet.fleet_invite_urls.sole.limit
+      end
+
+      test "an unlimited link is the default" do
+        call
+
+        invite = @fleet.fleet_invite_urls.sole
+
+        assert_nil invite.limit
+        assert_nil invite.expires_after
+      end
+
+      test "expires_in is turned into a moment" do
+        freeze_time do
+          call(options: {"expires_in" => "24h"})
+
+          assert_equal 24.hours.from_now, @fleet.fleet_invite_urls.sole.expires_after
+        end
+      end
+
+      test "never means no expiry" do
+        call(options: {"expires_in" => "never"})
+
+        assert_nil @fleet.fleet_invite_urls.sole.expires_after
+      end
+
+      # Zero passes the model's own validation and is then excluded by
+      # FleetInviteUrl.active, so it would hand out a link that is dead on
+      # arrival.
+      test "a limit of zero is refused rather than minted" do
+        assert_equal I18n.t("discord.commands.fleet.invite.limit_too_low"), call(options: {"limit" => 0})[:content]
+        assert_empty @fleet.fleet_invite_urls
+      end
+
+      test "a negative limit is refused" do
+        assert_equal I18n.t("discord.commands.fleet.invite.limit_too_low"), call(options: {"limit" => -3})[:content]
+        assert_empty @fleet.fleet_invite_urls
+      end
+
+      test "says so when the server is not bound to a fleet" do
+        assert_equal I18n.t("discord.commands.fleet.not_bound"), call(guild_id: "guild-nope")[:content]
+      end
+
+      test "says so when the command arrives without a guild" do
+        assert_equal I18n.t("discord.commands.fleet.not_bound"), call(guild_id: nil)[:content]
+      end
+
+      test "an unlinked Discord account is told where to link it" do
+        assert_includes call(discord_user_id: "stranger-uid")[:content],
+          I18n.t("discord.commands.account_not_linked", url: "https://#{Rails.configuration.app.domain}/settings/connections")
+        assert_empty @fleet.fleet_invite_urls
+      end
+
+      # The fleet's own privileges decide, not anything Discord says about the
+      # caller.
+      test "a member without the privilege cannot mint a link" do
+        member = create(:user)
+        create(:omniauth_connection, user: member, provider: "discord", uid: "member-uid")
+        @fleet.fleet_memberships
+          .create!(user: member, fleet_role: role_named("Member"))
+          .update!(aasm_state: "accepted")
+
+        assert_equal I18n.t("discord.commands.fleet.invite.not_allowed"), call(discord_user_id: "member-uid")[:content]
+        assert_empty @fleet.fleet_invite_urls
+      end
+
+      test "someone who only shares the Discord server cannot mint a link" do
+        create(:omniauth_connection, user: create(:user), provider: "discord", uid: "guest-uid")
+
+        assert_equal I18n.t("discord.commands.fleet.invite.not_allowed"), call(discord_user_id: "guest-uid")[:content]
+        assert_empty @fleet.fleet_invite_urls
+      end
+
+      # An officer whose membership is not accepted yet has a role, and that role
+      # carries the privilege -- the policy requires the membership to be
+      # accepted, which is the whole reason this goes through the policy.
+      test "an officer whose membership is not accepted cannot mint a link" do
+        @fleet.fleet_memberships.find_by(user_id: @user.id).update!(aasm_state: "requested")
+
+        assert_equal I18n.t("discord.commands.fleet.invite.not_allowed"), call[:content]
+        assert_empty @fleet.fleet_invite_urls
+      end
+
+      test "a discarded membership cannot mint a link" do
+        @fleet.fleet_memberships.find_by(user_id: @user.id).discard
+
+        assert_equal I18n.t("discord.commands.fleet.invite.not_allowed"), call[:content]
+        assert_empty @fleet.fleet_invite_urls
+      end
+
+      test "the command is refused while the flag is off" do
+        Flipper.disable(:discord_fleet_commands)
+
+        assert_equal I18n.t("discord.commands.disabled"), call[:content]
+        assert_empty @fleet.fleet_invite_urls
+      end
+
+      # Visibility is fixed at the acknowledgement; RegistryTest and
+      # DiscordInteractionsTest cover it where Discord actually reads it.
+      test "carries no flags, since a follow-up cannot set them" do
+        assert_nil call[:flags]
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/registry_test.rb
+++ b/test/lib/discord/commands/registry_test.rb
@@ -117,6 +117,12 @@ module Discord
         end
       end
 
+      # The token is the credential: a public answer hands the fleet to everyone
+      # in the channel, guests included.
+      test "an invite link answers privately" do
+        assert Registry.ephemeral?("fleet", "invite"), "/fleet invite would answer in the channel"
+      end
+
       # A "that command no longer exists" belongs to whoever typed it.
       test "an unregistered name answers privately" do
         assert Registry.ephemeral?("definitely-not-a-command")


### PR DESCRIPTION
> **Stacked on #4663** — review that one first. This PR targets `feat/discord-subcommands`, so its diff only shows the invite work.

## What

`/fleet invite [limit] [expires_in]` mints a `FleetInviteUrl` for the fleet bound to the guild and answers with the link — privately, always.

Ephemeral without exception: the token *is* the credential. A public answer hands the fleet to everyone in the channel, guests included.

## Authorization

Through `FleetInviteUrlPolicy#create?` itself, not a second copy of the privilege list. That is also what makes the membership have to be **accepted** and undiscarded — an officer whose own join request is still pending has the role and the privilege but not the membership, and there is a test for exactly that.

Nothing Discord says about the caller is consulted. Manage Roles in a guild does not create `fleet:invites:create` in a fleet.

Applying an action_policy policy outside a controller has no precedent in the tree; `FleetBasePolicy` only needs `user`, and the unsaved record carries `fleet_id`, so `FleetInviteUrlPolicy.new(invite, user:).apply(:create?)` is enough.

## Two things easy to get wrong

**The link is not a membership.** `FleetInviteUrlsController#use` creates the membership and then calls `request!`, so whoever opens the link lands in `requested` and still needs accepting. The answer says so — "they're in" would be a false promise. (Closing that loop from Discord is the last phase in the plan.)

**A limit of `0` is worse than no limit.** It passes `FleetInviteUrl`'s own validation (`>= 0`) and is then excluded by `FleetInviteUrl.active` (`limit > 0 OR limit IS NULL`), so the command would hand out a link that is dead on arrival. `min_value: 1` covers the Discord picker; an explicit guard covers a hand-rolled interaction, since the endpoint is public.

## Flag

New: `discord_fleet_commands`. `discord_commands` is on in production and gates dispatch as a whole; the first path that writes to a fleet from Discord gets a switch of its own. A flagged-off command still appears in the picker and answers the existing "not available yet" message — the difference between "not yet" and "broken".

## Reuse

`FleetContext` now holds the guild → fleet binding and the Discord uid → account lookup that `/fleet` had inline.

## Notes

- `i18n-tasks normalize` was **not** run; it reformats the entire locale tree. Copy added by hand to all seven files.
- Needs `discord:commands:sync` after deploy, and the flag enabled.
- `FleetInviteUrl` has no `paper_trail`, so nothing records that a link was minted from Discord beyond the row's `user_id`. Noted, not addressed here.

## Tests

`256 tests, 557 assertions, 0 failures` across the Discord suite. The invite command has 18 of its own: the four refusal paths (no binding, no account link, no privilege, membership not accepted), the limit guard at 0 and below, the expiry mapping, and the flag being off. 🤖
