### PR TITLE
fix(lists): give the mobile list toolbar its wasted row back

### DIFF
--- a/app/frontend/admin/pages/fleets/destroyed/index.vue
+++ b/app/frontend/admin/pages/fleets/destroyed/index.vue
@@ -147,14 +147,18 @@ const columns: BaseTableCol<DestroyedFleet>[] = [
       <BtnGroup segmented>
         <Btn
           :active="source === DestroyedFleetSourceEnum.DISCARDED"
+          mobile-icon-only
           @click="setSource(DestroyedFleetSourceEnum.DISCARDED)"
         >
+          <i class="fa-duotone fa-trash-can" />
           {{ t("labels.destroyedFleets.discarded") }}
         </Btn>
         <Btn
           :active="source === DestroyedFleetSourceEnum.PURGED"
+          mobile-icon-only
           @click="setSource(DestroyedFleetSourceEnum.PURGED)"
         >
+          <i class="fa-duotone fa-trash-can-xmark" />
           {{ t("labels.destroyedFleets.purged") }}
         </Btn>
       </BtnGroup>

--- a/app/frontend/frontend/pages/fleets/[slug]/events/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/events/index.vue
@@ -239,7 +239,9 @@ const crumbs = computed<Crumb[]>(() => [
     <Btn
       v-if="canManageMissions"
       :to="{ name: 'fleet-missions', params: { slug: props.fleet.slug } }"
+      :aria-label="t('actions.fleets.missions.viewMissions')"
       variant="bare"
+      mobile-icon-only
     >
       <i class="fa-light fa-flag-checkered" />
       <span>{{ t("actions.fleets.missions.viewMissions") }}</span>
@@ -247,6 +249,8 @@ const crumbs = computed<Crumb[]>(() => [
     <Btn
       v-if="canCreate"
       :to="{ name: 'fleet-event-new', params: { slug: props.fleet.slug } }"
+      :aria-label="t('actions.fleets.events.create')"
+      mobile-icon-only
     >
       <i class="fa-light fa-plus" />
       <span>{{ t("actions.fleets.events.create") }}</span>
@@ -259,13 +263,24 @@ const crumbs = computed<Crumb[]>(() => [
          offers to hand it to your own calendar instead. -->
     <div class="events-toolbar__lead">
       <BtnGroup v-if="view === 'list'" segmented data-test="events-tab-switch">
-        <Btn :active="tab === 'upcoming'" @click="tab = 'upcoming'">
+        <Btn
+          :active="tab === 'upcoming'"
+          mobile-icon-only
+          @click="tab = 'upcoming'"
+        >
+          <i class="fa-light fa-calendar-clock" />
           {{ t("labels.fleets.events.upcomingTab") }}
         </Btn>
-        <Btn :active="tab === 'past'" @click="tab = 'past'">
+        <Btn :active="tab === 'past'" mobile-icon-only @click="tab = 'past'">
+          <i class="fa-light fa-clock-rotate-left" />
           {{ t("labels.fleets.events.pastTab") }}
         </Btn>
-        <Btn :active="tab === 'archived'" @click="tab = 'archived'">
+        <Btn
+          :active="tab === 'archived'"
+          mobile-icon-only
+          @click="tab = 'archived'"
+        >
+          <i class="fa-light fa-box-archive" />
           {{ t("labels.fleets.events.archivedTab") }}
         </Btn>
       </BtnGroup>
@@ -289,11 +304,19 @@ const crumbs = computed<Crumb[]>(() => [
     </div>
 
     <BtnGroup segmented data-test="events-view-switch">
-      <Btn :active="view === 'list'" @click="toggleListCalendar('list')">
+      <Btn
+        :active="view === 'list'"
+        mobile-icon-only
+        @click="toggleListCalendar('list')"
+      >
         <i class="fa-light fa-list" />
         {{ t("labels.fleets.events.listTab") }}
       </Btn>
-      <Btn :active="isCalendar" @click="toggleListCalendar('calendar')">
+      <Btn
+        :active="isCalendar"
+        mobile-icon-only
+        @click="toggleListCalendar('calendar')"
+      >
         <i class="fa-light fa-calendar" />
         {{ t("labels.fleets.events.calendarTab") }}
       </Btn>

--- a/app/frontend/frontend/pages/fleets/[slug]/logistics/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics/index.vue
@@ -218,10 +218,20 @@ const crumbs = computed<Crumb[]>(() => [
 
     <template #actions-left>
       <BtnGroup segmented>
-        <Btn :active="activeTab === 'stock'" @click="activeTab = 'stock'">
+        <Btn
+          :active="activeTab === 'stock'"
+          mobile-icon-only
+          @click="activeTab = 'stock'"
+        >
+          <i class="fa-duotone fa-boxes-stacked" />
           {{ t("labels.logistics.stockView") }}
         </Btn>
-        <Btn :active="activeTab === 'log'" @click="activeTab = 'log'">
+        <Btn
+          :active="activeTab === 'log'"
+          mobile-icon-only
+          @click="activeTab = 'log'"
+        >
+          <i class="fa-duotone fa-clock-rotate-left" />
           {{ t("labels.logistics.logView") }}
         </Btn>
       </BtnGroup>

--- a/app/frontend/frontend/pages/fleets/[slug]/logistics/inventories/[inventory].vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics/inventories/[inventory].vue
@@ -277,10 +277,20 @@ const crumbs = computed<Crumb[]>(() => [
 
           <template #actions-left>
             <BtnGroup segmented>
-              <Btn :active="activeTab === 'stock'" @click="activeTab = 'stock'">
+              <Btn
+                :active="activeTab === 'stock'"
+                mobile-icon-only
+                @click="activeTab = 'stock'"
+              >
+                <i class="fa-duotone fa-boxes-stacked" />
                 {{ t("labels.logistics.stockView") }}
               </Btn>
-              <Btn :active="activeTab === 'log'" @click="activeTab = 'log'">
+              <Btn
+                :active="activeTab === 'log'"
+                mobile-icon-only
+                @click="activeTab = 'log'"
+              >
+                <i class="fa-duotone fa-clock-rotate-left" />
                 {{ t("labels.logistics.logView") }}
               </Btn>
             </BtnGroup>

--- a/app/frontend/frontend/pages/fleets/[slug]/missions/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/missions/index.vue
@@ -121,10 +121,20 @@ const crumbs = computed<Crumb[]>(() => [
 
     <template #actions-left>
       <BtnGroup segmented>
-        <Btn :active="!showArchived" @click="showArchived = false">
+        <Btn
+          :active="!showArchived"
+          mobile-icon-only
+          @click="showArchived = false"
+        >
+          <i class="fa-light fa-flag" />
           {{ t("labels.fleets.missions.activeTab") }}
         </Btn>
-        <Btn :active="showArchived" @click="showArchived = true">
+        <Btn
+          :active="showArchived"
+          mobile-icon-only
+          @click="showArchived = true"
+        >
+          <i class="fa-light fa-box-archive" />
           {{ t("labels.fleets.missions.archivedTab") }}
         </Btn>
       </BtnGroup>

--- a/app/frontend/frontend/pages/hangar/[id]/cargo.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/cargo.vue
@@ -330,10 +330,20 @@ onMounted(() => {
 
       <template #actions-left>
         <BtnGroup segmented>
-          <Btn :active="activeTab === 'stock'" @click="activeTab = 'stock'">
+          <Btn
+            :active="activeTab === 'stock'"
+            mobile-icon-only
+            @click="activeTab = 'stock'"
+          >
+            <i class="fa-duotone fa-boxes-stacked" />
             {{ t("labels.logistics.stockView") }}
           </Btn>
-          <Btn :active="activeTab === 'log'" @click="activeTab = 'log'">
+          <Btn
+            :active="activeTab === 'log'"
+            mobile-icon-only
+            @click="activeTab = 'log'"
+          >
+            <i class="fa-duotone fa-clock-rotate-left" />
             {{ t("labels.logistics.logView") }}
           </Btn>
         </BtnGroup>

--- a/app/frontend/frontend/pages/hangar/inventories/[inventory].vue
+++ b/app/frontend/frontend/pages/hangar/inventories/[inventory].vue
@@ -239,10 +239,20 @@ const crumbs = computed<Crumb[]>(() => [
 
           <template #actions-left>
             <BtnGroup segmented>
-              <Btn :active="activeTab === 'stock'" @click="activeTab = 'stock'">
+              <Btn
+                :active="activeTab === 'stock'"
+                mobile-icon-only
+                @click="activeTab = 'stock'"
+              >
+                <i class="fa-duotone fa-boxes-stacked" />
                 {{ t("labels.logistics.stockView") }}
               </Btn>
-              <Btn :active="activeTab === 'log'" @click="activeTab = 'log'">
+              <Btn
+                :active="activeTab === 'log'"
+                mobile-icon-only
+                @click="activeTab = 'log'"
+              >
+                <i class="fa-duotone fa-clock-rotate-left" />
                 {{ t("labels.logistics.logView") }}
               </Btn>
             </BtnGroup>

--- a/app/frontend/frontend/pages/hangar/inventories/index.vue
+++ b/app/frontend/frontend/pages/hangar/inventories/index.vue
@@ -169,10 +169,20 @@ onMounted(() => {
 
     <template #actions-left>
       <BtnGroup segmented>
-        <Btn :active="activeTab === 'stock'" @click="activeTab = 'stock'">
+        <Btn
+          :active="activeTab === 'stock'"
+          mobile-icon-only
+          @click="activeTab = 'stock'"
+        >
+          <i class="fa-duotone fa-boxes-stacked" />
           {{ t("labels.logistics.stockView") }}
         </Btn>
-        <Btn :active="activeTab === 'log'" @click="activeTab = 'log'">
+        <Btn
+          :active="activeTab === 'log'"
+          mobile-icon-only
+          @click="activeTab = 'log'"
+        >
+          <i class="fa-duotone fa-clock-rotate-left" />
           {{ t("labels.logistics.logView") }}
         </Btn>
       </BtnGroup>

--- a/app/frontend/shared/components/FilteredList/index.scss
+++ b/app/frontend/shared/components/FilteredList/index.scss
@@ -1,10 +1,12 @@
 .filtered-list {
   &__actions {
     display: flex;
-    justify-content: space-between;
     // Separates the toolbar from the list below it. Used to come from the
     // buttons' own margin-bottom, which Btn no longer ships.
-    gap: 20px;
+    // Two gaps, because the row now holds three blocks rather than two: 20px
+    // between wrapped rows, and the 10px the paginator had from the actions
+    // while it still sat inside their block.
+    gap: 20px 10px;
     margin-bottom: 20px;
     flex-wrap: wrap;
   }
@@ -16,7 +18,22 @@
     gap: 10px;
   }
 
-  &__actions-right {
+  // Whichever of the two right-hand blocks comes first carries the row: an
+  // auto margin rather than `space-between`, which would strand the actions in
+  // the middle of the row now that the paginator is a third child.
+  &__actions-right,
+  &__pagination-top {
+    margin-left: auto;
+  }
+
+  &__actions-right + &__pagination-top {
+    margin-left: 0;
+  }
+
+  &__pagination-top {
+    display: flex;
+    align-items: center;
+
     :deep(.pagination) {
       width: auto;
     }
@@ -26,6 +43,9 @@
 @media (max-width: $desktop-breakpoint) {
   .filtered-list {
     &__actions {
+      // No row gap: a wrapped paginator is centred on its own row, so it never
+      // reads as touching the actions above it, and 10px of air there would be
+      // 10px every list page pays for one that wraps.
       gap: 0 10px;
 
       &-left,
@@ -39,18 +59,18 @@
       }
 
       &-right {
-        flex: 1 1 auto;
+        flex: 0 1 auto;
         min-width: 0;
         justify-content: flex-end;
         gap: 10px;
       }
     }
 
+    // Takes the row it wraps onto, and centres itself in whatever is left of a
+    // row it still shares with the actions.
     &__pagination-top {
-      order: -1;
       flex: 1 1 auto;
       min-width: 0;
-      display: flex;
       justify-content: center;
     }
   }

--- a/app/frontend/shared/components/FilteredList/index.scss
+++ b/app/frontend/shared/components/FilteredList/index.scss
@@ -66,12 +66,15 @@
       }
     }
 
-    // Takes the row it wraps onto, and centres itself in whatever is left of a
-    // row it still shares with the actions.
+    // Takes the row it wraps onto, and holds the right edge of it - the same
+    // edge it sits on from the desktop breakpoint up. It used to centre here,
+    // which put it neither with the actions it shares the row with nor on the
+    // edge the rows below align to. The paginator under the list is the one
+    // that centres on a phone, and only because nothing shares its row.
     &__pagination-top {
       flex: 1 1 auto;
       min-width: 0;
-      justify-content: center;
+      justify-content: flex-end;
     }
   }
 }

--- a/app/frontend/shared/components/FilteredList/index.spec.ts
+++ b/app/frontend/shared/components/FilteredList/index.spec.ts
@@ -22,14 +22,32 @@ const failedWith = (status: number) =>
   }) as unknown as AsyncStatus;
 
 // FilteredList is a generic SFC, which is not a plain constructor type; this
-// names the props the test uses without reaching for `any`.
+// names the props and slots the test uses without reaching for `any`.
 const ListComponent = Component as unknown as new (...args: unknown[]) => {
   $props: { name: string; records: unknown[]; asyncStatus: AsyncStatus };
+  $slots: Record<string, unknown>;
 };
+
+const loaded = () =>
+  ({
+    fetchStatus: ref("idle"),
+    isError: ref(false),
+    isPending: ref(false),
+    isLoading: ref(false),
+    isFetching: ref(false),
+    isRefetching: ref(false),
+    error: ref(undefined),
+  }) as unknown as AsyncStatus;
 
 const mount = (status: number) =>
   mountWithDefaults<typeof ListComponent>(ListComponent, {
     props: { name: "test-list", records: [], asyncStatus: failedWith(status) },
+  });
+
+const mountWithToolbar = (slots: Record<string, string>) =>
+  mountWithDefaults<typeof ListComponent>(ListComponent, {
+    props: { name: "test-list", records: [{}], asyncStatus: loaded() },
+    slots,
   });
 
 describe("FilteredList", () => {
@@ -45,5 +63,37 @@ describe("FilteredList", () => {
 
     expect(wrapper.findComponent({ name: "ServerError" }).exists()).toBe(true);
     expect(wrapper.findComponent({ name: "Forbidden" }).exists()).toBe(false);
+  });
+
+  // A flex line breaks on a child's unwrapped width, so the paginator only
+  // wraps on its own - leaving the actions up with the filter button - while it
+  // is a child of the toolbar. Nested back inside the right-hand block, the
+  // whole block drops instead and a phone spends a row on the filter button
+  // alone.
+  it("hangs the paginator off the toolbar, not off the actions block", async () => {
+    const wrapper = await mountWithToolbar({
+      "actions-right": '<button data-test="action">action</button>',
+      "pagination-top": '<nav data-test="pager">pager</nav>',
+    });
+
+    const pager = wrapper.get('[data-test="pager"]');
+
+    expect(pager.element.parentElement?.className).toContain(
+      "filtered-list__pagination-top",
+    );
+    expect(
+      wrapper.get(".filtered-list__pagination-top").element.parentElement
+        ?.className,
+    ).toContain("filtered-list__actions");
+  });
+
+  it("renders no block for a slot it was not given", async () => {
+    const wrapper = await mountWithToolbar({
+      filter: "<div>filter</div>",
+    });
+
+    expect(wrapper.find(".filtered-list__actions").exists()).toBe(true);
+    expect(wrapper.find(".filtered-list__actions-right").exists()).toBe(false);
+    expect(wrapper.find(".filtered-list__pagination-top").exists()).toBe(false);
   });
 });

--- a/app/frontend/shared/components/FilteredList/index.vue
+++ b/app/frontend/shared/components/FilteredList/index.vue
@@ -85,6 +85,13 @@ const hasActions = computed(
     !!slots["pagination-top"],
 );
 
+// Both blocks only exist where their slot does: an empty one still claims the
+// toolbar's column gap, which on a phone is the difference between the actions
+// and the paginator sharing a row and the paginator wrapping below them.
+const hasActionsRight = computed(() => !!slots["actions-right"]);
+
+const hasPaginationTop = computed(() => !!slots["pagination-top"]);
+
 const { t } = useI18n();
 
 const filterTooltip = computed(() => {
@@ -202,11 +209,16 @@ const toggleFilter = () => {
             </Btn>
             <slot name="actions-left" :records="records" />
           </div>
-          <div class="filtered-list__actions-right">
+          <div v-if="hasActionsRight" class="filtered-list__actions-right">
             <slot name="actions-right" :records="records" />
-            <div class="filtered-list__pagination-top">
-              <slot name="pagination-top" />
-            </div>
+          </div>
+          <!-- A sibling of the two action blocks, not a child of the right one:
+               a phone toolbar that does not fit should drop the paginator to a
+               row of its own and keep the buttons up with the filter, and a flex
+               line breaks on a child's unwrapped width - so the paginator has to
+               be that child. -->
+          <div v-if="hasPaginationTop" class="filtered-list__pagination-top">
+            <slot name="pagination-top" />
           </div>
         </div>
       </div>

--- a/app/frontend/shared/components/base/BtnDropdown/index.vue
+++ b/app/frontend/shared/components/base/BtnDropdown/index.vue
@@ -19,6 +19,13 @@ type Props = {
   size?: `${BtnSizesEnum}`;
   variant?: `${BtnVariantsEnum}`;
   tone?: `${BtnTonesEnum}`;
+  /**
+   * Stretches the trigger, not just this wrapper. A `w-full` class only widens
+   * the wrapper - the trigger inside it keeps its natural width and the extra
+   * space stays empty, which is what a full-width dropdown on a phone looked
+   * like before this.
+   */
+  block?: boolean;
   expandLeft?: boolean;
   expandTop?: boolean;
   expandBottom?: boolean;
@@ -28,6 +35,7 @@ const props = withDefaults(defineProps<Props>(), {
   size: undefined,
   variant: BtnVariantsEnum.SOLID,
   tone: BtnTonesEnum.NEUTRAL,
+  block: false,
   expandLeft: false,
   expandTop: false,
   expandBottom: false,
@@ -196,6 +204,7 @@ const documentClick = (event: MouseEvent) => {
         :size="size"
         :variant="variant"
         :tone="tone"
+        :block="block"
         :active="visible"
         aria-haspopup="menu"
         :aria-expanded="visible"

--- a/app/frontend/shared/components/base/Chip/Row/index.vue
+++ b/app/frontend/shared/components/base/Chip/Row/index.vue
@@ -34,7 +34,11 @@ defineExpose({ itemsEl });
 </script>
 
 <template>
-  <BtnDropdown v-if="mobile" class="w-full md:w-auto" data-test="chip-row">
+  <!-- Full width, and `block` so the trigger goes with it. No `md:w-auto`: this
+       branch only renders below the 992px `mobile` switch, so the class only
+       ever took effect between md and that switch - where it collapsed the row
+       back to the label's own width and left the space beside it empty. -->
+  <BtnDropdown v-if="mobile" block class="w-full" data-test="chip-row">
     <!-- Omitted rather than rendered empty, so BtnDropdown's own fallback label
          still applies when a consumer passes no label. -->
     <template v-if="label" #label>


### PR DESCRIPTION
Follow-up to #4598, which taught the page header to hand a wrapped row of actions the whole row instead of leaving them huddled against one edge of it. This walks every list page and applies the same idea to the toolbar below the header — and finds two places where a phone in German scrolls sideways.

## The toolbar

`FilteredList` renders the filter button on the left, and the actions plus the paginator on the right. A flex line breaks on a child's *unwrapped* width, so while the paginator sat inside the right-hand block that whole block dropped below — the 43px filter button kept a row to itself with ~300px of nothing beside it, and the actions were crowded onto the next row with the paginator.

The paginator is now a sibling of the two action blocks, so it is the child that breaks: the actions stay up with the filter button, and only the paginator takes a row of its own. A toolbar that already fits keeps its single row — `/ships` and the plain admin lists render exactly as before, and so does every desktop layout.

## The labels

Page actions and the notification tabs already collapse to their icon on a phone. The tab strips in the list toolbars never did — they carried no icon at all, and a segmented track sizes its columns to the widest label and cannot shrink below it. Each segment gets an icon in its page's own icon family, and the label collapses; the events header actions, the last page actions still carrying labels down to a phone, get the same.

## The collapsed rows

The groups and classifications rows collapse into a dropdown below 992px, and their container hands each one a full share of the row. Only the wrapper took it: `w-full` widens the positioning box `BtnDropdown` draws around its trigger, while the trigger kept the width of its own label and left the rest of the share empty. `BtnDropdown` gets a `block` prop that reaches the trigger.

The `md:w-auto` half of that class goes with it. The branch only renders below the `mobile` switch at 992px, so tailwind's `md` was never the boundary it was written against — between 768px and 992px it was the rule that collapsed the row back to its label.

## The alignment

The top paginator centred below the desktop breakpoint, which left it on neither edge — not with the actions it shares the row with, and not on the right edge the list and the paginator under it align to. On the fleet member list, where nothing else is in the toolbar, it read as parked at random in the middle of the row. It holds the right edge at every width now, sharing a row and wrapped onto one of its own.

The paginator *under* the list still centres on a phone, and only because nothing shares its row. That rule lives in `Paginator` itself and is untouched.

## Measured

At a 375px viewport a list page has 345px of content. Widths below are the real component metrics — `Btn sm` at 43px/`px-14`/15px, a segmented track with equal columns, the mobile paginator — measured in Chromium with Open Sans.

| | before | after |
|---|---|---|
| Events toolbar (de) | 550px needed → 2 rows | **1 row**, no overflow down to 320px |
| Events header (de) | 358px → scrolls sideways | fits |
| Admin destroyed fleets (de) | 357px for the left block alone → scrolls sideways | no overflow |
| Fleet missions (de) | 364px → 2 rows | **1 row** |
| Hangar vehicle cargo | 388px → 2 rows | **1 row** |
| Logistics / inventories stock-log tabs | 343px of 345 | 1 row, ~200px spare |
| `/hangar`, `/hangar/wishlist`, fleet `/ships`, `/notifications` | 2 rows, row 1 = filter button only | 2 rows, row 1 = filter + actions, paginator right-aligned below |
| `/ships`, plain admin lists | 1 row | unchanged |
| Desktop, 1140px | — | unchanged: left block at the edge, paginator flush right |

Two `FilteredList` tests hold the structure: the paginator hangs off the toolbar rather than off the actions block, and neither block is rendered without its slot (an empty one still claims the column gap that decides whether the actions and the paginator share a row).

## Left alone

- The two bare hints in the events calendar view ("Subscribe", "Set up calendar subscriptions") — as an icon they would be cryptic, so that view's toolbar still wraps.
- The month/week switch in `CalendarGrid`: it sits in a panel heading, not in a list toolbar.
- `labels.logistics.stockView` / `logView` are still the English placeholders in `de`. A real translation would have overflowed that row on the spot; with the icons it no longer can, but they remain untranslated.

🤖
