### PR TITLE
feat(discord): list a fleet's upcoming events from Discord

### DIFF
--- a/config/locales/de/discord.yml
+++ b/config/locales/de/discord.yml
@@ -15,6 +15,10 @@ de:
           models: Schiffstypen
           ships: Schiffe
           upcoming_events: Kommende Events
+        events:
+          heading: '[Kommende Events von %{fleet}](%{url})'
+          none: In den nächsten 90 Tagen steht nichts an.
+          not_allowed: Du darfst die Events dieser Flotte nicht sehen.
         invite:
           expires: 'läuft in %{time} ab'
           failed: Der Einladungslink konnte nicht erstellt werden. Bitte versuche es erneut.
@@ -66,9 +70,10 @@ de:
         not_found: 'Kein Schiff für „%{query}“ gefunden.'
     direct_message:
       footer: Gesendet, weil du Discord-Benachrichtigungen auf Fleetyards aktiviert hast
-    event_reminder:
+    event_availability:
       signups: '%{count} Anmeldungen'
       slots: '%{open} von %{total} Plätzen frei'
+    event_reminder:
       starting_now: Beginnt jetzt
       starts_in: 'Beginnt in %{count} Min.'
       title: 'Erinnerung: %{title}'

--- a/config/locales/en/discord.yml
+++ b/config/locales/en/discord.yml
@@ -15,6 +15,10 @@ en:
           models: Ship types
           ships: Ships
           upcoming_events: Upcoming events
+        events:
+          heading: '[Upcoming in %{fleet}](%{url})'
+          none: Nothing is coming up in the next 90 days.
+          not_allowed: 'You are not allowed to see this fleet''s events.'
         invite:
           expires: 'expires in %{time}'
           failed: The invite link could not be created. Please try again.
@@ -66,9 +70,10 @@ en:
         not_found: 'No ship found for "%{query}".'
     direct_message:
       footer: Sent because you enabled Discord notifications on Fleetyards
-    event_reminder:
+    event_availability:
       signups: '%{count} signed up'
       slots: '%{open} of %{total} slots open'
+    event_reminder:
       starting_now: Starting now
       starts_in: 'Starts in %{count} min'
       title: 'Reminder: %{title}'

--- a/config/locales/es/discord.yml
+++ b/config/locales/es/discord.yml
@@ -15,6 +15,10 @@ es:
           models: Tipos de nave
           ships: Naves
           upcoming_events: Próximos eventos
+        events:
+          heading: '[Próximos eventos de %{fleet}](%{url})'
+          none: No hay nada previsto en los próximos 90 días.
+          not_allowed: No tienes permiso para ver los eventos de esta flota.
         invite:
           expires: 'caduca en %{time}'
           failed: No se pudo crear el enlace de invitación. Inténtalo de nuevo.
@@ -66,9 +70,10 @@ es:
         not_found: 'No se ha encontrado ninguna nave para «%{query}».'
     direct_message:
       footer: Enviado porque has activado las notificaciones de Discord en Fleetyards
-    event_reminder:
+    event_availability:
       signups: '%{count} inscritos'
       slots: '%{open} de %{total} plazas libres'
+    event_reminder:
       starting_now: Empieza ahora
       starts_in: 'Empieza en %{count} min'
       title: 'Recordatorio: %{title}'

--- a/config/locales/fr/discord.yml
+++ b/config/locales/fr/discord.yml
@@ -15,6 +15,10 @@ fr:
           models: Types de vaisseau
           ships: Vaisseaux
           upcoming_events: Événements à venir
+        events:
+          heading: '[À venir dans %{fleet}](%{url})'
+          none: 'Rien n''est prévu dans les 90 prochains jours.'
+          not_allowed: 'Tu n''as pas le droit de voir les événements de cette flotte.'
         invite:
           expires: 'expire dans %{time}'
           failed: 'Le lien d''invitation n''a pas pu être créé. Réessaie.'
@@ -66,9 +70,10 @@ fr:
         not_found: 'Aucun vaisseau trouvé pour « %{query} ».'
     direct_message:
       footer: Envoyé parce que vous avez activé les notifications Discord sur Fleetyards
-    event_reminder:
+    event_availability:
       signups: '%{count} inscrits'
       slots: '%{open} places libres sur %{total}'
+    event_reminder:
       starting_now: Commence maintenant
       starts_in: 'Commence dans %{count} min'
       title: 'Rappel : %{title}'

--- a/config/locales/it/discord.yml
+++ b/config/locales/it/discord.yml
@@ -15,6 +15,10 @@ it:
           models: Tipi di nave
           ships: Navi
           upcoming_events: Prossimi eventi
+        events:
+          heading: '[Prossimi eventi di %{fleet}](%{url})'
+          none: 'Non c''è nulla in programma nei prossimi 90 giorni.'
+          not_allowed: Non puoi vedere gli eventi di questa flotta.
         invite:
           expires: 'scade tra %{time}'
           failed: Non è stato possibile creare il link di invito. Riprova.
@@ -66,9 +70,10 @@ it:
         not_found: 'Nessuna nave trovata per «%{query}».'
     direct_message:
       footer: Inviato perché hai attivato le notifiche Discord su Fleetyards
-    event_reminder:
+    event_availability:
       signups: '%{count} iscritti'
       slots: '%{open} di %{total} posti liberi'
+    event_reminder:
       starting_now: Inizia ora
       starts_in: 'Inizia tra %{count} min'
       title: 'Promemoria: %{title}'

--- a/config/locales/zh-CN/discord.yml
+++ b/config/locales/zh-CN/discord.yml
@@ -15,6 +15,10 @@ zh-CN:
           models: 飞船类型
           ships: 飞船
           upcoming_events: 即将开始的活动
+        events:
+          heading: '[%{fleet} 即将举行](%{url})'
+          none: 未来 90 天内没有安排。
+          not_allowed: 你没有查看这支舰队活动的权限。
         invite:
           expires: '%{time}后过期'
           failed: 无法创建邀请链接，请重试。
@@ -66,9 +70,10 @@ zh-CN:
         not_found: '未找到与“%{query}”匹配的飞船。'
     direct_message:
       footer: 因为你在 Fleetyards 上启用了 Discord 通知
-    event_reminder:
+    event_availability:
       signups: '%{count} 人已报名'
       slots: '%{total} 个位置中还有 %{open} 个空缺'
+    event_reminder:
       starting_now: 即将开始
       starts_in: '%{count} 分钟后开始'
       title: '提醒：%{title}'

--- a/config/locales/zh-TW/discord.yml
+++ b/config/locales/zh-TW/discord.yml
@@ -15,6 +15,10 @@ zh-TW:
           models: 船艦類型
           ships: 船艦
           upcoming_events: 即將開始的活動
+        events:
+          heading: '[%{fleet} 即將舉行](%{url})'
+          none: 未來 90 天內沒有安排。
+          not_allowed: 你沒有查看這支艦隊活動的權限。
         invite:
           expires: '%{time}後過期'
           failed: 無法建立邀請連結，請重試。
@@ -66,9 +70,10 @@ zh-TW:
         not_found: '找不到符合「%{query}」的船艦。'
     direct_message:
       footer: 因為你在 Fleetyards 上啟用了 Discord 通知
-    event_reminder:
+    event_availability:
       signups: '%{count} 人已報名'
       slots: '%{total} 個位置中還有 %{open} 個空缺'
+    event_reminder:
       starting_now: 即將開始
       starts_in: '%{count} 分鐘後開始'
       title: '提醒：%{title}'

--- a/lib/discord/commands/fleet_events.rb
+++ b/lib/discord/commands/fleet_events.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "discord/event_availability"
+
+module Discord
+  module Commands
+    # What is coming up in the guild's fleet.
+    #
+    # Ephemeral, which is not obvious for a list: `fleet:events:read` is a
+    # *member* default privilege, so the schedule is internal data -- and a guild
+    # can have guests, the same reason /fleet info refuses non-members. Posting
+    # it in the channel would hand it to exactly the people the privilege
+    # excludes.
+    class FleetEvents < Base
+      include FleetContext
+
+      MAX_EVENTS = 5
+
+      # Far enough to cover a monthly series, without expanding a daily one
+      # forever to find five entries.
+      LOOKAHEAD = 90.days
+
+      # A draft is a work in progress; listing it in Discord publishes it in
+      # every sense that matters. Cancelled and completed are not "upcoming".
+      LISTED_STATUSES = %w[open locked active].freeze
+
+      def call
+        fleet = guild_fleet
+        return message(content: I18n.t("discord.commands.fleet.not_bound")) if fleet.nil?
+
+        user = linked_user
+        return message(content: account_not_linked) if user.nil?
+        return message(content: I18n.t("discord.commands.fleet.events.not_allowed")) unless allowed?(fleet, user)
+
+        occurrences = upcoming(fleet)
+        return message(content: I18n.t("discord.commands.fleet.events.none")) if occurrences.empty?
+
+        message(content: content_for(fleet, occurrences))
+      end
+
+      # The same policy the events endpoint authorizes against; it requires an
+      # accepted, undiscarded membership.
+      private def allowed?(fleet, user)
+        ::FleetEventPolicy.new(fleet, user: user).apply(:index?)
+      end
+
+      # The list is of *occurrences*, not of series rows: a weekly op would
+      # otherwise appear once, on the date the series started.
+      #
+      # `starting_after` is what makes the pre-filter safe -- a recurring row
+      # whose starts_at is long past still has occurrences ahead of it, so
+      # filtering on starts_at would drop it along with all of them.
+      private def upcoming(fleet)
+        from = Time.current
+        to = from + LOOKAHEAD
+
+        fleet.fleet_events
+          .active_status
+          .starting_after(from)
+          .where(status: LISTED_STATUSES)
+          .flat_map { |event| occurrences_of(event, from, to) }
+          .compact
+          .sort_by { |occurrence| occurrence[:starts_at] }
+          .first(MAX_EVENTS)
+      end
+
+      private def occurrences_of(event, from, to)
+        event.occurrences(from: from, to: to).first(MAX_EVENTS).map do |time|
+          date = event.recurring? ? time.to_date : nil
+          availability = ::Discord::EventAvailability.new(event, occurrence_date: date)
+
+          # A cancelled occurrence of a live series is not upcoming, and only the
+          # overlay row knows about it.
+          next nil if availability.cancelled?
+
+          {event: event, starts_at: availability.starts_at, title: availability.title, availability: availability.label}
+        end
+      end
+
+      private def content_for(fleet, occurrences)
+        [
+          I18n.t("discord.commands.fleet.events.heading",
+            fleet: fleet.name,
+            url: url_for_path("/fleets/#{fleet.slug}/events/")),
+          occurrences.map { |occurrence| line_for(occurrence) }.join("\n")
+        ].join("\n")
+      end
+
+      # Discord renders <t:unix:f> in the reader's own timezone, which is the
+      # only correct answer for a fleet whose members are spread across several.
+      private def line_for(occurrence)
+        [
+          "• [#{occurrence[:title]}](#{event_url(occurrence[:event])})",
+          "<t:#{occurrence[:starts_at].to_i}:f>",
+          occurrence[:availability]
+        ].compact_blank.join(" — ")
+      end
+
+      private def event_url(event)
+        url_for_path("/fleets/#{event.fleet.slug}/events/#{event.slug}/")
+      end
+    end
+  end
+end

--- a/lib/discord/commands/registry.rb
+++ b/lib/discord/commands/registry.rb
@@ -155,6 +155,14 @@ module Discord
                   ]
                 }
               ]
+            },
+            {
+              name: "events",
+              description: "List this server's fleet events, only to you",
+              type: SUB_COMMAND,
+              handler: "Discord::Commands::FleetEvents",
+              ephemeral: true,
+              options: []
             }
           ]
         },

--- a/lib/discord/event_availability.rb
+++ b/lib/discord/event_availability.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Discord
+  # What Fleetyards knows about an event that Discord does not: how much room is
+  # left in it, and -- for one occurrence of a recurring series -- which title
+  # and which start time actually apply.
+  #
+  # Shared by the reminder and the event list on purpose. A bot that disagrees
+  # with its own reminder about how many slots are open is a bug report nobody
+  # can reproduce.
+  class EventAvailability
+    def initialize(event, occurrence_date: nil)
+      @event = event
+      @occurrence_date = occurrence_date
+    end
+
+    # An occurrence may override the series title; nil means inherit.
+    def title
+      state&.title.presence || @event.title
+    end
+
+    def starts_at
+      return @event.starts_at if @occurrence_date.blank?
+
+      # A recurring occurrence keeps the parent's time of day on its own date.
+      @event.starts_at.change(
+        year: @occurrence_date.year,
+        month: @occurrence_date.month,
+        day: @occurrence_date.day
+      )
+    end
+
+    def cancelled?
+      state&.cancelled_at.present?
+    end
+
+    # Slots are the point, but plenty of events have none -- those report the
+    # signup count instead of "0 of 0 slots open", which reads like a full event.
+    # An event with neither reports nothing at all rather than a zero.
+    def label
+      total = @event.slots.count
+      return signups if total.zero?
+
+      I18n.t("discord.event_availability.slots", open: total - taken_slots, total: total)
+    end
+
+    private def signups
+      count = signups_scope.count
+      return nil if count.zero?
+
+      I18n.t("discord.event_availability.signups", count: count)
+    end
+
+    private def taken_slots
+      signups_scope.where.not(fleet_event_slot_id: nil).count
+    end
+
+    # A withdrawn signup frees its slot again, so the count matches what the
+    # event page shows.
+    private def signups_scope
+      scope = @event.fleet_event_signups.where.not(status: "withdrawn")
+      return scope if @occurrence_date.blank?
+
+      scope.where(occurrence_date: @occurrence_date)
+    end
+
+    private def state
+      return nil if @occurrence_date.blank?
+
+      @state = @event.occurrence_state_for(@occurrence_date, build: false) unless defined?(@state)
+      @state
+    end
+  end
+end

--- a/lib/discord/event_reminder.rb
+++ b/lib/discord/event_reminder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "discord/webhook"
+require "discord/event_availability"
 
 # rubocop:disable Naming/AccessorMethodName
 module Discord
@@ -45,25 +46,19 @@ module Discord
       frontend_fleet_event_url(fleet_slug: event.fleet.slug, event_slug: event.slug)
     end
 
-    private def event_title
-      state&.title.presence || event.title
+    # Title, start time and availability are all per-occurrence, and the event
+    # list needs exactly the same three. Sharing them is what keeps the reminder
+    # and the list from disagreeing about how many slots are open.
+    private def availability_for_occurrence
+      @availability_for_occurrence ||= ::Discord::EventAvailability.new(event, occurrence_date: occurrence_date)
     end
 
-    private def state
-      return nil if occurrence_date.blank?
-
-      event.occurrence_state_for(occurrence_date, build: false)
+    private def event_title
+      availability_for_occurrence.title
     end
 
     private def starts_at
-      return event.starts_at if occurrence_date.blank?
-
-      # A recurring occurrence keeps the parent's time of day on its own date.
-      event.starts_at.change(
-        year: occurrence_date.year,
-        month: occurrence_date.month,
-        day: occurrence_date.day
-      )
+      availability_for_occurrence.starts_at
     end
 
     private def starts_in
@@ -73,32 +68,8 @@ module Discord
       I18n.t("discord.event_reminder.starts_in", count: minutes)
     end
 
-    # Slots are the point of the message, but plenty of events have none --
-    # those get the signup count instead of "0 of 0 slots open", which reads
-    # like a full event.
     private def availability
-      total = event.slots.count
-      return signups if total.zero?
-
-      I18n.t("discord.event_reminder.slots", open: total - taken_slots, total: total)
-    end
-
-    private def signups
-      count = signups_scope.count
-      return nil if count.zero?
-
-      I18n.t("discord.event_reminder.signups", count: count)
-    end
-
-    private def taken_slots
-      signups_scope.where.not(fleet_event_slot_id: nil).count
-    end
-
-    private def signups_scope
-      scope = event.fleet_event_signups.where.not(status: "withdrawn")
-      return scope if occurrence_date.blank?
-
-      scope.where(occurrence_date: occurrence_date)
+      availability_for_occurrence.label
     end
   end
 end

--- a/test/lib/discord/commands/fleet_events_test.rb
+++ b/test/lib/discord/commands/fleet_events_test.rb
@@ -1,0 +1,215 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "discord/commands/fleet_events"
+
+module Discord
+  module Commands
+    class FleetEventsTest < ActiveSupport::TestCase
+      setup do
+        @fleet = create(:fleet, :private, name: "Test Wing")
+        @fleet.create_fleet_notification_setting!(discord_guild_id: "guild-1")
+
+        @user = create(:user)
+        create(:omniauth_connection, user: @user, provider: "discord", uid: "member-uid")
+        @fleet.fleet_memberships
+          .create!(user: @user, fleet_role: @fleet.fleet_roles.find_by(name: "Member"))
+          .update!(aasm_state: "accepted")
+      end
+
+      def call(guild_id: "guild-1", discord_user_id: "member-uid")
+        ::Discord::Commands::FleetEvents.new(guild_id: guild_id, discord_user_id: discord_user_id).call
+      end
+
+      def event(**attributes)
+        create(:fleet_event, :open, fleet: @fleet, **attributes)
+      end
+
+      # Slots hang off a team, not off the event: FleetEventSlot#slottable is
+      # polymorphic and FleetEvent#slots collects across teams and ships.
+      def team_with_slots(event, count)
+        team = create(:fleet_event_team, fleet_event: event)
+        count.times { create(:fleet_event_slot, slottable: team) }
+        team
+      end
+
+      def accepted_member
+        member = create(:user)
+        @fleet.fleet_memberships
+          .create!(user: member, fleet_role: @fleet.fleet_roles.find_by(name: "Member"))
+          .tap { |membership| membership.update!(aasm_state: "accepted") }
+      end
+
+      test "lists an upcoming event" do
+        event(title: "Strike Op", starts_at: 2.days.from_now)
+
+        assert_includes call[:content], "Strike Op"
+      end
+
+      test "links the event and the fleet's event page" do
+        strike = event(title: "Strike Op")
+
+        content = call[:content]
+
+        assert_includes content, "/fleets/#{@fleet.slug}/events/#{strike.slug}/"
+        assert_includes content, "/fleets/#{@fleet.slug}/events/"
+      end
+
+      # Discord renders this in the reader's own timezone, which is the only
+      # correct answer for a fleet spread across several.
+      test "the start time is a Discord timestamp, not a rendered date" do
+        strike = event(starts_at: 2.days.from_now)
+
+        assert_includes call[:content], "<t:#{strike.starts_at.to_i}:f>"
+      end
+
+      test "reads soonest first" do
+        event(title: "Later Op", starts_at: 5.days.from_now)
+        event(title: "Sooner Op", starts_at: 2.days.from_now)
+
+        content = call[:content]
+
+        assert_operator content.index("Sooner Op"), :<, content.index("Later Op")
+      end
+
+      test "a past event is not upcoming" do
+        event(title: "Old Op", starts_at: 2.days.ago)
+
+        assert_equal I18n.t("discord.commands.fleet.events.none"), call[:content]
+      end
+
+      # Listing a draft in Discord publishes it in every sense that matters.
+      test "a draft is not listed" do
+        create(:fleet_event, fleet: @fleet, title: "Secret Op", starts_at: 2.days.from_now, status: "draft")
+
+        assert_equal I18n.t("discord.commands.fleet.events.none"), call[:content]
+      end
+
+      test "a cancelled event is not listed" do
+        create(:fleet_event, :cancelled, fleet: @fleet, title: "Called Off", starts_at: 2.days.from_now)
+
+        assert_equal I18n.t("discord.commands.fleet.events.none"), call[:content]
+      end
+
+      test "an archived event is not listed" do
+        event(title: "Archived Op", starts_at: 2.days.from_now).update!(archived_at: Time.current)
+
+        assert_equal I18n.t("discord.commands.fleet.events.none"), call[:content]
+      end
+
+      test "reports how many slots are open" do
+        team_with_slots(event(title: "Strike Op"), 3)
+
+        assert_includes call[:content], I18n.t("discord.event_availability.slots", open: 3, total: 3)
+      end
+
+      test "a taken slot is not counted as open" do
+        strike = event(title: "Strike Op")
+        team = team_with_slots(strike, 3)
+        create(:fleet_event_signup,
+          fleet_event: strike,
+          fleet_event_slot: team.fleet_event_slots.first,
+          fleet_membership: accepted_member)
+
+        assert_includes call[:content], I18n.t("discord.event_availability.slots", open: 2, total: 3)
+      end
+
+      # "0 of 0 slots open" reads like a full event, which is the opposite of
+      # true.
+      test "an event without slots reports signups instead" do
+        strike = event(title: "Strike Op")
+        create(:fleet_event_signup, fleet_event: strike, fleet_event_slot: nil, fleet_membership: accepted_member)
+
+        content = call[:content]
+
+        assert_includes content, I18n.t("discord.event_availability.signups", count: 1)
+        assert_not_includes content, I18n.t("discord.event_availability.slots", open: 0, total: 0)
+      end
+
+      # A weekly op would otherwise appear once, on the date the series started.
+      test "a recurring series is listed by occurrence" do
+        event(title: "Weekly Op",
+          starts_at: 2.days.from_now,
+          recurring: true,
+          recurrence_interval: "weekly")
+
+        assert_equal ::Discord::Commands::FleetEvents::MAX_EVENTS, call[:content].scan("Weekly Op").size
+      end
+
+      test "a recurring occurrence keeps the parent's time of day on its own date" do
+        starts_at = 2.days.from_now.change(hour: 19, min: 30)
+        event(title: "Weekly Op", starts_at: starts_at, recurring: true, recurrence_interval: "weekly")
+
+        assert_includes call[:content], "<t:#{(starts_at + 1.week).to_i}:f>"
+      end
+
+      test "an occurrence with its own title uses it" do
+        weekly = event(title: "Weekly Op",
+          starts_at: 2.days.from_now,
+          recurring: true,
+          recurrence_interval: "weekly")
+        weekly.fleet_event_occurrence_states.create!(
+          occurrence_date: (2.days.from_now + 1.week).to_date,
+          title: "Special Edition"
+        )
+
+        assert_includes call[:content], "Special Edition"
+      end
+
+      # Only the overlay row knows a single occurrence of a live series is off.
+      test "a cancelled occurrence is not listed" do
+        weekly = event(title: "Weekly Op",
+          starts_at: 2.days.from_now,
+          recurring: true,
+          recurrence_interval: "weekly")
+        weekly.fleet_event_occurrence_states.create!(
+          occurrence_date: 2.days.from_now.to_date,
+          cancelled_at: Time.current
+        )
+
+        content = call[:content]
+
+        assert_includes content, "Weekly Op"
+        assert_not_includes content, "<t:#{weekly.starts_at.to_i}:f>"
+      end
+
+      test "caps the list" do
+        (::Discord::Commands::FleetEvents::MAX_EVENTS + 2).times do |i|
+          event(title: "Op #{i}", starts_at: (i + 2).days.from_now)
+        end
+
+        assert_equal ::Discord::Commands::FleetEvents::MAX_EVENTS, call[:content].scan("• [").size
+      end
+
+      test "says so when the server is not bound to a fleet" do
+        assert_equal I18n.t("discord.commands.fleet.not_bound"), call(guild_id: "guild-nope")[:content]
+      end
+
+      test "an unlinked Discord account is told where to link it" do
+        assert_includes call(discord_user_id: "stranger-uid")[:content],
+          I18n.t("discord.commands.account_not_linked", url: "https://#{Rails.configuration.app.domain}/settings/connections")
+      end
+
+      # The schedule is internal data: fleet:events:read is a member privilege,
+      # and a guild can have guests.
+      test "someone who only shares the Discord server cannot see the events" do
+        create(:omniauth_connection, user: create(:user), provider: "discord", uid: "guest-uid")
+        event(title: "Strike Op")
+
+        assert_equal I18n.t("discord.commands.fleet.events.not_allowed"),
+          call(discord_user_id: "guest-uid")[:content]
+      end
+
+      test "a member whose role has no read privilege cannot see the events" do
+        @fleet.fleet_roles.find_by(name: "Member").update!(resource_access: [])
+        event(title: "Strike Op")
+
+        assert_equal I18n.t("discord.commands.fleet.events.not_allowed"), call[:content]
+      end
+
+      test "carries no flags, since a follow-up cannot set them" do
+        assert_nil call[:flags]
+      end
+    end
+  end
+end

--- a/test/lib/discord/commands/registry_test.rb
+++ b/test/lib/discord/commands/registry_test.rb
@@ -129,6 +129,12 @@ module Discord
         assert Registry.ephemeral?("fleet", "members"), "/fleet members would answer in the channel"
       end
 
+      # fleet:events:read is a member privilege, so the schedule is internal
+      # data, and the guild it was typed in may have guests.
+      test "the event list answers privately" do
+        assert Registry.ephemeral?("fleet", "events"), "/fleet events would answer in the channel"
+      end
+
       # A "that command no longer exists" belongs to whoever typed it.
       test "an unregistered name answers privately" do
         assert Registry.ephemeral?("definitely-not-a-command")

--- a/test/lib/discord/event_reminder_test.rb
+++ b/test/lib/discord/event_reminder_test.rb
@@ -59,7 +59,7 @@ module Discord
     test "reports how many slots are open" do
       team_with_slots(14)
 
-      assert_includes post, I18n.t("discord.event_reminder.slots", open: 14, total: 14)
+      assert_includes post, I18n.t("discord.event_availability.slots", open: 14, total: 14)
     end
 
     test "a taken slot is not counted as open" do
@@ -69,7 +69,7 @@ module Discord
         fleet_event_slot: team.fleet_event_slots.first,
         fleet_membership: accepted_member)
 
-      assert_includes post, I18n.t("discord.event_reminder.slots", open: 2, total: 3)
+      assert_includes post, I18n.t("discord.event_availability.slots", open: 2, total: 3)
     end
 
     test "a withdrawn signup frees its slot again" do
@@ -80,7 +80,7 @@ module Discord
         fleet_membership: accepted_member)
       signup.update!(status: "withdrawn")
 
-      assert_includes post, I18n.t("discord.event_reminder.slots", open: 3, total: 3)
+      assert_includes post, I18n.t("discord.event_availability.slots", open: 3, total: 3)
     end
 
     # "0 of 0 slots open" reads like a full event, which is the opposite of true.
@@ -92,8 +92,8 @@ module Discord
 
       content = post
 
-      assert_includes content, I18n.t("discord.event_reminder.signups", count: 1)
-      assert_not_includes content, I18n.t("discord.event_reminder.slots", open: 0, total: 0)
+      assert_includes content, I18n.t("discord.event_availability.signups", count: 1)
+      assert_not_includes content, I18n.t("discord.event_availability.slots", open: 0, total: 0)
     end
 
     test "an event with neither slots nor signups still announces itself" do


### PR DESCRIPTION
> **Stacked on #4667** (→ #4665 → #4663). Targets `feat/discord-fleet-members`.

## What

`/fleet events` lists the next five upcoming occurrences in the guild's fleet, each with its availability and a link.

Ephemeral — less obvious for a list than for an invite link, but `fleet:events:read` is a **member** default privilege, so the schedule is internal data, and a guild can have guests. That is the same reason `/fleet info` refuses non-members; a channel post would hand the schedule to exactly the people the privilege excludes.

## Occurrences, not series rows

A weekly op would otherwise appear once, on the date the series started. The list expands `FleetEvent#occurrences` and sorts across events.

Three things this has to get right, all of them already solved elsewhere in the model and easy to re-break:

- **`starting_after` is what makes the pre-filter safe.** A recurring row whose `starts_at` is long past still has occurrences ahead of it, so filtering on `starts_at` would drop the series along with all of them.
- **A cancelled occurrence of a live series is not upcoming**, and only the `fleet_event_occurrence_states` overlay row knows about it.
- **An occurrence's own title wins** over the series title; `nil` means inherit.

Drafts stay out. Listing a draft in Discord publishes it in every sense that matters. Cancelled, completed and archived stay out too.

## Availability is no longer defined twice

`Discord::EventAvailability` now holds title, start time and the "6 of 14 slots open" logic that was private to `Discord::EventReminder` — including the fallback to a signup count when an event has no slots (because "0 of 0 slots open" reads like a full event) and the exclusion of withdrawn signups.

The reminder now reads from it. A bot that disagrees with its own reminder about how many slots are open is a bug report nobody can reproduce.

The two copy keys moved with the logic — `discord.event_reminder.{slots,signups}` → `discord.event_availability.{slots,signups}` — with the translations carried over verbatim in all seven files. The reminder's own keys (`title`, `starts_in`, `starting_now`) stay where they are.

## Timestamps

Start times are emitted as `<t:unix:f>`, which Discord renders in each reader's own timezone. For a fleet spread across several, a server-rendered date is wrong for most of the people reading it.

## Tests

`296 tests, 653 assertions, 0 failures` across the Discord suite; 21 for this command, covering the recurrence cases above, the slot/signup fallback, and the three refusal paths. The reminder's own tests pass unchanged apart from the two renamed keys. 🤖
