### PR TITLE
feat(stats): export every stats page as CSV

### DIFF
--- a/app/frontend/frontend/components/Fleets/FleetStats/index.vue
+++ b/app/frontend/frontend/components/Fleets/FleetStats/index.vue
@@ -12,6 +12,12 @@ import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import Chart from "@/shared/components/Chart/index.vue";
+import StatsCsvExportBtn from "@/shared/components/StatsCsvExportBtn/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import {
+  type StatsChart,
+  type StatsMetric,
+} from "@/shared/composables/useStatsCsv";
 import {
   useFleetVehiclesStats as useFleetVehiclesStatsQuery,
   useFleetMembersStats as useFleetMembersStatsQuery,
@@ -125,13 +131,16 @@ const crewDeficit = computed(() => {
   return Math.abs(minCrew.value - totalMemberCount.value);
 });
 
-const crewDeficitLabel = computed(() => {
-  if (!minCrew.value || !totalMemberCount.value)
-    return t("labels.stats.crewDeficit");
-  return minCrew.value > totalMemberCount.value
+const crewDeltaLabel = (crew: number, members: number) => {
+  if (!crew || !members) return t("labels.stats.crewDeficit");
+  return crew > members
     ? t("labels.stats.crewDeficit")
     : t("labels.stats.crewSurplus");
-});
+};
+
+const crewDeficitLabel = computed(() =>
+  crewDeltaLabel(minCrew.value, totalMemberCount.value),
+);
 
 const crewDeficitIcon = computed(() => {
   if (minCrew.value > totalMemberCount.value)
@@ -186,9 +195,127 @@ const totalCreditsCompact = computed(() => compactUec(totalCredits.value));
 const totalIngameValueCompact = computed(() =>
   compactUec(totalIngameValue.value),
 );
+
+const csvScope = computed(() => `${props.fleet.slug}-fleet`);
+
+/*
+ * Keyed by the same `name` the Chart component gets, so a panel's export button
+ * and its chart cannot drift apart and the page-level export is just every
+ * value in here.
+ */
+const csvCharts = computed(() => ({
+  "vehicles-by-model": {
+    name: "vehicles-by-model",
+    title: t("labels.stats.vehiclesByModel", {
+      limit: vehiclesByModelLimit.value,
+    }),
+    points: vehiclesByModelOptions.value,
+  },
+  "members-by-role": {
+    name: "members-by-role",
+    title: t("labels.stats.membersByRole"),
+    points: membersByRole.value,
+  },
+  "models-by-classification": {
+    name: "models-by-classification",
+    title: t("labels.stats.modelsByClassification"),
+    points: modelsByClassificationOptions.value,
+  },
+  "models-by-manufacturer": {
+    name: "models-by-manufacturer",
+    title: t("labels.stats.modelsByManufacturer"),
+    points: modelsByManufacturerOptions.value,
+  },
+  "models-by-production-status": {
+    name: "models-by-production-status",
+    title: t("labels.stats.modelsByProductionStatus"),
+    points: modelsByProductionStatusOptions.value,
+  },
+  "models-by-size": {
+    name: "models-by-size",
+    title: t("labels.stats.modelsBySize"),
+    points: modelsBySizeOptions.value,
+  },
+}));
+
+const csvChartList = computed<StatsChart[]>(() =>
+  Object.values(csvCharts.value),
+);
+
+/*
+ * Read off the queries, not off the animated refs above - those hold 0 for the
+ * first 200ms of every visit, and an export is not an animation. The aUEC
+ * figures go out at full precision too; `compactUec` is for a panel that has one
+ * line to spend, not for a spreadsheet column.
+ */
+const csvMetrics = computed<StatsMetric[]>(() => {
+  const metrics = vehicleStats.value?.metrics;
+  const members = memberStats.value?.total;
+  const crew = metrics?.totalMinCrew;
+
+  return [
+    { label: t("labels.stats.quickStats.totalMembers"), value: members },
+    { label: t("labels.hangarMetrics.totalMinCrew"), value: crew },
+    {
+      label: t("labels.hangarMetrics.totalMaxCrew"),
+      value: metrics?.totalMaxCrew,
+    },
+    {
+      label: crewDeltaLabel(crew || 0, members || 0),
+      value: crew && members ? Math.abs(crew - members) : undefined,
+    },
+    {
+      label: t("labels.stats.quickStats.totalShips"),
+      value: vehicleStats.value?.total,
+    },
+    {
+      label: t("labels.hangarMetrics.uniqueModels"),
+      value: metrics?.uniqueModelsCount,
+    },
+    {
+      label: t("labels.hangarMetrics.flightReady"),
+      value: metrics?.flightReadyCount,
+    },
+    { label: t("labels.hangarMetrics.totalMoney"), value: metrics?.totalMoney },
+    {
+      label: t("labels.hangarMetrics.totalCredits"),
+      value: metrics?.totalCredits,
+    },
+    {
+      label: t("labels.hangarMetrics.totalIngameValue"),
+      value: metrics?.totalIngameValue,
+    },
+    {
+      label: t("labels.hangarMetrics.averagePledgePrice"),
+      value: metrics?.averagePledgePrice,
+    },
+    {
+      label: t("labels.hangarMetrics.manufacturerCount"),
+      value: metrics?.manufacturerCount,
+    },
+    {
+      label: t("labels.hangarMetrics.largestShip"),
+      value: metrics?.largestShip,
+    },
+    {
+      label: t("labels.hangarMetrics.smallestShip"),
+      value: metrics?.smallestShip,
+    },
+    { label: t("labels.hangarMetrics.totalCargo"), value: metrics?.totalCargo },
+  ];
+});
 </script>
 
 <template>
+  <Teleport to="#header-right">
+    <StatsCsvExportBtn
+      :scope="csvScope"
+      :charts="csvChartList"
+      :metrics="csvMetrics"
+      :size="BtnSizesEnum.MD"
+    />
+  </Teleport>
+
   <div class="row">
     <div class="col-12 col-sm-6 col-lg-3">
       <StatsPanel
@@ -332,6 +459,12 @@ const totalIngameValueCompact = computed(() =>
               limit: vehiclesByModelLimit,
             })
           }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['vehicles-by-model']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -350,6 +483,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.membersByRole") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['members-by-role']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -370,6 +509,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByClassification") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-classification']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -388,6 +533,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByManufacturer") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-manufacturer']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -408,6 +559,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByProductionStatus") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-production-status']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -426,6 +583,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsBySize") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-size']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart

--- a/app/frontend/frontend/components/Fleets/PublicFleetStats/index.vue
+++ b/app/frontend/frontend/components/Fleets/PublicFleetStats/index.vue
@@ -11,6 +11,12 @@ import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import Chart from "@/shared/components/Chart/index.vue";
+import StatsCsvExportBtn from "@/shared/components/StatsCsvExportBtn/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import {
+  type StatsChart,
+  type StatsMetric,
+} from "@/shared/composables/useStatsCsv";
 import {
   usePublicFleetVehiclesStats as usePublicFleetVehiclesStatsQuery,
   usePublicFleetMembersStats as usePublicFleetMembersStatsQuery,
@@ -150,9 +156,122 @@ const totalCreditsCompact = computed(() => compactUec(totalCredits.value));
 const totalIngameValueCompact = computed(() =>
   compactUec(totalIngameValue.value),
 );
+
+const csvScope = computed(() => `${props.fleet.slug}-fleet`);
+
+/*
+ * Keyed by the same `name` the Chart component gets, so a panel's export button
+ * and its chart cannot drift apart and the page-level export is just every
+ * value in here.
+ */
+const csvCharts = computed(() => ({
+  "vehicles-by-model": {
+    name: "vehicles-by-model",
+    title: t("labels.stats.vehiclesByModel", {
+      limit: vehiclesByModelLimit.value,
+    }),
+    points: vehiclesByModelOptions.value,
+  },
+  "models-by-classification": {
+    name: "models-by-classification",
+    title: t("labels.stats.modelsByClassification"),
+    points: modelsByClassificationOptions.value,
+  },
+  "models-by-production-status": {
+    name: "models-by-production-status",
+    title: t("labels.stats.modelsByProductionStatus"),
+    points: modelsByProductionStatusOptions.value,
+  },
+  "models-by-manufacturer": {
+    name: "models-by-manufacturer",
+    title: t("labels.stats.modelsByManufacturer"),
+    points: modelsByManufacturerOptions.value,
+  },
+  "models-by-size": {
+    name: "models-by-size",
+    title: t("labels.stats.modelsBySize"),
+    points: modelsBySizeOptions.value,
+  },
+}));
+
+const csvChartList = computed<StatsChart[]>(() =>
+  Object.values(csvCharts.value),
+);
+
+/*
+ * Read off the queries, not off the animated refs above - those hold 0 for the
+ * first 200ms of every visit, and an export is not an animation. The aUEC
+ * figures go out at full precision too; `compactUec` is for a panel that has one
+ * line to spend, not for a spreadsheet column.
+ */
+const csvMetrics = computed<StatsMetric[]>(() => {
+  const metrics = vehicleStats.value?.metrics;
+
+  return [
+    {
+      label: t("labels.stats.quickStats.totalMembers"),
+      value: memberStats.value?.total,
+    },
+    {
+      label: t("labels.hangarMetrics.totalMinCrew"),
+      value: metrics?.totalMinCrew,
+    },
+    {
+      label: t("labels.hangarMetrics.totalMaxCrew"),
+      value: metrics?.totalMaxCrew,
+    },
+    {
+      label: t("labels.stats.quickStats.totalShips"),
+      value: vehicleStats.value?.total,
+    },
+    {
+      label: t("labels.hangarMetrics.uniqueModels"),
+      value: metrics?.uniqueModelsCount,
+    },
+    {
+      label: t("labels.hangarMetrics.flightReady"),
+      value: metrics?.flightReadyCount,
+    },
+    { label: t("labels.hangarMetrics.totalMoney"), value: metrics?.totalMoney },
+    {
+      label: t("labels.hangarMetrics.totalCredits"),
+      value: metrics?.totalCredits,
+    },
+    {
+      label: t("labels.hangarMetrics.totalIngameValue"),
+      value: metrics?.totalIngameValue,
+    },
+    {
+      label: t("labels.hangarMetrics.averagePledgePrice"),
+      value: metrics?.averagePledgePrice,
+    },
+    {
+      label: t("labels.hangarMetrics.manufacturerCount"),
+      value: metrics?.manufacturerCount,
+    },
+    {
+      label: t("labels.hangarMetrics.largestShip"),
+      value: metrics?.largestShip,
+    },
+    {
+      label: t("labels.hangarMetrics.smallestShip"),
+      value: metrics?.smallestShip,
+    },
+    { label: t("labels.hangarMetrics.totalCargo"), value: metrics?.totalCargo },
+  ];
+});
 </script>
 
 <template>
+  <Teleport to="#header-right">
+    <StatsCsvExportBtn
+      :scope="csvScope"
+      :charts="csvChartList"
+      :metrics="csvMetrics"
+      :size="BtnSizesEnum.MD"
+    />
+  </Teleport>
+
   <div class="row">
     <div class="col-12 col-sm-6 col-lg-3">
       <StatsPanel
@@ -282,6 +401,12 @@ const totalIngameValueCompact = computed(() =>
               limit: vehiclesByModelLimit,
             })
           }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['vehicles-by-model']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -300,6 +425,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByClassification") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-classification']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -320,6 +451,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByProductionStatus") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-production-status']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -338,6 +475,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByManufacturer") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-manufacturer']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -358,6 +501,12 @@ const totalIngameValueCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsBySize") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-size']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart

--- a/app/frontend/frontend/components/Hangar/PublicHangarStats/index.vue
+++ b/app/frontend/frontend/components/Hangar/PublicHangarStats/index.vue
@@ -11,6 +11,12 @@ import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import Chart from "@/shared/components/Chart/index.vue";
+import StatsCsvExportBtn from "@/shared/components/StatsCsvExportBtn/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import {
+  type StatsChart,
+  type StatsMetric,
+} from "@/shared/composables/useStatsCsv";
 import {
   usePublicHangarStats as usePublicHangarStatsQuery,
   usePublicHangarModelsByClassification as usePublicHangarModelsByClassificationQuery,
@@ -93,9 +99,93 @@ const flightReadyPercent = computed(() => {
   if (!totalCount.value || !flightReadyCount.value) return "";
   return `(${Math.round((flightReadyCount.value / totalCount.value) * 100)}%)`;
 });
+
+const csvScope = computed(() => `${props.username}-hangar`);
+
+/*
+ * Keyed by the same `name` the Chart component gets, so a panel's export button
+ * and its chart cannot drift apart and the page-level export is just every
+ * value in here.
+ */
+const csvCharts = computed(() => ({
+  "models-by-classification": {
+    name: "models-by-classification",
+    title: t("labels.stats.modelsByClassification"),
+    points: modelsByClassificationOptions.value,
+  },
+  "models-by-size": {
+    name: "models-by-size",
+    title: t("labels.stats.modelsBySize"),
+    points: modelsBySizeOptions.value,
+  },
+  "models-by-production-status": {
+    name: "models-by-production-status",
+    title: t("labels.stats.modelsByProductionStatus"),
+    points: modelsByProductionStatusOptions.value,
+  },
+  "models-by-manufacturer": {
+    name: "models-by-manufacturer",
+    title: t("labels.stats.modelsByManufacturer"),
+    points: modelsByManufacturerOptions.value,
+  },
+}));
+
+const csvChartList = computed<StatsChart[]>(() =>
+  Object.values(csvCharts.value),
+);
+
+// Read off the query, not off the animated refs above - those hold 0 for the
+// first 200ms of every visit, and an export is not an animation.
+const csvMetrics = computed<StatsMetric[]>(() => [
+  {
+    label: t("labels.stats.quickStats.totalShips"),
+    value: quickStats.value?.total,
+  },
+  {
+    label: t("labels.hangarMetrics.uniqueModels"),
+    value: quickStats.value?.metrics.uniqueModelsCount,
+  },
+  {
+    label: t("labels.hangarMetrics.flightReady"),
+    value: quickStats.value?.metrics.flightReadyCount,
+  },
+  {
+    label: t("labels.hangarMetrics.totalCargo"),
+    value: quickStats.value?.metrics.totalCargo,
+  },
+  {
+    label: t("labels.hangarMetrics.manufacturerCount"),
+    value: quickStats.value?.metrics.manufacturerCount,
+  },
+  {
+    label: t("labels.hangarMetrics.largestShip"),
+    value: quickStats.value?.metrics.largestShip,
+  },
+  {
+    label: t("labels.hangarMetrics.smallestShip"),
+    value: quickStats.value?.metrics.smallestShip,
+  },
+  {
+    label: t("labels.hangarMetrics.totalMinCrew"),
+    value: quickStats.value?.metrics.totalMinCrew,
+  },
+  {
+    label: t("labels.hangarMetrics.totalMaxCrew"),
+    value: quickStats.value?.metrics.totalMaxCrew,
+  },
+]);
 </script>
 
 <template>
+  <Teleport to="#header-right">
+    <StatsCsvExportBtn
+      :scope="csvScope"
+      :charts="csvChartList"
+      :metrics="csvMetrics"
+      :size="BtnSizesEnum.MD"
+    />
+  </Teleport>
+
   <div class="row">
     <div class="col-12 col-sm-6 col-lg-3">
       <StatsPanel
@@ -180,6 +270,12 @@ const flightReadyPercent = computed(() => {
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByClassification") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-classification']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -198,6 +294,12 @@ const flightReadyPercent = computed(() => {
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsBySize") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-size']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -218,6 +320,12 @@ const flightReadyPercent = computed(() => {
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByProductionStatus") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-production-status']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -236,6 +344,12 @@ const flightReadyPercent = computed(() => {
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByManufacturer") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              :scope="csvScope"
+              :chart="csvCharts['models-by-manufacturer']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart

--- a/app/frontend/frontend/pages/hangar/stats.vue
+++ b/app/frontend/frontend/pages/hangar/stats.vue
@@ -16,6 +16,11 @@ import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import StatsPanel from "@/shared/components/StatsPanel/index.vue";
 import MissingRolesPanel from "@/shared/components/MissingRolesPanel/index.vue";
+import StatsCsvExportBtn from "@/shared/components/StatsCsvExportBtn/index.vue";
+import {
+  type StatsChart,
+  type StatsMetric,
+} from "@/shared/composables/useStatsCsv";
 import { useI18n } from "@/shared/composables/useI18n";
 import { storeToRefs } from "pinia";
 import { useSessionStore } from "@/frontend/stores/session";
@@ -174,6 +179,111 @@ const totalIngameValueCompact = computed(() =>
 const wishlistTotalCreditsCompact = computed(() =>
   compactUec(wishlistTotalCredits.value),
 );
+
+/*
+ * Keyed by the same `name` the Chart component gets, so a panel's export button
+ * and its chart cannot drift apart and the page-level export is just every
+ * value in here.
+ */
+const csvCharts = computed(() => ({
+  "models-by-classification": {
+    name: "models-by-classification",
+    title: t("labels.stats.modelsByClassification"),
+    points: modelsByClassificationOptions.value,
+  },
+  "models-by-size": {
+    name: "models-by-size",
+    title: t("labels.stats.modelsBySize"),
+    points: modelsBySizeOptions.value,
+  },
+  "models-by-production-status": {
+    name: "models-by-production-status",
+    title: t("labels.stats.modelsByProductionStatus"),
+    points: modelsByProductionStatusOptions.value,
+  },
+  "models-by-manufacturer": {
+    name: "models-by-manufacturer",
+    title: t("labels.stats.modelsByManufacturer"),
+    points: modelsByManufacturerOptions.value,
+  },
+}));
+
+const csvChartList = computed<StatsChart[]>(() =>
+  Object.values(csvCharts.value),
+);
+
+/*
+ * Read off the query, not off the animated refs above - those hold 0 for the
+ * first 200ms of every visit, and an export is not an animation. The aUEC
+ * figures go out at full precision too; `compactUec` is for a panel that has one
+ * line to spend, not for a spreadsheet column.
+ */
+const csvMetrics = computed<StatsMetric[]>(() => [
+  {
+    label: t("labels.stats.quickStats.totalShips"),
+    value: quickStats.value?.total,
+  },
+  {
+    label: t("labels.hangarMetrics.uniqueModels"),
+    value: quickStats.value?.metrics.uniqueModelsCount,
+  },
+  {
+    label: t("labels.hangarMetrics.flightReady"),
+    value: quickStats.value?.metrics.flightReadyCount,
+  },
+  {
+    label: t("labels.hangarMetrics.totalCargo"),
+    value: quickStats.value?.metrics.totalCargo,
+  },
+  {
+    label: t("labels.hangarMetrics.totalMoney"),
+    value: quickStats.value?.metrics.totalMoney,
+  },
+  {
+    label: t("labels.hangarMetrics.totalCredits"),
+    value: quickStats.value?.metrics.totalCredits,
+  },
+  {
+    label: t("labels.hangarMetrics.totalIngameValue"),
+    value: quickStats.value?.metrics.totalIngameValue,
+  },
+  {
+    label: t("labels.hangarMetrics.averagePledgePrice"),
+    value: quickStats.value?.metrics.averagePledgePrice,
+  },
+  {
+    label: t("labels.hangarMetrics.manufacturerCount"),
+    value: quickStats.value?.metrics.manufacturerCount,
+  },
+  {
+    label: t("labels.hangarMetrics.largestShip"),
+    value: quickStats.value?.metrics.largestShip,
+  },
+  {
+    label: t("labels.hangarMetrics.smallestShip"),
+    value: quickStats.value?.metrics.smallestShip,
+  },
+  {
+    label: t("labels.hangarMetrics.wishlistTotalMoney"),
+    value: quickStats.value?.metrics.wishlistTotalMoney,
+  },
+  {
+    label: t("labels.hangarMetrics.wishlistTotalCredits"),
+    value: quickStats.value?.metrics.wishlistTotalCredits,
+  },
+  {
+    label: t("labels.hangarMetrics.totalMinCrew"),
+    value: quickStats.value?.metrics.totalMinCrew,
+  },
+  {
+    label: t("labels.hangarMetrics.totalMaxCrew"),
+    value: quickStats.value?.metrics.totalMaxCrew,
+  },
+  {
+    label: t("labels.wishlist"),
+    value: quickStats.value?.wishlistTotal,
+  },
+]);
 </script>
 
 <template>
@@ -189,6 +299,12 @@ const wishlistTotalCreditsCompact = computed(() =>
       :url="shareUrl"
       :title="shareTitle"
       no-label
+    />
+    <StatsCsvExportBtn
+      scope="hangar"
+      :charts="csvChartList"
+      :metrics="csvMetrics"
+      :size="BtnSizesEnum.MD"
     />
   </Teleport>
 
@@ -341,6 +457,12 @@ const wishlistTotalCreditsCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByClassification") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="hangar"
+              :chart="csvCharts['models-by-classification']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -357,6 +479,12 @@ const wishlistTotalCreditsCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsBySize") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="hangar"
+              :chart="csvCharts['models-by-size']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -375,6 +503,12 @@ const wishlistTotalCreditsCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByProductionStatus") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="hangar"
+              :chart="csvCharts['models-by-production-status']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -391,6 +525,12 @@ const wishlistTotalCreditsCompact = computed(() =>
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByManufacturer") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="hangar"
+              :chart="csvCharts['models-by-manufacturer']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart

--- a/app/frontend/frontend/pages/stats.vue
+++ b/app/frontend/frontend/pages/stats.vue
@@ -12,6 +12,12 @@ import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import StatsPanel from "@/shared/components/StatsPanel/index.vue";
+import StatsCsvExportBtn from "@/shared/components/StatsCsvExportBtn/index.vue";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import {
+  type StatsChart,
+  type StatsMetric,
+} from "@/shared/composables/useStatsCsv";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
   useStats as useStatsQuery,
@@ -107,12 +113,121 @@ watch(
   },
   { immediate: true },
 );
+
+/*
+ * Keyed by the same `name` the Chart component gets, so a panel's export button
+ * and its chart cannot drift apart and the page-level export is just every
+ * value in here.
+ */
+const csvCharts = computed(() => ({
+  "vehicles-by-model": {
+    name: "vehicles-by-model",
+    title: t("labels.stats.topVehiclesByModel"),
+    points: vehiclesByModelOptions.value,
+  },
+  "ships-of-the-month": {
+    name: "ships-of-the-month",
+    title: t("labels.stats.shipsOfTheMonth"),
+    points: shipsOfTheMonthOptions.value,
+  },
+  "models-by-classification": {
+    name: "models-by-classification",
+    title: t("labels.stats.modelsByClassification"),
+    points: modelsByClassification.value,
+  },
+  "models-by-size": {
+    name: "models-by-size",
+    title: t("labels.stats.modelsBySize"),
+    points: modelsBySize.value,
+  },
+  "models-by-production-status": {
+    name: "models-by-production-status",
+    title: t("labels.stats.modelsByProductionStatus"),
+    points: modelsByProductionStatus.value,
+  },
+  "models-per-month": {
+    name: "models-per-month",
+    title: t("labels.stats.modelsPerMonth"),
+    points: modelsPerMonth.value,
+  },
+  "models-by-manufacturer": {
+    name: "models-by-manufacturer",
+    title: t("labels.stats.modelsByManufacturer"),
+    points: modelsByManufacturer.value,
+  },
+  "vehicles-per-month": {
+    name: "vehicles-per-month",
+    title: t("labels.stats.vehiclesPerMonth"),
+    points: vehiclesPerMonthOptions.value,
+  },
+}));
+
+const csvChartList = computed<StatsChart[]>(() =>
+  Object.values(csvCharts.value),
+);
+
+// Read off the query, not off the animated refs above - those hold 0 for the
+// first 200ms of every visit, and an export is not an animation.
+const csvMetrics = computed<StatsMetric[]>(() => [
+  {
+    label: t("labels.stats.quickStats.newShips", {
+      year: String(new Date().getFullYear()),
+    }),
+    value: quickStats.value?.shipsCountYear,
+  },
+  {
+    label: t("labels.stats.quickStats.totalShips"),
+    value: quickStats.value?.shipsCountTotal,
+  },
+  {
+    label: t("labels.hangarMetrics.flightReady"),
+    value: quickStats.value?.flightReadyCount,
+  },
+  {
+    label: t("labels.hangarMetrics.manufacturerCount"),
+    value: quickStats.value?.manufacturerCount,
+  },
+  {
+    label: t("labels.hangarMetrics.averagePledgePrice"),
+    value: quickStats.value?.averagePledgePrice,
+  },
+  {
+    label: t("labels.hangarMetrics.largestShip"),
+    value: quickStats.value?.largestShip,
+  },
+  {
+    label: t("labels.hangarMetrics.smallestShip"),
+    value: quickStats.value?.smallestShip,
+  },
+  {
+    label: t("labels.stats.quickStats.vehicles"),
+    value: quickStats.value?.vehiclesCount,
+  },
+  {
+    label: t("labels.stats.quickStats.wishlists"),
+    value: quickStats.value?.wishlistsCount,
+  },
+  {
+    label: shipOfTheMonthLabel.value,
+    value: quickStats.value?.shipOfTheMonthCount,
+  },
+]);
 </script>
 
 <template>
   <Teleport to="#header-left">
     <Heading hidden>{{ t(`headlines.${route.meta.title}`) }}</Heading>
   </Teleport>
+
+  <Teleport to="#header-right">
+    <StatsCsvExportBtn
+      scope="stats"
+      :charts="csvChartList"
+      :metrics="csvMetrics"
+      :size="BtnSizesEnum.MD"
+    />
+  </Teleport>
+
   <div class="row" data-test="stats">
     <div class="col-12 col-sm-6 col-lg-3">
       <StatsPanel
@@ -205,6 +320,12 @@ watch(
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.topVehiclesByModel") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['vehicles-by-model']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -223,6 +344,12 @@ watch(
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.shipsOfTheMonth") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['ships-of-the-month']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -244,6 +371,12 @@ watch(
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByClassification") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['models-by-classification']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -262,6 +395,12 @@ watch(
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsBySize") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['models-by-size']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -281,6 +420,12 @@ watch(
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByProductionStatus") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['models-by-production-status']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -298,6 +443,12 @@ watch(
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsPerMonth") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['models-per-month']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -317,6 +468,12 @@ watch(
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.modelsByManufacturer") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['models-by-manufacturer']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart
@@ -334,6 +491,12 @@ watch(
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.vehiclesPerMonth") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['vehicles-per-month']"
+            />
+          </template>
         </PanelHeading>
         <PanelBody>
           <Chart

--- a/app/frontend/shared/components/StatsCsvExportBtn/index.spec.ts
+++ b/app/frontend/shared/components/StatsCsvExportBtn/index.spec.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+import Component from "./index.vue";
+import {
+  type StatsChart,
+  type StatsMetric,
+} from "@/shared/composables/useStatsCsv";
+
+const downloadJs = vi.hoisted(() => vi.fn());
+
+vi.mock("downloadjs", () => ({ default: downloadJs }));
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const slices = [
+  { name: "large", y: 2, selected: false, sliced: false },
+  { name: "small", y: 1, selected: false, sliced: false },
+];
+
+const bySize: StatsChart = {
+  name: "models-by-size",
+  title: "Ships by Size",
+  points: slices,
+};
+
+const mountWith = (props: {
+  chart?: StatsChart;
+  charts?: StatsChart[];
+  metrics?: StatsMetric[];
+  withLabel?: boolean;
+}) =>
+  mount(Component, {
+    props: { scope: "stats", ...props },
+    global: {
+      stubs: {
+        Btn: {
+          inheritAttrs: false,
+          props: ["disabled"],
+          template:
+            '<button v-bind="$attrs" :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+        },
+      },
+      directives: { tooltip: () => {} },
+    },
+  });
+
+describe("StatsCsvExportBtn", () => {
+  it("names itself after the chart it exports", () => {
+    const wrapper = mountWith({ chart: bySize });
+
+    expect(
+      wrapper.find('[data-test="export-csv-models-by-size"]').exists(),
+    ).toBe(true);
+  });
+
+  it("is the page-level button when handed a list instead of one chart", () => {
+    const wrapper = mountWith({ charts: [bySize] });
+
+    expect(wrapper.find('[data-test="export-csv-all"]').exists()).toBe(true);
+  });
+
+  it("carries an icon and no label unless asked for one", () => {
+    expect(mountWith({ chart: bySize }).text()).toBe("");
+    expect(mountWith({ chart: bySize, withLabel: true }).text()).toBe(
+      "actions.exportCsv",
+    );
+  });
+
+  it("stays disabled while the chart has no data", () => {
+    const wrapper = mountWith({
+      chart: { name: "models-by-size", title: "Ships by Size", points: [] },
+    });
+
+    expect(wrapper.get<HTMLButtonElement>("button").element.disabled).toBe(
+      true,
+    );
+  });
+
+  it("enables once the data lands", () => {
+    const wrapper = mountWith({ chart: bySize });
+
+    expect(wrapper.get<HTMLButtonElement>("button").element.disabled).toBe(
+      false,
+    );
+  });
+
+  it("exports just its own chart on click", async () => {
+    downloadJs.mockClear();
+
+    await mountWith({ chart: bySize }).get("button").trigger("click");
+
+    const [, filename] = downloadJs.mock.calls.at(-1) as [Blob, string];
+
+    expect(filename).toContain("fleetyards-stats-models-by-size-");
+  });
+
+  it("exports the whole page on click, without a chart name in the file", async () => {
+    downloadJs.mockClear();
+
+    await mountWith({
+      charts: [bySize],
+      metrics: [{ label: "Total Ships", value: 3 }],
+    })
+      .get("button")
+      .trigger("click");
+
+    const [, filename] = downloadJs.mock.calls.at(-1) as [Blob, string];
+
+    expect(filename).toContain("fleetyards-stats-");
+    expect(filename).not.toContain("models-by-size");
+  });
+
+  it("is enabled by metrics alone, for a page whose charts are all empty", () => {
+    const wrapper = mountWith({
+      charts: [{ name: "models-by-size", title: "t", points: [] }],
+      metrics: [{ label: "Total Ships", value: 3 }],
+    });
+
+    expect(wrapper.get<HTMLButtonElement>("button").element.disabled).toBe(
+      false,
+    );
+  });
+});

--- a/app/frontend/shared/components/StatsCsvExportBtn/index.vue
+++ b/app/frontend/shared/components/StatsCsvExportBtn/index.vue
@@ -1,0 +1,84 @@
+<script lang="ts">
+export default {
+  name: "StatsCsvExportBtn",
+};
+</script>
+
+<script lang="ts" setup>
+import { computed } from "vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import {
+  BtnSizesEnum,
+  BtnVariantsEnum,
+} from "@/shared/components/base/Btn/types";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  useStatsCsv,
+  useStatsCsvReady,
+  type StatsChart,
+  type StatsMetric,
+} from "@/shared/composables/useStatsCsv";
+
+type Props = {
+  /** Names the subject in the filename: "stats", "<slug>-fleet", ... */
+  scope: string;
+  /** One chart's data, for the button in that chart's panel heading. */
+  chart?: StatsChart;
+  /** Every chart on the page, for the page-level button. */
+  charts?: StatsChart[];
+  /** The page's quick-stat panels, for the page-level button. */
+  metrics?: StatsMetric[];
+  withLabel?: boolean;
+  variant?: `${BtnVariantsEnum}`;
+  size?: `${BtnSizesEnum}`;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  chart: undefined,
+  charts: undefined,
+  metrics: undefined,
+  withLabel: false,
+  variant: undefined,
+  size: undefined,
+});
+
+const { t } = useI18n();
+
+const { exportChart, exportAll } = useStatsCsv(() => props.scope);
+
+const label = computed(() =>
+  props.chart ? t("actions.exportCsv") : t("actions.exportAllCsv"),
+);
+
+// A single `chart` is the panel-heading button; `charts` plus `metrics` is the
+// one in the page header that writes the whole page as one file.
+const charts = computed(() =>
+  props.chart ? [props.chart] : props.charts || [],
+);
+
+const ready = useStatsCsvReady(charts, () => props.metrics || []);
+
+const download = () => {
+  if (props.chart) {
+    exportChart(props.chart);
+    return;
+  }
+
+  exportAll(props.metrics || [], props.charts || []);
+};
+</script>
+
+<template>
+  <Btn
+    v-tooltip="withLabel ? undefined : label"
+    :aria-label="label"
+    :disabled="!ready"
+    :variant="variant"
+    :size="size"
+    :data-test="chart ? `export-csv-${chart.name}` : 'export-csv-all'"
+    @click="download"
+  >
+    <i class="fa-duotone fa-file-csv" />
+    <span v-if="withLabel">{{ label }}</span>
+  </Btn>
+</template>

--- a/app/frontend/shared/composables/useStatsCsv.spec.ts
+++ b/app/frontend/shared/composables/useStatsCsv.spec.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ref } from "vue";
+
+import {
+  chartRows,
+  useStatsCsv,
+  useStatsCsvReady,
+  type StatsChart,
+} from "./useStatsCsv";
+
+const downloadJs = vi.hoisted(() => vi.fn());
+
+vi.mock("downloadjs", () => ({ default: downloadJs }));
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+const BOM_BYTES = [0xef, 0xbb, 0xbf];
+
+const bars = [
+  { label: "Aurora", count: 3, tooltip: "Aurora: 3 Ships" },
+  { label: "Drake, Interplanetary", count: 1, tooltip: "..." },
+];
+
+const slices = [
+  { name: "large", y: 2, selected: false, sliced: false },
+  { name: "small", y: 1, selected: false, sliced: false },
+];
+
+const lastDownload = () => {
+  const [blob, filename] = downloadJs.mock.calls.at(-1) as [Blob, string];
+
+  return { blob, filename };
+};
+
+const lastBytes = async () =>
+  new Uint8Array(await lastDownload().blob.arrayBuffer());
+
+// Byte-level and past the BOM, because `Blob.text()` performs a UTF-8 decode
+// and that strips a leading BOM - the very thing the export writes for Excel.
+const lastCsv = async () =>
+  new TextDecoder().decode((await lastBytes()).slice(BOM_BYTES.length));
+
+beforeEach(() => {
+  downloadJs.mockClear();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-02T10:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("chartRows", () => {
+  it("reads a label and a count off either point shape", () => {
+    expect(chartRows(bars)).toEqual([
+      ["Aurora", 3],
+      ["Drake, Interplanetary", 1],
+    ]);
+    expect(chartRows(slices)).toEqual([
+      ["large", 2],
+      ["small", 1],
+    ]);
+  });
+
+  it("is empty for a chart whose data has not landed", () => {
+    expect(chartRows(undefined)).toEqual([]);
+    expect(chartRows(null)).toEqual([]);
+  });
+});
+
+describe("useStatsCsv", () => {
+  describe("exportChart", () => {
+    it("writes one two-column section headed by the chart's title", async () => {
+      useStatsCsv("stats").exportChart({
+        name: "models-by-size",
+        title: "Ships by Size",
+        points: slices,
+      });
+
+      expect(await lastCsv()).toBe(
+        "Ships by Size,labels.stats.csv.count\r\nlarge,2\r\nsmall,1",
+      );
+    });
+
+    it("opens the file with a UTF-8 BOM, so Excel reads it as UTF-8", async () => {
+      useStatsCsv("stats").exportChart({
+        name: "models-by-size",
+        title: "Ships by Size",
+        points: slices,
+      });
+
+      const { blob } = lastDownload();
+
+      expect(Array.from((await lastBytes()).slice(0, 3))).toEqual(BOM_BYTES);
+      expect(blob.type).toBe("text/csv;charset=utf-8");
+    });
+
+    it("names the file after the scope, the chart and the day", () => {
+      useStatsCsv("stats").exportChart({
+        name: "models-by-size",
+        title: "Ships by Size",
+        points: slices,
+      });
+
+      expect(lastDownload().filename).toBe(
+        "fleetyards-stats-models-by-size-2026-09-02.csv",
+      );
+    });
+
+    it("tracks a reactive scope", () => {
+      const scope = ref("aurora-hangar");
+      const { exportChart } = useStatsCsv(scope);
+
+      scope.value = "reaper-fleet";
+
+      exportChart({ name: "models-by-size", title: "t", points: slices });
+
+      expect(lastDownload().filename).toBe(
+        "fleetyards-reaper-fleet-models-by-size-2026-09-02.csv",
+      );
+    });
+
+    it("quotes a label carrying a delimiter", async () => {
+      useStatsCsv("stats").exportChart({
+        name: "models-by-manufacturer",
+        title: "Ships by Manufacturer",
+        points: bars,
+      });
+
+      expect(await lastCsv()).toContain('"Drake, Interplanetary",1');
+    });
+
+    it("downloads nothing for a chart with no data", () => {
+      useStatsCsv("stats").exportChart({
+        name: "models-by-size",
+        title: "Ships by Size",
+        points: [],
+      });
+
+      expect(downloadJs).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("exportAll", () => {
+    const charts: StatsChart[] = [
+      { name: "models-by-size", title: "Ships by Size", points: slices },
+      { name: "models-per-month", title: "Ships per Month", points: [] },
+      { name: "vehicles-by-model", title: "Ships by Model", points: bars },
+    ];
+
+    it("leads with the metrics, then one section per chart that has data", async () => {
+      useStatsCsv("hangar").exportAll(
+        [
+          { label: "Total Ships", value: 4 },
+          { label: "Average Price", value: 72.5 },
+        ],
+        charts,
+      );
+
+      expect(await lastCsv()).toBe(
+        [
+          "labels.stats.csv.metric,labels.stats.csv.value",
+          "Total Ships,4",
+          "Average Price,72.5",
+          "",
+          "Ships by Size,labels.stats.csv.count",
+          "large,2",
+          "small,1",
+          "",
+          "Ships by Model,labels.stats.csv.count",
+          "Aurora,3",
+          '"Drake, Interplanetary",1',
+        ].join("\r\n"),
+      );
+    });
+
+    it("skips a metric whose query has not answered yet", async () => {
+      useStatsCsv("hangar").exportAll(
+        [
+          { label: "Total Ships", value: 4 },
+          { label: "Total Credits", value: undefined },
+          { label: "Total Cargo", value: null },
+          { label: "Flight Ready", value: 0 },
+        ],
+        [],
+      );
+
+      expect(await lastCsv()).toBe(
+        [
+          "labels.stats.csv.metric,labels.stats.csv.value",
+          "Total Ships,4",
+          "Flight Ready,0",
+        ].join("\r\n"),
+      );
+    });
+
+    it("names the file after the scope and the day only", () => {
+      useStatsCsv("aurora-hangar").exportAll([], charts);
+
+      expect(lastDownload().filename).toBe(
+        "fleetyards-aurora-hangar-2026-09-02.csv",
+      );
+    });
+
+    it("downloads nothing when neither the metrics nor the charts have data", () => {
+      useStatsCsv("hangar").exportAll(
+        [{ label: "Total Ships", value: undefined }],
+        [{ name: "models-by-size", title: "t", points: [] }],
+      );
+
+      expect(downloadJs).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("useStatsCsvReady", () => {
+  it("is false while every chart and metric is still empty", () => {
+    const ready = useStatsCsvReady(
+      () => [{ name: "a", title: "a", points: [] }],
+      () => [{ label: "Total Ships", value: null }],
+    );
+
+    expect(ready.value).toBe(false);
+  });
+
+  it("is true once one chart has a point", () => {
+    const charts = ref<StatsChart[]>([{ name: "a", title: "a", points: [] }]);
+    const ready = useStatsCsvReady(charts);
+
+    expect(ready.value).toBe(false);
+
+    charts.value = [{ name: "a", title: "a", points: slices }];
+
+    expect(ready.value).toBe(true);
+  });
+
+  it("is true once one metric has a value, charts or not", () => {
+    const ready = useStatsCsvReady(
+      () => [],
+      () => [{ label: "Total Ships", value: 0 }],
+    );
+
+    expect(ready.value).toBe(true);
+  });
+});

--- a/app/frontend/shared/composables/useStatsCsv.ts
+++ b/app/frontend/shared/composables/useStatsCsv.ts
@@ -1,0 +1,107 @@
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+import { format } from "date-fns";
+import downloadJs from "downloadjs";
+import { sectionsToCsv, type CsvSection } from "@/shared/utils/Csv";
+import { useI18n } from "@/shared/composables/useI18n";
+import type { PieChartStats, BarChartStats } from "@/services/fyApi";
+
+/*
+ * Both shapes the API serves a chart in, plus the bare Highcharts point the
+ * fleet's members-by-role chart is assembled from in the component. They differ
+ * only in what the label and the value are called.
+ */
+export type StatsChartPoint =
+  PieChartStats | BarChartStats | { name: string; y: number };
+
+export type StatsChart = {
+  /** Slug for the per-chart filename; the same `name` the Chart component gets. */
+  name: string;
+  /** The panel heading, which is also this section's first header cell. */
+  title: string;
+  points?: StatsChartPoint[] | null;
+};
+
+export type StatsMetric = {
+  label: string;
+  value: number | string | null | undefined;
+};
+
+// Excel reads a file without one as the system codepage, which mojibakes every
+// non-ASCII manufacturer, ship and fleet-role name and empties the CJK headers.
+const BOM = "\uFEFF";
+
+const pointLabel = (point: StatsChartPoint): string =>
+  "label" in point ? point.label : point.name;
+
+const pointValue = (point: StatsChartPoint): number =>
+  "count" in point ? point.count : point.y;
+
+export const chartRows = (points?: StatsChartPoint[] | null) =>
+  (points || []).map((point) => [pointLabel(point), pointValue(point)]);
+
+const hasValue = ({ value }: StatsMetric) =>
+  value !== null && value !== undefined;
+
+/**
+ * Builds the CSV a stats page hands to the browser, from data the page has
+ * already fetched. `scope` names the subject - "stats", "hangar",
+ * "<username>-hangar", "<slug>-fleet" - and lands in the filename.
+ */
+export const useStatsCsv = (scope: MaybeRefOrGetter<string>) => {
+  const { t } = useI18n();
+
+  const filename = (suffix?: string) =>
+    `${["fleetyards", toValue(scope), suffix, format(new Date(), "yyyy-MM-dd")]
+      .filter(Boolean)
+      .join("-")}.csv`;
+
+  const chartSection = (chart: StatsChart): CsvSection => ({
+    headers: [chart.title, t("labels.stats.csv.count")],
+    rows: chartRows(chart.points),
+  });
+
+  const metricsSection = (metrics: StatsMetric[]): CsvSection => ({
+    headers: [t("labels.stats.csv.metric"), t("labels.stats.csv.value")],
+    rows: metrics.filter(hasValue).map(({ label, value }) => [label, value]),
+  });
+
+  const download = (name: string, sections: CsvSection[]) => {
+    const csv = sectionsToCsv(sections);
+
+    if (!csv) {
+      return;
+    }
+
+    downloadJs(
+      new Blob([BOM + csv], { type: "text/csv;charset=utf-8" }),
+      name,
+      "text/csv",
+    );
+  };
+
+  const exportChart = (chart: StatsChart) =>
+    download(filename(chart.name), [chartSection(chart)]);
+
+  const exportAll = (metrics: StatsMetric[], charts: StatsChart[]) =>
+    download(filename(), [
+      metricsSection(metrics),
+      ...charts.map(chartSection),
+    ]);
+
+  return { filename, chartSection, metricsSection, exportChart, exportAll };
+};
+
+/**
+ * True once there is something to write. The export controls stay disabled until
+ * then, so a click while the queries are still in flight cannot hand the user an
+ * empty file.
+ */
+export const useStatsCsvReady = (
+  charts: MaybeRefOrGetter<StatsChart[]>,
+  metrics: MaybeRefOrGetter<StatsMetric[]> = () => [],
+) =>
+  computed(
+    () =>
+      toValue(charts).some((chart) => !!chart.points?.length) ||
+      toValue(metrics).some(hasValue),
+  );

--- a/app/frontend/shared/utils/Csv.spec.ts
+++ b/app/frontend/shared/utils/Csv.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { csvRow, sectionsToCsv, toCsv } from "./Csv";
+
+describe("csvRow", () => {
+  it("joins plain cells with commas", () => {
+    expect(csvRow(["Aurora", 12])).toBe("Aurora,12");
+  });
+
+  it("writes an empty cell for null and undefined", () => {
+    expect(csvRow([null, undefined, 0])).toBe(",,0");
+  });
+
+  it("keeps booleans and negative numbers as they are", () => {
+    expect(csvRow([true, false, -4, -0.5])).toBe("true,false,-4,-0.5");
+  });
+
+  it("quotes a cell carrying a delimiter", () => {
+    expect(csvRow(["Drake, Interplanetary", 1])).toBe(
+      '"Drake, Interplanetary",1',
+    );
+    expect(csvRow(["a;b"])).toBe('"a;b"');
+    expect(csvRow(["a\tb"])).toBe('"a\tb"');
+  });
+
+  it("quotes a cell carrying a line break", () => {
+    expect(csvRow(["two\nlines"])).toBe('"two\nlines"');
+    expect(csvRow(["two\r\nlines"])).toBe('"two\r\nlines"');
+  });
+
+  it("doubles an embedded quote and quotes the cell", () => {
+    expect(csvRow(['the "Best" ship'])).toBe('"the ""Best"" ship"');
+  });
+
+  it("neutralizes a cell a spreadsheet would read as a formula", () => {
+    expect(csvRow(["=1+1"])).toBe("'=1+1");
+    expect(csvRow(["+SUM(A1)"])).toBe("'+SUM(A1)");
+    expect(csvRow(["-2+3"])).toBe("'-2+3");
+    expect(csvRow(["@role"])).toBe("'@role");
+  });
+
+  it("quotes a neutralized cell that also carries a delimiter", () => {
+    expect(csvRow(['=HYPERLINK("a","b")'])).toBe('"\'=HYPERLINK(""a"",""b"")"');
+  });
+});
+
+describe("toCsv", () => {
+  it("separates rows with CRLF", () => {
+    expect(
+      toCsv([
+        ["a", "b"],
+        [1, 2],
+      ]),
+    ).toBe("a,b\r\n1,2");
+  });
+
+  it("is empty for no rows", () => {
+    expect(toCsv([])).toBe("");
+  });
+});
+
+describe("sectionsToCsv", () => {
+  it("puts a blank line between sections", () => {
+    const csv = sectionsToCsv([
+      { headers: ["Metric", "Value"], rows: [["Total Ships", 3]] },
+      {
+        headers: ["Ships by Size", "Count"],
+        rows: [
+          ["large", 2],
+          ["small", 1],
+        ],
+      },
+    ]);
+
+    expect(csv).toBe(
+      [
+        "Metric,Value",
+        "Total Ships,3",
+        "",
+        "Ships by Size,Count",
+        "large,2",
+        "small,1",
+      ].join("\r\n"),
+    );
+  });
+
+  it("drops a section with no rows rather than leaving a bare header", () => {
+    const csv = sectionsToCsv([
+      { headers: ["Metric", "Value"], rows: [["Total Ships", 3]] },
+      { headers: ["Ships by Size", "Count"], rows: [] },
+    ]);
+
+    expect(csv).toBe("Metric,Value\r\nTotal Ships,3");
+  });
+
+  it("is empty when every section is empty", () => {
+    expect(sectionsToCsv([{ headers: ["a", "b"], rows: [] }])).toBe("");
+  });
+});

--- a/app/frontend/shared/utils/Csv.ts
+++ b/app/frontend/shared/utils/Csv.ts
@@ -1,0 +1,59 @@
+export type CsvCell = string | number | boolean | null | undefined;
+
+export type CsvRow = CsvCell[];
+
+export type CsvSection = {
+  headers: CsvRow;
+  rows: CsvRow[];
+};
+
+// Semicolons and tabs are not delimiters here, but a spreadsheet opening the
+// file may treat them as such depending on its locale, so they get quoted too.
+const NEEDS_QUOTING = /["\n\r,;\t]/;
+
+// A cell opening with one of these is read as a formula rather than as text by
+// Excel and Sheets. Labels reach this file from fleet role names and ship names,
+// so they are not ours to trust; prefixing an apostrophe keeps them inert.
+const FORMULA_PREFIXES = ["=", "+", "-", "@"];
+
+const escape = (value: CsvCell): string => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  // Numbers and booleans cannot carry a formula or a delimiter, and a negative
+  // number must not pick up the apostrophe the guard below would add.
+  if (typeof value !== "string") {
+    return String(value);
+  }
+
+  const text = FORMULA_PREFIXES.some((prefix) => value.startsWith(prefix))
+    ? `'${value}`
+    : value;
+
+  if (!NEEDS_QUOTING.test(text)) {
+    return text;
+  }
+
+  return `"${text.replaceAll('"', '""')}"`;
+};
+
+export const csvRow = (row: CsvRow): string => row.map(escape).join(",");
+
+// CRLF per RFC 4180 - the one line ending every spreadsheet agrees on.
+export const toCsv = (rows: CsvRow[]): string => rows.map(csvRow).join("\r\n");
+
+/*
+ * Several two-column tables in one file, separated by a blank line. A section
+ * names itself in its own header row rather than in a title line of its own, so
+ * every row in the file has the same shape and a spreadsheet reads the whole
+ * thing as one sheet instead of guessing at a ragged first column.
+ *
+ * Empty sections are dropped: a header with nothing under it reads as data that
+ * failed to load rather than as a chart that has none.
+ */
+export const sectionsToCsv = (sections: CsvSection[]): string =>
+  sections
+    .filter((section) => section.rows.length)
+    .map((section) => toCsv([section.headers, ...section.rows]))
+    .join("\r\n\r\n");

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -385,7 +385,9 @@
         "markAsPaintSelected": "Auswahl als Lackierungen markieren",
         "ignoreSelected": "Auswahl ignorieren"
       },
-      "revert": "Zurücksetzen"
+      "revert": "Zurücksetzen",
+      "exportCsv": "CSV exportieren",
+      "exportAllCsv": "Alles als CSV exportieren"
     }
   }
 }

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -187,7 +187,12 @@
         "shipsOfTheMonth": "Schiff des Monats",
         "crewDeficit": "Crew Defizit",
         "crewSurplus": "Crew Überschuss",
-        "membersByRole": "Mitglieder nach Rolle"
+        "membersByRole": "Mitglieder nach Rolle",
+        "csv": {
+          "metric": "Kennzahl",
+          "value": "Wert",
+          "count": "Anzahl"
+        }
       },
       "roadmap": {
         "selectWeek": "Woche auswählen",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -385,7 +385,9 @@
         "markAsPaintSelected": "Mark selected as paints",
         "ignoreSelected": "Ignore selected"
       },
-      "revert": "Revert"
+      "revert": "Revert",
+      "exportCsv": "Export CSV",
+      "exportAllCsv": "Export all as CSV"
     }
   }
 }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -187,7 +187,12 @@
         "shipsOfTheMonth": "Ship of the Month",
         "crewDeficit": "Crew Deficit",
         "crewSurplus": "Crew Surplus",
-        "membersByRole": "Members by Role"
+        "membersByRole": "Members by Role",
+        "csv": {
+          "metric": "Metric",
+          "value": "Value",
+          "count": "Count"
+        }
       },
       "roadmap": {
         "selectWeek": "Select Week",

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -385,7 +385,9 @@
         "markAsPaintSelected": "Marcar la selección como pinturas",
         "ignoreSelected": "Ignorar la selección"
       },
-      "revert": "Revertir"
+      "revert": "Revertir",
+      "exportCsv": "Exportar CSV",
+      "exportAllCsv": "Exportar todo como CSV"
     }
   }
 }

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -187,7 +187,12 @@
         "shipsOfTheMonth": "Nave del mes",
         "crewDeficit": "Déficit de tripulación",
         "crewSurplus": "Excedente de tripulación",
-        "membersByRole": "Miembros por rol"
+        "membersByRole": "Miembros por rol",
+        "csv": {
+          "metric": "Métrica",
+          "value": "Valor",
+          "count": "Cantidad"
+        }
       },
       "roadmap": {
         "selectWeek": "Seleccionar semana",

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -385,7 +385,9 @@
         "markAsPaintSelected": "Marquer la sélection comme peintures",
         "ignoreSelected": "Ignorer la sélection"
       },
-      "revert": "Rétablir"
+      "revert": "Rétablir",
+      "exportCsv": "Exporter en CSV",
+      "exportAllCsv": "Tout exporter en CSV"
     }
   }
 }

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -187,7 +187,12 @@
         "shipsOfTheMonth": "Vaisseau du mois",
         "crewDeficit": "Déficit d'équipage",
         "crewSurplus": "Excédent d'équipage",
-        "membersByRole": "Membres par rôle"
+        "membersByRole": "Membres par rôle",
+        "csv": {
+          "metric": "Métrique",
+          "value": "Valeur",
+          "count": "Nombre"
+        }
       },
       "roadmap": {
         "selectWeek": "Sélectionnez une carte",

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -385,7 +385,9 @@
         "markAsPaintSelected": "Segna la selezione come livree",
         "ignoreSelected": "Ignora la selezione"
       },
-      "revert": "Ripristina"
+      "revert": "Ripristina",
+      "exportCsv": "Esporta CSV",
+      "exportAllCsv": "Esporta tutto in CSV"
     }
   }
 }

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -187,7 +187,12 @@
         "shipsOfTheMonth": "Nave del mese",
         "crewDeficit": "Deficit equipaggio",
         "crewSurplus": "Surplus equipaggio",
-        "membersByRole": "Membri per ruolo"
+        "membersByRole": "Membri per ruolo",
+        "csv": {
+          "metric": "Metrica",
+          "value": "Valore",
+          "count": "Conteggio"
+        }
       },
       "roadmap": {
         "selectWeek": "Seleziona Settimana",

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -385,7 +385,9 @@
         "markAsPaintSelected": "将所选标记为涂装",
         "ignoreSelected": "忽略所选"
       },
-      "revert": "还原"
+      "revert": "还原",
+      "exportCsv": "导出 CSV",
+      "exportAllCsv": "全部导出为 CSV"
     }
   }
 }

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -187,7 +187,12 @@
         "shipsOfTheMonth": "月度飞船",
         "crewDeficit": "船员缺口",
         "crewSurplus": "船员盈余",
-        "membersByRole": "按角色分组成员"
+        "membersByRole": "按角色分组成员",
+        "csv": {
+          "metric": "指标",
+          "value": "数值",
+          "count": "数量"
+        }
       },
       "roadmap": {
         "selectWeek": "选择周",

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -385,7 +385,9 @@
         "markAsPaintSelected": "將所選標記為塗裝",
         "ignoreSelected": "忽略所選"
       },
-      "revert": "還原"
+      "revert": "還原",
+      "exportCsv": "匯出 CSV",
+      "exportAllCsv": "全部匯出為 CSV"
     }
   }
 }

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -187,7 +187,12 @@
         "shipsOfTheMonth": "月度飛船",
         "crewDeficit": "船員缺口",
         "crewSurplus": "船員盈餘",
-        "membersByRole": "按角色分組成員"
+        "membersByRole": "按角色分組成員",
+        "csv": {
+          "metric": "指標",
+          "value": "數值",
+          "count": "數量"
+        }
       },
       "roadmap": {
         "selectWeek": "選擇週",


### PR DESCRIPTION
Adds CSV export to every stats page, at two levels: a button in each chart panel's heading that writes just that chart, and one in the page header that writes the quick-stat metrics plus every chart into a single file.

Covered surfaces:

| Page | Charts |
| --- | --- |
| `/stats` | 8 |
| `/hangar/stats` | 4 |
| Public hangar stats | 4 |
| Fleet stats | 6 |
| Public fleet stats | 5 |

Everything is generated in the browser from data the page has already fetched — no new endpoints, no schema regeneration, no policy work.

## Shape of the file

Every section is two columns and names itself in its own header row rather than in a title line of its own, so a spreadsheet reads the whole file as one sheet instead of guessing at a ragged first column:

```
Metric,Value
Total Ships,215
Flight Ready,143

Ships by Classification,Count
Combat,50
Transport,38
```

Empty sections are dropped — a header with nothing under it reads as data that failed to load rather than as a chart that has none.

## Decisions worth a look

- **Formula cells are neutralised.** A cell opening with `=`, `+`, `-` or `@` gets an apostrophe. Fleet role names and ship names reach this file, so they aren't ours to trust, and Excel and Sheets would otherwise read them as formulas. Numbers are exempt so a negative value keeps its sign.
- **The blob opens with a UTF-8 BOM.** Without it Excel reads the file as the system codepage, which mojibakes every non-ASCII manufacturer, ship and fleet-role name and empties the CJK headers. Worth knowing if you write a test against it: `Blob.text()` performs a UTF-8 decode, and that *strips* a leading BOM, so the assertion has to read raw bytes.
- **Metrics come off the queries, not the animated refs** the panels bind to. Those hold `0` for the first 200ms of every visit, and an export is not an animation. aUEC figures also go out at full precision — `compactUec` is for a panel with one line to spend, not a spreadsheet column.
- **Charts are declared once**, keyed by the same `name` the `Chart` component gets, so a panel's button and its chart can't drift apart and the page-level export is just every value in that object.
- **The button stays disabled until something has data**, so a click while the queries are still in flight can't hand over an empty file.

`FleetStats` gains a small `crewDeltaLabel` extraction so the panel and the CSV pick the deficit-or-surplus label by the same rule instead of duplicating it.

## Verification

- 36 new tests across `Csv.spec.ts`, `useStatsCsv.spec.ts` and `StatsCsvExportBtn/index.spec.ts` — all passing
- `eslint`, `vue-tsc` and `tsc` clean
- `bin/vite build --mode=test` succeeds
- Checked that every `<Chart name>` on all five surfaces has a matching declared key and a button, and that each surface has exactly one page-level button

Translations added for all seven locales.

🤖
