### PR TITLE
feat(paginator): hold the paginator's place while a list loads

### DIFF
--- a/app/frontend/admin/components/Images/List.vue
+++ b/app/frontend/admin/components/Images/List.vue
@@ -299,7 +299,6 @@ const columns: BaseTableCol<Image>[] = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="data"
         :query-result-ref="data"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -308,7 +307,6 @@ const columns: BaseTableCol<Image>[] = [
 
     <template #pagination-bottom>
       <Paginator
-        v-if="data"
         :query-result-ref="data"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/admins/index.vue
+++ b/app/frontend/admin/pages/admins/index.vue
@@ -118,7 +118,6 @@ const { t, l } = useI18n();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="adminUsers"
         :query-result-ref="adminUsers"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -126,7 +125,6 @@ const { t, l } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="adminUsers"
         :query-result-ref="adminUsers"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/commodities/index.vue
+++ b/app/frontend/admin/pages/commodities/index.vue
@@ -220,7 +220,6 @@ const { t, l, toUEC } = useI18n();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="commodities"
         :query-result-ref="commodities"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -228,7 +227,6 @@ const { t, l, toUEC } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="commodities"
         :query-result-ref="commodities"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/components/index.vue
+++ b/app/frontend/admin/pages/components/index.vue
@@ -245,7 +245,6 @@ const { t, l, toUEC } = useI18n();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="components"
         :query-result-ref="components"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -253,7 +252,6 @@ const { t, l, toUEC } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="components"
         :query-result-ref="components"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/equipment/index.vue
+++ b/app/frontend/admin/pages/equipment/index.vue
@@ -245,7 +245,6 @@ const { t, l, toUEC } = useI18n();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="equipment"
         :query-result-ref="equipment"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -253,7 +252,6 @@ const { t, l, toUEC } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="equipment"
         :query-result-ref="equipment"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/fleets/[id]/inventories.vue
+++ b/app/frontend/admin/pages/fleets/[id]/inventories.vue
@@ -120,7 +120,6 @@ const columns: BaseTableCol<FleetInventory>[] = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="inventories"
         :query-result-ref="inventories"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -128,7 +127,6 @@ const columns: BaseTableCol<FleetInventory>[] = [
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="inventories"
         :query-result-ref="inventories"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/fleets/[id]/inventories/[inventoryId].vue
+++ b/app/frontend/admin/pages/fleets/[id]/inventories/[inventoryId].vue
@@ -152,7 +152,6 @@ const columns: BaseTableCol<FleetInventoryItem>[] = [
         </BaseTable>
 
         <Paginator
-          v-if="items"
           :query-result-ref="items"
           :per-page="perPage"
           :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/fleets/[id]/members.vue
+++ b/app/frontend/admin/pages/fleets/[id]/members.vue
@@ -163,7 +163,6 @@ const columns: BaseTableCol<AdminFleetMember>[] = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="members"
         :query-result-ref="members"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -171,7 +170,6 @@ const columns: BaseTableCol<AdminFleetMember>[] = [
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="members"
         :query-result-ref="members"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/fleets/destroyed/index.vue
+++ b/app/frontend/admin/pages/fleets/destroyed/index.vue
@@ -193,7 +193,6 @@ const columns: BaseTableCol<DestroyedFleet>[] = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="destroyedFleets"
         :query-result-ref="destroyedFleets"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -201,7 +200,6 @@ const columns: BaseTableCol<DestroyedFleet>[] = [
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="destroyedFleets"
         :query-result-ref="destroyedFleets"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/fleets/index.vue
+++ b/app/frontend/admin/pages/fleets/index.vue
@@ -180,7 +180,6 @@ const { t, l } = useI18n();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="fleets"
         :query-result-ref="fleets"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -188,7 +187,6 @@ const { t, l } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="fleets"
         :query-result-ref="fleets"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/maintenance/imports.vue
+++ b/app/frontend/admin/pages/maintenance/imports.vue
@@ -295,7 +295,6 @@ const columns: BaseTableCol<Import>[] = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="importsList"
         :query-result-ref="importsList"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -303,7 +302,6 @@ const columns: BaseTableCol<Import>[] = [
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="importsList"
         :query-result-ref="importsList"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/maintenance/rsi-api-status.vue
+++ b/app/frontend/admin/pages/maintenance/rsi-api-status.vue
@@ -139,7 +139,6 @@ const resolve = async (log: RsiRequestLog) => {
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="rsiRequestLogs"
         :query-result-ref="rsiRequestLogs"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -147,7 +146,6 @@ const resolve = async (log: RsiRequestLog) => {
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="rsiRequestLogs"
         :query-result-ref="rsiRequestLogs"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/manufacturers/index.vue
+++ b/app/frontend/admin/pages/manufacturers/index.vue
@@ -194,7 +194,6 @@ const { t, l } = useI18n();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="manufacturers"
         :query-result-ref="manufacturers"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -202,7 +201,6 @@ const { t, l } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="manufacturers"
         :query-result-ref="manufacturers"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/cargo-holds.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/cargo-holds.vue
@@ -249,7 +249,6 @@ const formatOffset = (hold: AdminCargoHold) => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/docks.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/docks.vue
@@ -225,7 +225,6 @@ const onSaveCreate = async () => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/hardpoints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/hardpoints.vue
@@ -435,7 +435,6 @@ const onSaveCreate = async () => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/images.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/images.vue
@@ -296,7 +296,6 @@ const handleUploadDone = async (files: FileUpload[]) => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/loaners.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/loaners.vue
@@ -199,7 +199,6 @@ const onSaveCreate = async () => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/modules.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/modules.vue
@@ -354,7 +354,6 @@ const onUnlink = (record: ModelModule) => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/packages.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/packages.vue
@@ -350,7 +350,6 @@ const onSaveCreate = async () => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/paints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/paints.vue
@@ -332,7 +332,6 @@ const bulkCopy = (selectedIds: string[]) => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/positions.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/positions.vue
@@ -288,7 +288,6 @@ const onRegenerate = async () => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/snub-crafts.vue
@@ -180,7 +180,6 @@ const onSaveCreate = async () => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/upgrades.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/upgrades.vue
@@ -319,7 +319,6 @@ const onUnlink = (record: ModelUpgrade) => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/[id]/edit/videos.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/videos.vue
@@ -219,7 +219,6 @@ const videoTypeOptions: FilterOption[] = Object.values(VideoTypeEnum).map(
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/index.vue
+++ b/app/frontend/admin/pages/models/index.vue
@@ -427,7 +427,6 @@ watch(
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="models"
         :query-result-ref="models"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -435,7 +434,6 @@ watch(
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="models"
         :query-result-ref="models"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/modules/[id]/edit/cargo-holds.vue
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/cargo-holds.vue
@@ -217,7 +217,6 @@ const formatOffset = (hold: AdminCargoHold) => {
   </InlineEditableList>
 
   <Paginator
-    v-if="data"
     :query-result-ref="data"
     :per-page="perPage"
     :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/modules/index.vue
+++ b/app/frontend/admin/pages/models/modules/index.vue
@@ -334,7 +334,6 @@ const crumbs = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="modules"
         :query-result-ref="modules"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -342,7 +341,6 @@ const crumbs = [
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="modules"
         :query-result-ref="modules"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/modules/packages.vue
+++ b/app/frontend/admin/pages/models/modules/packages.vue
@@ -213,7 +213,6 @@ const { t } = useI18n();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="models"
         :query-result-ref="models"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -221,7 +220,6 @@ const { t } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="models"
         :query-result-ref="models"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/models/unlisted.vue
+++ b/app/frontend/admin/pages/models/unlisted.vue
@@ -242,7 +242,6 @@ const { t } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="unlistedModels"
         :query-result-ref="unlistedModels"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -513,7 +513,6 @@ const destroySelected = () =>
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="notifications"
         :query-result-ref="notifications"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -521,7 +520,6 @@ const destroySelected = () =>
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="notifications"
         :query-result-ref="notifications"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/oauth-applications/index.vue
+++ b/app/frontend/admin/pages/oauth-applications/index.vue
@@ -129,7 +129,6 @@ const { t, l } = useI18n();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="oauthApplications"
         :query-result-ref="oauthApplications"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -137,7 +136,6 @@ const { t, l } = useI18n();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="oauthApplications"
         :query-result-ref="oauthApplications"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/supporter-contributions/funding-goals/index.vue
+++ b/app/frontend/admin/pages/supporter-contributions/funding-goals/index.vue
@@ -186,7 +186,6 @@ const { formatCents } = useCurrencyFormat();
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="fundingGoals"
         :query-result-ref="fundingGoals"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -194,7 +193,6 @@ const { formatCents } = useCurrencyFormat();
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="fundingGoals"
         :query-result-ref="fundingGoals"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/supporter-contributions/index.vue
+++ b/app/frontend/admin/pages/supporter-contributions/index.vue
@@ -285,7 +285,6 @@ const syncFromPatreon = () => {
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="supporterContributions"
         :query-result-ref="supporterContributions"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -293,7 +292,6 @@ const syncFromPatreon = () => {
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="supporterContributions"
         :query-result-ref="supporterContributions"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/users/[id]/fleets.vue
+++ b/app/frontend/admin/pages/users/[id]/fleets.vue
@@ -150,7 +150,6 @@ const columns: BaseTableCol<AdminUserFleet>[] = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="fleets"
         :query-result-ref="fleets"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -158,7 +157,6 @@ const columns: BaseTableCol<AdminUserFleet>[] = [
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="fleets"
         :query-result-ref="fleets"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/users/[id]/inventories.vue
+++ b/app/frontend/admin/pages/users/[id]/inventories.vue
@@ -107,7 +107,6 @@ const columns: BaseTableCol<Inventory>[] = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="inventories"
         :query-result-ref="inventories"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -115,7 +114,6 @@ const columns: BaseTableCol<Inventory>[] = [
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="inventories"
         :query-result-ref="inventories"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/users/[id]/inventories/[inventoryId].vue
+++ b/app/frontend/admin/pages/users/[id]/inventories/[inventoryId].vue
@@ -148,7 +148,6 @@ const columns: BaseTableCol<InventoryItem>[] = [
         </BaseTable>
 
         <Paginator
-          v-if="items"
           :query-result-ref="items"
           :per-page="perPage"
           :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/users/index.vue
+++ b/app/frontend/admin/pages/users/index.vue
@@ -180,7 +180,6 @@ const columns: BaseTableCol<User>[] = [
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="users"
         :query-result-ref="users"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -188,7 +187,6 @@ const columns: BaseTableCol<User>[] = [
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="users"
         :query-result-ref="users"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/admin/pages/vehicles/index.vue
+++ b/app/frontend/admin/pages/vehicles/index.vue
@@ -198,7 +198,6 @@ const image = (record: Vehicle) => {
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="vehicles"
         :query-result-ref="vehicles"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -206,7 +205,6 @@ const image = (record: Vehicle) => {
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="vehicles"
         :query-result-ref="vehicles"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/frontend/components/Fleets/PublicShipsList/index.vue
+++ b/app/frontend/frontend/components/Fleets/PublicShipsList/index.vue
@@ -179,7 +179,6 @@ const refetch = async () => {
       </template>
       <template #pagination-top>
         <Paginator
-          v-if="fleetVehicles"
           :query-result-ref="fleetVehicles"
           :per-page="perPage"
           :update-per-page="updatePerPage"
@@ -188,7 +187,6 @@ const refetch = async () => {
 
       <template #pagination-bottom>
         <Paginator
-          v-if="fleetVehicles"
           :query-result-ref="fleetVehicles"
           :per-page="perPage"
           :update-per-page="updatePerPage"

--- a/app/frontend/frontend/components/Fleets/ShipsList/index.vue
+++ b/app/frontend/frontend/components/Fleets/ShipsList/index.vue
@@ -351,7 +351,6 @@ const {
           >
             <template #pagination>
               <Paginator
-                v-if="fleetVehicles"
                 :query-result-ref="fleetVehicles"
                 :per-page="perPage"
                 :size="BtnSizesEnum.SM"
@@ -362,7 +361,6 @@ const {
         </template>
         <template #pagination-top>
           <Paginator
-            v-if="fleetVehicles"
             :query-result-ref="fleetVehicles"
             :per-page="perPage"
             :update-per-page="updatePerPage"
@@ -371,7 +369,6 @@ const {
 
         <template #pagination-bottom>
           <Paginator
-            v-if="fleetVehicles"
             :query-result-ref="fleetVehicles"
             :per-page="perPage"
             :update-per-page="updatePerPage"

--- a/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
@@ -205,7 +205,6 @@ const crumbs = computed<Crumb[]>(() => {
 
     <template #pagination-top>
       <Paginator
-        v-if="members"
         :query-result-ref="members"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -214,7 +213,6 @@ const crumbs = computed<Crumb[]>(() => {
 
     <template #pagination-bottom>
       <Paginator
-        v-if="members"
         :query-result-ref="members"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/frontend/pages/hangar/[username]/index.vue
+++ b/app/frontend/frontend/pages/hangar/[username]/index.vue
@@ -308,7 +308,6 @@ useSubscription({
         </template>
         <template #pagination>
           <Paginator
-            v-if="vehicles"
             :query-result-ref="vehicles"
             :per-page="perPage"
             :size="BtnSizesEnum.SM"
@@ -320,7 +319,6 @@ useSubscription({
 
     <template #pagination-top>
       <Paginator
-        v-if="vehicles"
         :query-result-ref="vehicles"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -329,7 +327,6 @@ useSubscription({
 
     <template #pagination-bottom>
       <Paginator
-        v-if="vehicles"
         :query-result-ref="vehicles"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/frontend/pages/hangar/[username]/wishlist.vue
+++ b/app/frontend/frontend/pages/hangar/[username]/wishlist.vue
@@ -212,7 +212,6 @@ onMounted(async () => {
         </template>
         <template #pagination>
           <Paginator
-            v-if="wishlist"
             :query-result-ref="wishlist"
             :per-page="wishlist?.meta?.pagination?.defaultPerPage || 20"
             :size="BtnSizesEnum.SM"
@@ -224,7 +223,6 @@ onMounted(async () => {
 
     <template #pagination-top>
       <Paginator
-        v-if="wishlist"
         :query-result-ref="wishlist"
         :per-page="wishlist?.meta?.pagination?.defaultPerPage || 20"
         :update-per-page="() => refetch()"
@@ -233,7 +231,6 @@ onMounted(async () => {
 
     <template #pagination-bottom>
       <Paginator
-        v-if="wishlist"
         :query-result-ref="wishlist"
         :per-page="wishlist?.meta?.pagination?.defaultPerPage || 20"
         :update-per-page="() => refetch()"

--- a/app/frontend/frontend/pages/hangar/index.vue
+++ b/app/frontend/frontend/pages/hangar/index.vue
@@ -571,7 +571,6 @@ const openDisplayOptionsModal = () => {
         </template>
         <template #pagination>
           <Paginator
-            v-if="vehicles"
             :query-result-ref="vehicles"
             :per-page="perPage"
             :size="BtnSizesEnum.SM"
@@ -583,7 +582,6 @@ const openDisplayOptionsModal = () => {
 
     <template #pagination-top>
       <Paginator
-        v-if="vehicles"
         :query-result-ref="vehicles"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -592,7 +590,6 @@ const openDisplayOptionsModal = () => {
 
     <template #pagination-bottom>
       <Paginator
-        v-if="vehicles"
         :query-result-ref="vehicles"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/frontend/pages/hangar/wishlist.vue
+++ b/app/frontend/frontend/pages/hangar/wishlist.vue
@@ -352,7 +352,6 @@ const openDisplayOptionsModal = () => {
         </template>
         <template #pagination>
           <Paginator
-            v-if="vehicles"
             :query-result-ref="vehicles"
             :per-page="perPage"
             :size="BtnSizesEnum.SM"
@@ -364,7 +363,6 @@ const openDisplayOptionsModal = () => {
 
     <template #pagination-top>
       <Paginator
-        v-if="vehicles"
         :query-result-ref="vehicles"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -373,7 +371,6 @@ const openDisplayOptionsModal = () => {
 
     <template #pagination-bottom>
       <Paginator
-        v-if="vehicles"
         :query-result-ref="vehicles"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/frontend/pages/images.vue
+++ b/app/frontend/frontend/pages/images.vue
@@ -71,10 +71,10 @@ useGallery(".images");
       </Grid>
     </template>
     <template #pagination-top>
-      <Paginator v-if="images" :query-result-ref="images" :per-page="perPage" />
+      <Paginator :query-result-ref="images" :per-page="perPage" />
     </template>
     <template #pagination-bottom>
-      <Paginator v-if="images" :query-result-ref="images" :per-page="perPage" />
+      <Paginator :query-result-ref="images" :per-page="perPage" />
     </template>
   </FilteredList>
 </template>

--- a/app/frontend/frontend/pages/notifications.vue
+++ b/app/frontend/frontend/pages/notifications.vue
@@ -512,7 +512,6 @@ const destroySelected = () =>
     </template>
     <template #pagination-top>
       <Paginator
-        v-if="notifications"
         :query-result-ref="notifications"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -520,7 +519,6 @@ const destroySelected = () =>
     </template>
     <template #pagination-bottom>
       <Paginator
-        v-if="notifications"
         :query-result-ref="notifications"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/frontend/pages/ships/[slug]/images.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/images.vue
@@ -168,10 +168,10 @@ useGallery(".images");
       </Grid>
     </template>
     <template #pagination-top>
-      <Paginator v-if="images" :query-result-ref="images" :per-page="perPage" />
+      <Paginator :query-result-ref="images" :per-page="perPage" />
     </template>
     <template #pagination-bottom>
-      <Paginator v-if="images" :query-result-ref="images" :per-page="perPage" />
+      <Paginator :query-result-ref="images" :per-page="perPage" />
     </template>
   </FilteredList>
 </template>

--- a/app/frontend/frontend/pages/ships/index.vue
+++ b/app/frontend/frontend/pages/ships/index.vue
@@ -133,7 +133,6 @@ const openDisplayOptionsModal = () => {
 
     <template #pagination-top>
       <Paginator
-        v-if="models"
         :query-result-ref="models"
         :per-page="perPage"
         :update-per-page="updatePerPage"
@@ -167,7 +166,6 @@ const openDisplayOptionsModal = () => {
       >
         <template #pagination>
           <Paginator
-            v-if="models"
             :query-result-ref="models"
             :per-page="perPage"
             :size="BtnSizesEnum.SM"
@@ -182,7 +180,6 @@ const openDisplayOptionsModal = () => {
 
     <template #pagination-bottom>
       <Paginator
-        v-if="models"
         :query-result-ref="models"
         :per-page="perPage"
         :update-per-page="updatePerPage"

--- a/app/frontend/frontend/pages/tools/travel-times.vue
+++ b/app/frontend/frontend/pages/tools/travel-times.vue
@@ -215,7 +215,6 @@ const { data: quantumDrives, ...asyncStatus } = useComponentsQuery(
 
       <template #pagination-top>
         <Paginator
-          v-if="quantumDrives"
           :query-result-ref="quantumDrives"
           :per-page="perPage"
           :update-per-page="updatePerPage"
@@ -224,7 +223,6 @@ const { data: quantumDrives, ...asyncStatus } = useComponentsQuery(
 
       <template #pagination-bottom>
         <Paginator
-          v-if="quantumDrives"
           :query-result-ref="quantumDrives"
           :per-page="perPage"
           :update-per-page="updatePerPage"

--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -78,6 +78,18 @@ const singlePage: BaseList = {
   },
 };
 
+const emptyList: BaseList = {
+  meta: {
+    pagination: {
+      totalCount: 0,
+      currentPage: 1,
+      totalPages: 0,
+      perPage: 25,
+      defaultPerPage: 25,
+    },
+  },
+};
+
 const perPage = ref<number | string>(25);
 
 const updatePerPage = (value: number | string) => {
@@ -194,8 +206,9 @@ const updatePerPage = (value: number | string) => {
 
   <Heading :level="HeadingLevelEnum.H2">Paginator</Heading>
   <p>
-    Ten pages with a per-page dropdown, and a single-page result. Page links
-    write to the route, so clicking one navigates this page.
+    Ten pages with a per-page dropdown, a single-page result, an empty result
+    and the state before a list has answered. Page links write to the route, so
+    clicking one navigates this page.
   </p>
   <div class="row">
     <div class="col-12 vt-stack">
@@ -206,6 +219,8 @@ const updatePerPage = (value: number | string) => {
       />
       <Paginator :query-result-ref="paginated" inline />
       <Paginator :query-result-ref="singlePage" />
+      <Paginator :query-result-ref="emptyList" />
+      <Paginator :query-result-ref="undefined" />
     </div>
   </div>
 

--- a/app/frontend/shared/components/FilteredList/index.scss
+++ b/app/frontend/shared/components/FilteredList/index.scss
@@ -40,6 +40,33 @@
   }
 }
 
+.filtered-list--pagination-only {
+  // Hidden rather than left empty: the flex gap counts an empty box as a
+  // sibling and would push the paginator off centre by half of it.
+  .filtered-list__actions-left {
+    display: none;
+  }
+
+  .filtered-list__actions {
+    justify-content: center;
+  }
+
+  // The toolbar hands its right-hand blocks an auto margin, which would swallow
+  // the free space before `justify-content` could split it; and below the
+  // desktop breakpoint the block grows and pins the control to the right edge.
+  // Neither holds for a row that has nothing else on it.
+  .filtered-list__pagination-top {
+    margin-left: 0;
+    justify-content: center;
+  }
+
+  // The bottom paginator is alone in its row on every list; it follows the top
+  // one so the two ends of the same list do not disagree.
+  :deep(.pagination) {
+    justify-content: center;
+  }
+}
+
 @media (max-width: $desktop-breakpoint) {
   .filtered-list {
     &__actions {

--- a/app/frontend/shared/components/FilteredList/index.spec.ts
+++ b/app/frontend/shared/components/FilteredList/index.spec.ts
@@ -50,6 +50,12 @@ const mountWithToolbar = (slots: Record<string, string>) =>
     slots,
   });
 
+const mountWithSlots = (slots: Record<string, () => unknown>) =>
+  mountWithDefaults<typeof ListComponent>(ListComponent, {
+    props: { name: "test-list", records: [], asyncStatus: loaded() },
+    slots,
+  });
+
 describe("FilteredList", () => {
   it("sends a refused list to the access screen, not the outage one", async () => {
     const wrapper = await mount(403);
@@ -95,5 +101,26 @@ describe("FilteredList", () => {
     expect(wrapper.find(".filtered-list__actions").exists()).toBe(true);
     expect(wrapper.find(".filtered-list__actions-right").exists()).toBe(false);
     expect(wrapper.find(".filtered-list__pagination-top").exists()).toBe(false);
+  });
+
+  it("centres a toolbar that carries nothing but the paginator", async () => {
+    const wrapper = await mountWithSlots({
+      "pagination-top": () => "pages",
+    });
+
+    expect(wrapper.get(".filtered-list").classes()).toContain(
+      "filtered-list--pagination-only",
+    );
+  });
+
+  it("leaves the paginator on the edge once it shares the toolbar", async () => {
+    const wrapper = await mountWithSlots({
+      "pagination-top": () => "pages",
+      "actions-left": () => "action",
+    });
+
+    expect(wrapper.get(".filtered-list").classes()).not.toContain(
+      "filtered-list--pagination-only",
+    );
   });
 });

--- a/app/frontend/shared/components/FilteredList/index.vue
+++ b/app/frontend/shared/components/FilteredList/index.vue
@@ -92,6 +92,16 @@ const hasActionsRight = computed(() => !!slots["actions-right"]);
 
 const hasPaginationTop = computed(() => !!slots["pagination-top"]);
 
+// A toolbar holding nothing but the paginator has no left-hand side to align
+// away from, so the control reads as centred rather than pushed to one edge.
+const paginationOnly = computed(
+  () =>
+    !!slots["pagination-top"] &&
+    !hasFilterSlot.value &&
+    !slots["actions-left"] &&
+    !slots["actions-right"],
+);
+
 const { t } = useI18n();
 
 const filterTooltip = computed(() => {
@@ -189,7 +199,10 @@ const toggleFilter = () => {
 </script>
 
 <template>
-  <div class="row filtered-list">
+  <div
+    class="row filtered-list"
+    :class="{ 'filtered-list--pagination-only': paginationOnly }"
+  >
     <div class="col-12">
       <div class="row">
         <div class="col-12 filtered-list__header">

--- a/app/frontend/shared/components/Paginator/index.spec.ts
+++ b/app/frontend/shared/components/Paginator/index.spec.ts
@@ -1,0 +1,77 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import Component from "./index.vue";
+import type { BaseList } from "@/services/fyApi";
+
+const listWith = (pagination: Partial<BaseList["meta"]["pagination"]>) =>
+  ({
+    meta: {
+      pagination: {
+        totalCount: 0,
+        currentPage: 1,
+        totalPages: 0,
+        perPage: 25,
+        ...pagination,
+      },
+    },
+  }) as BaseList;
+
+const mount = (queryResultRef: BaseList | undefined) =>
+  mountWithDefaults(Component, {
+    props: { queryResultRef, updatePerPage: () => {} },
+  });
+
+// A page link renders as an anchor once it leads anywhere, so the arrows are
+// only countable as components.
+const arrows = (wrapper: Awaited<ReturnType<typeof mount>>) =>
+  wrapper.findAllComponents({ name: "BaseBtn" });
+
+describe("Paginator", () => {
+  it("holds its place while the list is still loading", async () => {
+    const wrapper = await mount(undefined);
+
+    expect(wrapper.get(".pagination__pages").text()).toBe("1 of –");
+    expect(arrows(wrapper).every((arrow) => arrow.props("disabled"))).toBe(
+      true,
+    );
+  });
+
+  it("waits for the response before offering per-page steps", async () => {
+    const wrapper = await mount(undefined);
+
+    expect(wrapper.findComponent({ name: "PerPageDropdown" }).exists()).toBe(
+      false,
+    );
+  });
+
+  it("counts an empty result as one page rather than none", async () => {
+    const wrapper = await mount(listWith({ totalCount: 0, totalPages: 0 }));
+
+    expect(wrapper.get(".pagination__pages").text()).toBe("1 of 1");
+    expect(arrows(wrapper)).toHaveLength(0);
+  });
+
+  it("drops the arrows on a result that fits one page", async () => {
+    const wrapper = await mount(listWith({ totalCount: 8, totalPages: 1 }));
+
+    expect(wrapper.get(".pagination__pages").text()).toBe("1 of 1");
+    expect(arrows(wrapper)).toHaveLength(0);
+  });
+
+  it("offers the way forward but not back on the first of many pages", async () => {
+    const wrapper = await mount(listWith({ totalCount: 248, totalPages: 10 }));
+
+    expect(wrapper.get(".pagination__pages").text()).toBe("1 of 10");
+
+    const [previous, next] = arrows(wrapper);
+
+    expect(previous.props("disabled")).toBe(true);
+    expect(next.props("disabled")).toBe(false);
+  });
+
+  it("renders nothing for an endpoint that does not paginate", async () => {
+    const wrapper = await mount({ meta: {} } as BaseList);
+
+    expect(wrapper.find(".pagination").exists()).toBe(false);
+  });
+});

--- a/app/frontend/shared/components/Paginator/index.vue
+++ b/app/frontend/shared/components/Paginator/index.vue
@@ -16,7 +16,7 @@ import { useMobile } from "@/shared/composables/useMobile";
 import type { MaybeRef } from "vue";
 
 type Props = {
-  queryResultRef: MaybeRef<BaseList>;
+  queryResultRef: MaybeRef<BaseList | undefined>;
   updatePerPage?: (perPage: number | string) => void;
   perPage?: number | string;
   size?: BtnSizesEnum;
@@ -32,11 +32,16 @@ const props = withDefaults(defineProps<Props>(), {
   hash: undefined,
 });
 
-const pagination = computed(() => {
-  const result = unref(props.queryResultRef);
+const result = computed(() => unref(props.queryResultRef));
 
-  return result.meta.pagination;
-});
+// No result yet rather than a result without pagination: the first stands in
+// for the list still loading and keeps the control on screen, the second is an
+// endpoint that does not paginate at all and gets nothing.
+const loading = computed(() => !result.value);
+
+const pagination = computed(() => result.value?.meta.pagination);
+
+const visible = computed(() => loading.value || !!pagination.value);
 
 const perPageSelectable = computed(
   () => !!pagination.value?.perPageSteps && !!props.updatePerPage,
@@ -45,6 +50,12 @@ const perPageSelectable = computed(
 const internalPerPage = computed(
   () => props.perPage || pagination.value?.defaultPerPage,
 );
+
+// An empty list still has a page one, and a page count is only unknown while the
+// request is out.
+const totalPages = computed(() => pagination.value?.totalPages || 1);
+
+const pagesVisible = computed(() => loading.value || totalPages.value > 1);
 
 const { t } = useI18n();
 
@@ -61,27 +72,31 @@ const currentPage = computed(() => {
   const page = Number(route.query.page);
   return Number.isNaN(page) ? 1 : page;
 });
+
+const pagesLabel = computed(() =>
+  t("paginator.labels.pages", {
+    page: String(currentPage.value),
+    total: loading.value ? "–" : String(totalPages.value),
+  }),
+);
 </script>
 
 <template>
-  <div
-    v-if="pagination && (perPageSelectable || pagination.totalCount > 0)"
-    class="pagination"
-  >
+  <div v-if="visible" class="pagination">
     <BtnGroup>
       <PerPageDropdown
         v-if="perPageSelectable"
         :size="size"
         :per-page="internalPerPage"
-        :steps="pagination.perPageSteps"
+        :steps="pagination?.perPageSteps"
         @change="updatePerPage"
       />
-      <template v-if="pagination.totalCount > 0 && pagination.totalPages > 1">
+      <template v-if="pagesVisible">
         <Btn
           v-if="!mobile"
           :size="size"
           :to="pageRoute(1)"
-          :disabled="currentPage <= 1"
+          :disabled="loading || currentPage <= 1"
           route-active-class=""
         >
           <i class="fa fa-chevron-double-left" />
@@ -89,29 +104,20 @@ const currentPage = computed(() => {
         <Btn
           :size="size"
           :to="pageRoute(currentPage - 1)"
-          :disabled="currentPage <= 1"
+          :disabled="loading || currentPage <= 1"
           route-active-class=""
         >
           <i class="fa fa-chevron-left" />
         </Btn>
       </template>
-      <span
-        v-if="pagination.totalCount > 0"
-        class="pagination__pages"
-        style="flex-grow: none"
-      >
-        {{
-          t("paginator.labels.pages", {
-            page: String(currentPage),
-            total: String(pagination.totalPages || 1),
-          })
-        }}
+      <span class="pagination__pages" style="flex-grow: none">
+        {{ pagesLabel }}
       </span>
-      <template v-if="pagination.totalCount > 0 && pagination.totalPages > 1">
+      <template v-if="pagesVisible">
         <Btn
           :size="size"
           :to="pageRoute(currentPage + 1)"
-          :disabled="currentPage >= pagination.totalPages"
+          :disabled="loading || currentPage >= totalPages"
           route-active-class=""
         >
           <i class="fa fa-chevron-right" />
@@ -119,8 +125,8 @@ const currentPage = computed(() => {
         <Btn
           v-if="!mobile"
           :size="size"
-          :to="pageRoute(pagination.totalPages)"
-          :disabled="currentPage >= pagination.totalPages"
+          :to="pageRoute(totalPages)"
+          :disabled="loading || currentPage >= totalPages"
           route-active-class=""
         >
           <i class="fa fa-chevron-double-right" />


### PR DESCRIPTION
## What

Two changes to how lists carry their paginator.

**The paginator no longer waits for the response.** Every call site guarded it with `v-if="<data>"`, so the control did not exist until the request came back. On the eleven lists whose toolbar holds nothing else, that row was empty until then and the page jumped by a button's height once it filled. The loading state moves into the component instead — no result yet renders the frame with disabled arrows and an unknown page count (`1 of –`) — and the 92 guards across 51 files go with it.

A loaded but empty result now counts as one page rather than none, so it keeps the control too. An endpoint that sends no pagination meta at all still renders nothing.

**A toolbar carrying nothing but the paginator is centred.** `FilteredList` flags the case where there is no filter and no actions, and centres the control instead of pinning it to the right edge of an otherwise empty row. The empty left-hand box is hidden on the way, because the flex gap counts it as a sibling and would offset the control by half of it. The bottom paginator follows the top one — it is alone in its row on every list, and was only right-aligned to match the top.

Affected: `frontend/images`, `ships/[slug]/images`, `tools/travel-times`, `admin/admins`, `admin/oauth-applications`, `admin/fleets/[id]/members`, `admin/fleets/[id]/inventories`, `admin/users/[id]/fleets`, `admin/users/[id]/inventories`, `admin/maintenance/rsi-api-status`, `admin/supporter-contributions/funding-goals`. Every other list stays right-aligned.

## Notes

The per-page dropdown still only appears after the response: `perPageSteps` comes from the API and only `Model`, `Vehicle` and `FleetVehicle` declare `per_page_steps`, so it cannot be rendered ahead of time. On those three lists it slides in from the side after loading — horizontal only, the height is stable. Giving `ApplicationRecord` a default would fix that, but it is an API change and stayed out of here.

## Testing

- New `Paginator/index.spec.ts`: loading, empty, single page, many pages, no pagination meta (6 tests).
- Two tests in `FilteredList/index.spec.ts` for the centring condition.
- `/visual-tests/states` gained an empty and a loading paginator next to the existing fixtures.
- Not verified in a browser — no dev server was available in this session.

🤖
