### PR TITLE
feat(discord): list a fleet's members and join requests from Discord

### DIFF
--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -23,6 +23,14 @@ de:
           limit_too_low: Ein Einladungslink braucht mindestens eine Verwendung.
           needs_approval: Wer ihn öffnet, stellt eine Beitrittsanfrage — die muss noch bestätigt werden.
           not_allowed: Du darfst für diese Flotte keine Einladungslinks erstellen.
+        members:
+          empty: Diese Flotte hat noch keine bestätigten Mitglieder.
+          heading: '[Mitglieder von %{fleet}](%{url}) — %{count}'
+          more: '…und %{count} weitere.'
+          no_requests: Derzeit wartet niemand auf Aufnahme.
+          not_allowed: Du darfst die Mitglieder dieser Flotte nicht sehen.
+          requests_heading: '[Beitrittsanfragen für %{fleet}](%{url}) — %{count}'
+          waiting: 'wartet seit %{time}'
         not_allowed: '%{fleet} hat seine Seite nicht öffentlich gemacht.'
         not_bound: Dieser Server ist mit keiner Flotte auf Fleetyards verknüpft.
       hangar:

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -23,6 +23,14 @@ en:
           limit_too_low: An invite link needs at least one use.
           needs_approval: Whoever opens it asks to join — the request still needs accepting.
           not_allowed: You are not allowed to create invite links for this fleet.
+        members:
+          empty: This fleet has no accepted members yet.
+          heading: '[%{fleet} members](%{url}) — %{count}'
+          more: '…and %{count} more.'
+          no_requests: No one is waiting to join right now.
+          not_allowed: 'You are not allowed to see this fleet''s members.'
+          requests_heading: '[%{fleet} join requests](%{url}) — %{count}'
+          waiting: 'waiting %{time}'
         not_allowed: '%{fleet} has not made its page public.'
         not_bound: This server is not linked to a fleet on Fleetyards.
       hangar:

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -23,6 +23,14 @@ es:
           limit_too_low: Un enlace de invitación necesita al menos un uso.
           needs_approval: Quien lo abra solicitará unirse — la solicitud aún debe aceptarse.
           not_allowed: No tienes permiso para crear enlaces de invitación para esta flota.
+        members:
+          empty: Esta flota todavía no tiene miembros aceptados.
+          heading: '[Miembros de %{fleet}](%{url}) — %{count}'
+          more: '…y %{count} más.'
+          no_requests: Ahora mismo no hay nadie esperando para unirse.
+          not_allowed: No tienes permiso para ver los miembros de esta flota.
+          requests_heading: '[Solicitudes para %{fleet}](%{url}) — %{count}'
+          waiting: 'esperando %{time}'
         not_allowed: '%{fleet} no ha hecho pública su página.'
         not_bound: Este servidor no está vinculado a ninguna flota en Fleetyards.
       hangar:

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -23,6 +23,14 @@ fr:
           limit_too_low: 'Un lien d''invitation nécessite au moins une utilisation.'
           needs_approval: 'Celui qui l''ouvre demande à rejoindre — la demande doit encore être acceptée.'
           not_allowed: 'Tu n''as pas le droit de créer des liens d''invitation pour cette flotte.'
+        members:
+          empty: 'Cette flotte n''a encore aucun membre accepté.'
+          heading: '[Membres de %{fleet}](%{url}) — %{count}'
+          more: '…et %{count} de plus.'
+          no_requests: 'Personne n''attend d''être accepté pour le moment.'
+          not_allowed: 'Tu n''as pas le droit de voir les membres de cette flotte.'
+          requests_heading: '[Demandes pour %{fleet}](%{url}) — %{count}'
+          waiting: 'en attente depuis %{time}'
         not_allowed: "%{fleet} n'a pas rendu sa page publique."
         not_bound: "Ce serveur n'est lié à aucune flotte sur Fleetyards."
       hangar:

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -23,6 +23,14 @@ it:
           limit_too_low: Un link di invito richiede almeno un utilizzo.
           needs_approval: Chi lo apre chiede di entrare — la richiesta deve ancora essere accettata.
           not_allowed: Non puoi creare link di invito per questa flotta.
+        members:
+          empty: Questa flotta non ha ancora membri accettati.
+          heading: '[Membri di %{fleet}](%{url}) — %{count}'
+          more: '…e altri %{count}.'
+          no_requests: Al momento nessuno è in attesa di entrare.
+          not_allowed: Non puoi vedere i membri di questa flotta.
+          requests_heading: '[Richieste per %{fleet}](%{url}) — %{count}'
+          waiting: 'in attesa da %{time}'
         not_allowed: '%{fleet} non ha reso pubblica la propria pagina.'
         not_bound: Questo server non è collegato a nessuna flotta su Fleetyards.
       hangar:

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -23,6 +23,14 @@ zh-CN:
           limit_too_low: 邀请链接至少需要一次使用次数。
           needs_approval: 打开链接的人会提交加入申请 — 申请仍需批准。
           not_allowed: 你没有为这支舰队创建邀请链接的权限。
+        members:
+          empty: 这支舰队还没有已接受的成员。
+          heading: '[%{fleet} 成员](%{url}) — %{count}'
+          more: '…还有 %{count} 位。'
+          no_requests: 目前没有人在等待加入。
+          not_allowed: 你没有查看这支舰队成员的权限。
+          requests_heading: '[%{fleet} 加入申请](%{url}) — %{count}'
+          waiting: '已等待 %{time}'
         not_allowed: '%{fleet} 未公开其页面。'
         not_bound: 此服务器尚未与 Fleetyards 上的舰队关联。
       hangar:

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -23,6 +23,14 @@ zh-TW:
           limit_too_low: 邀請連結至少需要一次使用次數。
           needs_approval: 開啟連結的人會送出加入申請 — 申請仍需核准。
           not_allowed: 你沒有為這支艦隊建立邀請連結的權限。
+        members:
+          empty: 這支艦隊還沒有已接受的成員。
+          heading: '[%{fleet} 成員](%{url}) — %{count}'
+          more: '…還有 %{count} 位。'
+          no_requests: 目前沒有人在等待加入。
+          not_allowed: 你沒有查看這支艦隊成員的權限。
+          requests_heading: '[%{fleet} 加入申請](%{url}) — %{count}'
+          waiting: '已等待 %{time}'
         not_allowed: '%{fleet} 未公開其頁面。'
         not_bound: 此伺服器尚未與 Fleetyards 上的艦隊連結。
       hangar:

--- a/lib/discord/commands/fleet_members.rb
+++ b/lib/discord/commands/fleet_members.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Discord
+  module Commands
+    # The fleet's roster, or the join requests waiting on someone.
+    #
+    # Always ephemeral: a roster is usernames and RSI handles, which is personal
+    # data whatever the fleet's public flag says, and the guild it was typed in
+    # may have guests.
+    class FleetMembers < Base
+      include FleetContext
+      include ActionView::Helpers::DateHelper
+
+      MAX_MEMBERS = 10
+
+      PENDING = "pending"
+
+      def call
+        fleet = guild_fleet
+        return message(content: I18n.t("discord.commands.fleet.not_bound")) if fleet.nil?
+
+        user = linked_user
+        return message(content: account_not_linked) if user.nil?
+        return message(content: I18n.t("discord.commands.fleet.members.not_allowed")) unless allowed?(fleet, user)
+
+        memberships = memberships_for(fleet)
+        return message(content: I18n.t("discord.commands.fleet.members.#{empty_key}")) if memberships.empty?
+
+        message(content: content_for(fleet, memberships))
+      end
+
+      # The same policy the members endpoint authorizes against, so there is one
+      # definition of who may read a roster. It requires an accepted,
+      # undiscarded membership.
+      private def allowed?(fleet, user)
+        ::FleetMembershipPolicy.new(fleet, user: user).apply(:index?)
+      end
+
+      private def pending?
+        option("filter").to_s == PENDING
+      end
+
+      private def empty_key
+        pending? ? "no_requests" : "empty"
+      end
+
+      # The pending list is a queue, so it reads oldest first -- that is the
+      # order someone works through it. The roster is a list to find a name in,
+      # so it reads alphabetically.
+      private def memberships_for(fleet)
+        scope = fleet.fleet_memberships.kept.includes(:user, :fleet_role)
+
+        if pending?
+          scope.where(aasm_state: "requested").order(requested_at: :asc)
+        else
+          scope.where(aasm_state: "accepted").joins(:user).order("users.username asc")
+        end
+      end
+
+      private def content_for(fleet, memberships)
+        shown = memberships.first(MAX_MEMBERS)
+        omitted = memberships.size - shown.size
+
+        [
+          heading(fleet, memberships.size),
+          shown.map { |membership| line_for(membership) }.join("\n"),
+          (I18n.t("discord.commands.fleet.members.more", count: omitted) if omitted.positive?)
+        ].compact.join("\n")
+      end
+
+      private def heading(fleet, count)
+        I18n.t("discord.commands.fleet.members.#{pending? ? "requests_heading" : "heading"}",
+          fleet: fleet.name,
+          url: url_for_path("/fleets/#{fleet.slug}/members/"),
+          count: count)
+      end
+
+      # A pending line answers "how long has this been waiting"; a roster line
+      # answers "what can this person do". Neither carries the other's noise.
+      private def line_for(membership)
+        if pending?
+          "• #{membership.user.username}#{waiting_since(membership)}"
+        else
+          "• #{membership.user.username}#{role_of(membership)}"
+        end
+      end
+
+      private def role_of(membership)
+        name = membership.fleet_role&.name
+        return "" if name.blank?
+
+        " — #{name}"
+      end
+
+      private def waiting_since(membership)
+        return "" if membership.requested_at.blank?
+
+        " — #{I18n.t("discord.commands.fleet.members.waiting", time: time_ago(membership.requested_at))}"
+      end
+
+      private def time_ago(time)
+        distance_of_time_in_words(Time.zone.now, time)
+      end
+    end
+  end
+end

--- a/lib/discord/commands/registry.rb
+++ b/lib/discord/commands/registry.rb
@@ -136,6 +136,25 @@ module Discord
                   ]
                 }
               ]
+            },
+            {
+              name: "members",
+              description: "List this server's fleet members, only to you",
+              type: SUB_COMMAND,
+              handler: "Discord::Commands::FleetMembers",
+              ephemeral: true,
+              options: [
+                {
+                  name: "filter",
+                  description: "Which members to list",
+                  type: STRING,
+                  required: false,
+                  choices: [
+                    {name: "Members", value: "all"},
+                    {name: "Pending requests", value: "pending"}
+                  ]
+                }
+              ]
             }
           ]
         },

--- a/test/lib/discord/commands/fleet_members_test.rb
+++ b/test/lib/discord/commands/fleet_members_test.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/fleet_members"
+
+module Discord
+  module Commands
+    class FleetMembersTest < ActiveSupport::TestCase
+      setup do
+        @fleet = create(:fleet, :private, name: "Test Wing")
+        @fleet.create_fleet_notification_setting!(discord_guild_id: "guild-1")
+
+        @officer = create(:user, username: "Aendrax")
+        create(:omniauth_connection, user: @officer, provider: "discord", uid: "officer-uid")
+        accept(@officer, "Officer")
+      end
+
+      def role_named(name)
+        @fleet.fleet_roles.find_by(name: name)
+      end
+
+      def accept(user, role = "Member")
+        @fleet.fleet_memberships
+          .create!(user: user, fleet_role: role_named(role))
+          .tap { |membership| membership.update!(aasm_state: "accepted") }
+      end
+
+      def request(user, requested_at: Time.zone.now)
+        @fleet.fleet_memberships
+          .create!(user: user, fleet_role: role_named("Member"))
+          .tap { |membership| membership.update!(aasm_state: "requested", requested_at: requested_at) }
+      end
+
+      def call(guild_id: "guild-1", discord_user_id: "officer-uid", options: {})
+        ::Discord::Commands::FleetMembers.new(
+          guild_id: guild_id,
+          discord_user_id: discord_user_id,
+          options: options
+        ).call
+      end
+
+      test "lists the accepted members" do
+        accept(create(:user, username: "Bravo"))
+
+        content = call[:content]
+
+        assert_includes content, "Aendrax"
+        assert_includes content, "Bravo"
+      end
+
+      test "names each member's role" do
+        assert_includes call[:content], "Officer"
+      end
+
+      test "reads alphabetically, so a name can be found" do
+        accept(create(:user, username: "Zulu"))
+        accept(create(:user, username: "Bravo"))
+
+        content = call[:content]
+
+        assert_operator content.index("Aendrax"), :<, content.index("Bravo")
+        assert_operator content.index("Bravo"), :<, content.index("Zulu")
+      end
+
+      test "links the fleet's member page" do
+        assert_includes call[:content], "/fleets/#{@fleet.slug}/members/"
+      end
+
+      test "a pending request is not in the roster" do
+        request(create(:user, username: "Waiting"))
+
+        assert_not_includes call[:content], "Waiting"
+      end
+
+      test "a discarded membership is not in the roster" do
+        accept(create(:user, username: "Gone")).discard
+
+        assert_not_includes call[:content], "Gone"
+      end
+
+      test "the pending filter lists the join requests" do
+        request(create(:user, username: "Waiting"))
+
+        content = call(options: {"filter" => "pending"})[:content]
+
+        assert_includes content, "Waiting"
+        assert_not_includes content, "Aendrax"
+      end
+
+      # The queue is worked through oldest first, so that is how it reads.
+      test "the pending list reads oldest first" do
+        request(create(:user, username: "Newer"), requested_at: 1.hour.ago)
+        request(create(:user, username: "Older"), requested_at: 3.days.ago)
+
+        content = call(options: {"filter" => "pending"})[:content]
+
+        assert_operator content.index("Older"), :<, content.index("Newer")
+      end
+
+      test "the pending list says how long each request has waited" do
+        request(create(:user, username: "Waiting"), requested_at: 3.days.ago)
+
+        assert_includes call(options: {"filter" => "pending"})[:content],
+          I18n.t("discord.commands.fleet.members.waiting", time: "3 days")
+      end
+
+      test "an empty queue says so rather than showing an empty list" do
+        assert_equal I18n.t("discord.commands.fleet.members.no_requests"),
+          call(options: {"filter" => "pending"})[:content]
+      end
+
+      test "says so when the server is not bound to a fleet" do
+        assert_equal I18n.t("discord.commands.fleet.not_bound"), call(guild_id: "guild-nope")[:content]
+      end
+
+      test "an unlinked Discord account is told where to link it" do
+        assert_includes call(discord_user_id: "stranger-uid")[:content],
+          I18n.t("discord.commands.account_not_linked", url: "https://#{Rails.configuration.app.domain}/settings/connections")
+      end
+
+      # A roster is personal data, so the fleet's own privilege decides -- not
+      # the fact that someone is in the Discord server.
+      test "a member without the read privilege cannot see the roster" do
+        stripped = role_named("Member")
+        stripped.update!(resource_access: [])
+
+        member = create(:user, username: "Plain")
+        create(:omniauth_connection, user: member, provider: "discord", uid: "member-uid")
+        accept(member, "Member")
+
+        assert_equal I18n.t("discord.commands.fleet.members.not_allowed"),
+          call(discord_user_id: "member-uid")[:content]
+      end
+
+      test "someone who only shares the Discord server cannot see the roster" do
+        create(:omniauth_connection, user: create(:user), provider: "discord", uid: "guest-uid")
+
+        assert_equal I18n.t("discord.commands.fleet.members.not_allowed"),
+          call(discord_user_id: "guest-uid")[:content]
+      end
+
+      test "an officer whose membership is not accepted cannot see the roster" do
+        @fleet.fleet_memberships.find_by(user_id: @officer.id).update!(aasm_state: "requested")
+
+        assert_equal I18n.t("discord.commands.fleet.members.not_allowed"), call[:content]
+      end
+
+      test "caps a long roster and says how many were left out" do
+        # The officer from the setup is already on the roster, so the overflow is
+        # counted from the total rather than from the number added here.
+        added = ::Discord::Commands::FleetMembers::MAX_MEMBERS + 2
+        added.times { |i| accept(create(:user, username: "Member#{i.to_s.rjust(2, "0")}")) }
+        omitted = added + 1 - ::Discord::Commands::FleetMembers::MAX_MEMBERS
+
+        assert_includes call[:content], I18n.t("discord.commands.fleet.members.more", count: omitted)
+      end
+
+      test "carries no flags, since a follow-up cannot set them" do
+        assert_nil call[:flags]
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/registry_test.rb
+++ b/test/lib/discord/commands/registry_test.rb
@@ -123,6 +123,12 @@ module Discord
         assert Registry.ephemeral?("fleet", "invite"), "/fleet invite would answer in the channel"
       end
 
+      # A roster is usernames and RSI handles, and the guild it was typed in may
+      # have guests.
+      test "the member list answers privately" do
+        assert Registry.ephemeral?("fleet", "members"), "/fleet members would answer in the channel"
+      end
+
       # A "that command no longer exists" belongs to whoever typed it.
       test "an unregistered name answers privately" do
         assert Registry.ephemeral?("definitely-not-a-command")


### PR DESCRIPTION
> **Stacked on #4665** (which is stacked on #4663). This PR targets `feat/discord-fleet-invite`, so its diff only shows the member list.

## What

`/fleet members [filter]` — the roster, or with `filter: pending`, the queue of join requests waiting on someone.

Always ephemeral. A roster is usernames and RSI handles, which is personal data whatever the fleet's public flag says, and the guild it was typed in may have guests — the same reason `/fleet info` refuses non-members.

## Authorization

`FleetMembershipPolicy#index?`, the policy the members endpoint already authorizes against. One definition of who may read a roster, and it is what makes the membership have to be accepted and undiscarded. There are tests for a member whose role has no read privilege, for a guest who only shares the Discord server, and for an officer whose own membership is still `requested`.

## Ordering is per list, not uniform

The two lists are used differently, so they are sorted differently:

- **Pending** reads oldest first. It is a queue, and that is the order someone works through it. Each line says how long the request has waited.
- **Roster** reads alphabetically. It is a list to find a name in. Each line carries the member's role.

`FleetMembership::DEFAULT_SORTING_PARAMS` (`created_at desc`) is what the API list uses for pagination; neither of those is what either of these lists is for.

An empty queue answers "no one is waiting" rather than an empty list — the two read very differently to whoever asked.

## Notes

- Read-only, so no feature flag: `discord_fleet_commands` gates the paths that write.
- `i18n-tasks normalize` was **not** run. Copy added by hand to all seven files.
- Needs `discord:commands:sync` after deploy.

## Tests

`274 tests, 605 assertions, 0 failures` across the Discord suite; 17 for this command. 🤖
