### PR TITLE
fix(manufacturers): merge the row the export filed under a second code

### DIFF
--- a/app/services/manufacturers/deduplicator.rb
+++ b/app/services/manufacturers/deduplicator.rb
@@ -10,6 +10,12 @@ module Manufacturers
   # produces those names and the loader no longer creates the rows, but the ones
   # already in the table have to be brought together, and the loader never
   # rewrites `name` so they cannot fix themselves.
+  #
+  # A second kind no grouping can see: the same company under two codes and two
+  # names, where neither the code nor the slug they produce match. The RSI matrix
+  # calls Musashi Industrial & Starflight Concern "MISC" while the export files
+  # it under "MIS", so the two rows share nothing to group on and have to be
+  # named as a pair.
   class Deduplicator
     # Tables carrying `manufacturer_id`. Checked against the schema on the way in
     # so a table added later fails loudly here rather than quietly orphaning its
@@ -18,20 +24,25 @@ module Manufacturers
       Model, Component, ComponentBuild, Equipment, EquipmentBuild, ModelModule
     ].freeze
 
-    Result = Struct.new(:renamed, :dropped, :merged)
+    Result = Struct.new(:renamed, :dropped, :aliased, :merged)
 
-    def initialize(corrections: {}, dropped_codes: [], logger: nil)
+    def initialize(corrections: {}, dropped_codes: [], aliased_codes: {}, logger: nil)
       @corrections = corrections
       @dropped_codes = dropped_codes
+      @aliased_codes = aliased_codes
       @logger = logger
-      @result = Result.new([], [], [])
+      @result = Result.new([], [], [], [])
     end
 
-    # All or nothing. The three phases feed each other -- a correction takes a row
-    # out of a group before the merge looks at it -- so a failure partway through
+    # All or nothing. The phases feed each other -- a correction takes a row out
+    # of a group before the merge looks at it -- so a failure partway through
     # would leave some names corrected, some placeholders gone and some collisions
     # still standing, which is a worse table to recover from than the one we
     # started with. Nothing here is undoable once committed.
+    #
+    # The aliases go before the slug merge so a pair named there is settled while
+    # both rows are still identified by their own code, rather than depending on
+    # which of them a slug group would have left standing.
     #
     # requires_new so it is a savepoint inside a surrounding transaction: #plan
     # wraps it in one to roll the whole thing back, and the tests run in one.
@@ -41,6 +52,7 @@ module Manufacturers
       Manufacturer.transaction(requires_new: true) do
         apply_corrections
         drop_records
+        merge_aliases
         merge_collisions
       end
 
@@ -65,6 +77,7 @@ module Manufacturers
         result = self.class.new(
           corrections: @corrections,
           dropped_codes: @dropped_codes,
+          aliased_codes: @aliased_codes,
           logger: ->(message) { lines << message }
         ).call
 
@@ -74,6 +87,7 @@ module Manufacturers
           orphaned: ASSOCIATED_MODELS.sum { |model| model.where(manufacturer_id: nil).count },
           renamed: result.renamed,
           dropped: result.dropped,
+          aliased: result.aliased,
           merged: result.merged
         }
 
@@ -153,14 +167,80 @@ module Manufacturers
           log "  merging #{loser.name.inspect} code=#{loser.code.inspect} " \
               "(#{self.class.association_count(loser)} records move across)"
 
-          repoint(loser, winner)
-          loser.reload.destroy!
+          absorb(loser, winner)
         end
 
         normalize_name(winner)
 
         @result.merged << slug
       end
+    end
+
+    # The pairs no grouping finds: one company the RSI matrix and the export
+    # spell differently enough that neither the code nor the slug matches --
+    # "MISC" against "MIS", `misc` against `musashi-industrial-starflight-concern`.
+    #
+    # The pair is directed rather than scored, unlike a slug group: the target
+    # code names the row that survives, so the slug the public API and every
+    # saved filter already use stays put. Left to #pick_winner the export row
+    # could take a pair whose curated side happens to carry no rsi_id, and the
+    # manufacturer would change its public identifier as a side effect of a
+    # cleanup.
+    private def merge_aliases
+      @aliased_codes.each do |from_code, to_code|
+        loser = Manufacturer.find_by(code: from_code)
+
+        next if loser.blank?
+
+        winner = Manufacturer.find_by(code: to_code)
+
+        # Reported rather than skipped quietly: a pair pointing at a code the
+        # table does not carry is a stale entry, and the row it names is sitting
+        # there as a duplicate in the meantime.
+        if winner.blank?
+          log "keeping #{from_code}: no row carries #{to_code}"
+          next
+        end
+
+        next if winner == loser
+
+        log "#{from_code} -> #{to_code}: keeping #{winner.name.inspect} " \
+            "(#{self.class.association_count(loser)} records move across)"
+
+        absorb(loser, winner)
+
+        @result.aliased << from_code
+      end
+    end
+
+    private def absorb(loser, winner)
+      adopt_export_identity(loser, winner)
+      repoint(loser, winner)
+      loser.reload.destroy!
+    end
+
+    # The export's half of the identity moves across before the row goes, because
+    # `sc_ref` is what the next sc_data load matches on: a merge that dropped it
+    # would leave the export's record matching nothing, and the very next import
+    # would mint the duplicate again. Everything else the load rebuilds from the
+    # export -- the icon path is written on every run -- but the icon itself is
+    # carried anyway so the manufacturer is not left without a picture until then.
+    #
+    # Only ever fills a blank, the same rule the loader follows: the winner is the
+    # curated row, and what an admin put there outlives the export.
+    private def adopt_export_identity(loser, winner)
+      updates = {}
+      updates[:sc_ref] = loser.sc_ref if winner.sc_ref.blank? && loser.sc_ref.present?
+      updates[:icon_path] = loser.icon_path if winner.icon_path.blank? && loser.icon_path.present?
+
+      winner.update!(updates) if updates.present?
+
+      return if winner.icon.attached? || !loser.icon.attached?
+
+      # Moved rather than re-attached from the same blob: the destroy purges what
+      # the loser still holds, and two attachments sharing one blob would have it
+      # delete the file the winner now points at.
+      loser.icon.attachment.update!(record: winner)
     end
 
     # The surviving row is the curated one, which is not necessarily the one

--- a/app/tasks/maintenance/dedupe_manufacturers_task.rb
+++ b/app/tasks/maintenance/dedupe_manufacturers_task.rb
@@ -24,6 +24,20 @@ module Maintenance
     # nothing in the export references. Dropped only while nothing points at them.
     DROPPED_CODES = %w[TRAS GHEX].freeze
 
+    # One company under two codes, read as `export code => the code that stays`.
+    #
+    # MISC is the row the RSI matrix created in 2014 and every ship hangs off;
+    # MIS is what the export's `scitemmanufacturer` record calls the same
+    # company, and the loader had nothing to match it on -- neither the code nor
+    # the slug "Musashi Industrial & Starflight Concern" produces -- so it minted
+    # a second row for the items. The table already records the pair: MISC
+    # carries `code_mapping` "MIS" and the full name in `long_name`.
+    #
+    # Named here rather than read from that column because the merge destroys
+    # rows: which pairs collapse should be visible in a diff and pinned by a
+    # test, not taken from a field nothing else reads and no admin can see.
+    ALIASED_CODES = {"MIS" => "MISC"}.freeze
+
     # Left on by default so an accidental run reports instead of destroying.
     attribute :dry_run, :boolean, default: true
 
@@ -35,7 +49,7 @@ module Maintenance
       result = deduplicator(logger: method(:log)).call
 
       log "renamed #{result.renamed.size}, dropped #{result.dropped.size}, " \
-          "merged #{result.merged.size} slugs"
+          "aliased #{result.aliased.size}, merged #{result.merged.size} slugs"
     end
 
     private def report_plan
@@ -45,7 +59,7 @@ module Maintenance
 
       log "manufacturers: #{plan[:before]} -> #{plan[:after]}"
       log "renamed #{plan[:renamed].size}, dropped #{plan[:dropped].size}, " \
-          "merged #{plan[:merged].size} slugs"
+          "aliased #{plan[:aliased].size}, merged #{plan[:merged].size} slugs"
       log "records left without a manufacturer: #{plan[:orphaned]}"
       log "dry run -- rolled back, no rows were changed"
     end
@@ -54,6 +68,7 @@ module Maintenance
       ::Manufacturers::Deduplicator.new(
         corrections: CORRECTIONS,
         dropped_codes: DROPPED_CODES,
+        aliased_codes: ALIASED_CODES,
         logger:
       )
     end

--- a/test/services/manufacturers/deduplicator_test.rb
+++ b/test/services/manufacturers/deduplicator_test.rb
@@ -172,6 +172,109 @@ module Manufacturers
       assert_equal [aegis.id], Manufacturer.where(name: "Aegis Dynamics").ids
     end
 
+    # The pair the table cannot group: the RSI matrix calls the company "MISC"
+    # and the export calls it "MIS", so neither the code nor the slug matches and
+    # both the name grouping and the slug grouping walk straight past them.
+    test "#call merges a manufacturer the export filed under a second code" do
+      keep = create(:manufacturer, name: "MISC", code: "MISC", rsi_id: 4)
+      drop = create(:manufacturer, name: "Musashi Industrial & Starflight Concern", code: "MIS")
+      component = create(:component, manufacturer: drop)
+
+      result = ::Manufacturers::Deduplicator.new(aliased_codes: {"MIS" => "MISC"}).call
+
+      assert_nil Manufacturer.find_by(id: drop.id)
+      assert_equal keep, component.reload.manufacturer
+      assert_equal ["MIS"], result.aliased
+    end
+
+    # The pair names the survivor rather than scoring it, so a cleanup cannot
+    # change the slug the public API and every saved filter already use.
+    test "#call keeps the aliased target even when the other row scores better" do
+      keep = create(:manufacturer, name: "MISC", code: "MISC", rsi_id: nil)
+      drop = create(:manufacturer, name: "Musashi Industrial & Starflight Concern",
+        code: "MIS", rsi_id: 4)
+      create_list(:component, 3, manufacturer: drop)
+
+      ::Manufacturers::Deduplicator.new(aliased_codes: {"MIS" => "MISC"}).call
+
+      assert_nil Manufacturer.find_by(code: "MIS")
+      assert_equal "misc", keep.reload.slug
+      assert_equal 3, keep.components.count
+    end
+
+    # `sc_ref` is what the next sc_data load matches on, so a merge that dropped
+    # it would have the very next import mint the duplicate again.
+    test "#call carries the export ref onto the surviving row" do
+      keep = create(:manufacturer, name: "MISC", code: "MISC", sc_ref: nil)
+      create(:manufacturer, name: "Musashi Industrial & Starflight Concern",
+        code: "MIS", sc_ref: "b28a5c61")
+
+      ::Manufacturers::Deduplicator.new(aliased_codes: {"MIS" => "MISC"}).call
+
+      assert_equal "b28a5c61", keep.reload.sc_ref
+    end
+
+    test "#call leaves a ref the surviving row already carries" do
+      keep = create(:manufacturer, name: "MISC", code: "MISC", sc_ref: "curated")
+      create(:manufacturer, name: "Musashi Industrial & Starflight Concern",
+        code: "MIS", sc_ref: "b28a5c61")
+
+      ::Manufacturers::Deduplicator.new(aliased_codes: {"MIS" => "MISC"}).call
+
+      assert_equal "curated", keep.reload.sc_ref
+    end
+
+    # The destroy purges what the loser still holds, so the export art has to
+    # move across before the row goes.
+    test "#call carries the export icon onto the surviving row" do
+      keep = create(:manufacturer, name: "MISC", code: "MISC", icon_path: nil)
+      drop = create(:manufacturer, :with_icon, name: "Musashi Industrial & Starflight Concern",
+        code: "MIS")
+      blob = drop.icon.blob
+
+      ::Manufacturers::Deduplicator.new(aliased_codes: {"MIS" => "MISC"}).call
+
+      assert_equal blob, keep.reload.icon.blob
+      assert_equal drop.icon_path, keep.icon_path
+      assert blob.service.exist?(blob.key), "the file behind the blob was deleted"
+    end
+
+    test "#call leaves an icon the surviving row already carries" do
+      keep = create(:manufacturer, :with_icon, name: "MISC", code: "MISC")
+      curated = keep.icon.blob
+      create(:manufacturer, :with_icon, name: "Musashi Industrial & Starflight Concern",
+        code: "MIS")
+
+      ::Manufacturers::Deduplicator.new(aliased_codes: {"MIS" => "MISC"}).call
+
+      assert_equal curated, keep.reload.icon.blob
+    end
+
+    # A pair pointing at a code the table does not carry is a stale entry, and
+    # the row it names sits there as a duplicate in the meantime.
+    test "#call reports an alias whose target no row carries" do
+      drop = create(:manufacturer, name: "Musashi Industrial & Starflight Concern", code: "MIS")
+      lines = []
+
+      result = ::Manufacturers::Deduplicator.new(
+        aliased_codes: {"MIS" => "MISC"},
+        logger: ->(line) { lines << line }
+      ).call
+
+      assert_equal drop, Manufacturer.find_by(code: "MIS")
+      assert_empty result.aliased
+      assert_includes lines.join("\n"), "no row carries MISC"
+    end
+
+    test "#call leaves the table alone when nothing carries the aliased code" do
+      create(:manufacturer, name: "MISC", code: "MISC")
+
+      result = ::Manufacturers::Deduplicator.new(aliased_codes: {"MIS" => "MISC"}).call
+
+      assert_empty result.aliased
+      assert_equal 1, Manufacturer.count
+    end
+
     # The merge repoints only the tables it is told about, and `dependent:
     # :nullify` on an association nobody declared does nothing -- so a table
     # added later would lose its manufacturer without a word. This is the guard
@@ -267,6 +370,22 @@ module Manufacturers
       # Two, not one: the component's build carries the manufacturer as well,
       # which is exactly why ComponentBuild is in ASSOCIATED_MODELS.
       assert_includes plan[:log].join("\n"), "2 records still point at it"
+    end
+
+    test "#plan reports the alias merge and rolls it back" do
+      create(:manufacturer, name: "MISC", code: "MISC", rsi_id: 4)
+      drop = create(:manufacturer, name: "Musashi Industrial & Starflight Concern", code: "MIS")
+      component = create(:component, manufacturer: drop)
+
+      plan = nil
+
+      assert_no_difference -> { Manufacturer.count } do
+        plan = ::Manufacturers::Deduplicator.new(aliased_codes: {"MIS" => "MISC"}).plan
+      end
+
+      assert_equal ["MIS"], plan[:aliased]
+      assert_equal 1, plan[:after]
+      assert_equal drop, component.reload.manufacturer
     end
 
     test "#plan reports no record left without a manufacturer" do

--- a/test/tasks/maintenance/dedupe_manufacturers_task_test.rb
+++ b/test/tasks/maintenance/dedupe_manufacturers_task_test.rb
@@ -69,6 +69,30 @@ module Maintenance
       assert_nil Manufacturer.find_by(code: "TRAS")
     end
 
+    test "#process merges the row the export filed under a second code" do
+      keep = create(:manufacturer, name: "MISC", code: "MISC", rsi_id: 4, sc_ref: nil)
+      drop = create(:manufacturer, name: "Musashi Industrial & Starflight Concern",
+        code: "MIS", sc_ref: "b28a5c61")
+      component = create(:component, manufacturer: drop)
+
+      run_task(dry_run: false)
+
+      assert_nil Manufacturer.find_by(code: "MIS")
+      assert_equal keep, component.reload.manufacturer
+      assert_equal "b28a5c61", keep.reload.sc_ref
+    end
+
+    test "#process reports the alias merge on a dry run" do
+      create(:manufacturer, name: "MISC", code: "MISC", rsi_id: 4)
+      create(:manufacturer, name: "Musashi Industrial & Starflight Concern", code: "MIS")
+
+      output = run_task(dry_run: true)
+
+      assert_includes output, "MIS -> MISC"
+      assert_includes output, "manufacturers: 2 -> 1"
+      assert_includes output, "dry run"
+    end
+
     # The corrections have to match the overrides the parser applies, or a fresh
     # import and a cleaned table would disagree about what a code is called.
     test "the corrections agree with the shipped parser overrides" do


### PR DESCRIPTION
## Was

`manufacturers` führt Musashi Industrial & Starflight Concern zweimal:

| | `MISC` | `MIS` |
|---|---|---|
| name | `MISC` | `Musashi Industrial & Starflight Concern` |
| slug | `misc` | `musashi-industrial-starflight-concern` |
| angelegt | 2014-10-04 | 2026-04-03 |
| `sc_ref` | – | `b28a5c61-…` |
| hängt dran | 23 Models, 93 Components, 9 Modules | 265 Components |

`MISC` ist die Zeile aus der RSI-Ship-Matrix, an der alle Schiffe hängen. `MIS` hat der sc_data-Manufacturers-Loader aus dem Game-Export angelegt: dort lautet der `Code` im `scitemmanufacturer`-Record `MIS`. Der Loader sucht nach `sc_ref`, dann `code`, dann `slug` — alle drei gehen ins Leere, also wurde eine zweite Zeile für die Items angelegt.

Der `Deduplicator` findet das Paar nicht: er gruppiert nach Slug, und die beiden teilen weder Code noch Slug.

## Wie

**`ALIASED_CODES = {"MIS" => "MISC"}`** im Maintenance-Task, neben `CORRECTIONS` und `DROPPED_CODES`.

Die Alternative wäre die `code_mapping`-Spalte gewesen — sie hält in der ganzen Tabelle genau diesen einen Wert (`MISC` → `MIS`) und wurde 2023 offenbar dafür angelegt. Dagegen: sie ist weder im Admin-Input-Schema noch sonstwo im Code lesbar. Welche Zeilen ein Merge zerstört, sollte im Diff stehen und per Test festgenagelt sein, nicht aus einem Feld kommen, das niemand sieht. Der Kommentar an der Konstante nennt die Spalte als Beleg.

Zwei Details, die nicht offensichtlich sind:

- **Gerichtet statt bewertet.** Anders als eine Slug-Gruppe entscheidet hier nicht `pick_winner`, sondern das Paar benennt den Überlebenden. Sonst könnte die Export-Zeile ein Paar gewinnen, dessen kuratierte Seite kein `rsi_id` trägt — und der öffentliche Slug würde als Nebenwirkung eines Cleanups kippen.
- **`sc_ref` wandert mit** (in beiden Merge-Pfaden, nicht nur im neuen). Das ist der Punkt, der den Merge überhaupt haltbar macht: `sc_ref` ist das, worauf der `ManufacturersLoader` zuerst matcht. Ohne Übernahme hätte der nächste sc_data-Import die MIS-Zeile sofort neu angelegt. Dasselbe Loch gab es latent auch im bestehenden Slug-Merge.

Das Icon wandert als Attachment-Umhängung statt Re-Attach auf denselben Blob — sonst löscht `loser.destroy!` die Datei, auf die der Gewinner gerade gezeigt wurde. Das kuratierte `logo` von MISC bleibt unangetastet.

## Verifikation

Dry Run gegen einen Produktions-Dump:

```
MIS -> MISC: keeping "MISC" (785 records move across)
manufacturers: 137 -> 136
renamed 0, dropped 0, aliased 1, merged 0 slugs
records left without a manufacturer: 12966
```

Die 12966 sind der unveränderte Ausgangsstand — separat nachgezählt, der Merge verwaist nichts.

Ergebniszeile nach einem zurückgerollten Echtlauf:

```
name: "MISC", slug: "misc", long_name: "Musashi Industrial & Starflight Concern",
sc_ref: "b28a5c61-…", icon_path: "…/misc_256.tif", icon: "misc_256.png",
logo: "MISC-a998da99-….png", models: 23, components: 358, modules: 9, mis_left: false
```

39 Tests grün in `deduplicator_test.rb` + `dedupe_manufacturers_task_test.rb`, Rubocop sauber.

## Nach dem Merge

Der Task läuft nicht automatisch — bewusst, er zerstört Zeilen. Auf Produktion einmal mit `dry_run` fahren, dann scharf.

Danach geht `/components?manufacturer=musashi-industrial-starflight-concern` ins Leere; für Manufacturer gibt es keinen Slug-Redirect. `misc` bleibt.

🤖
