### PR TITLE
fix(fleets): refuse to delete a fleet role that still has members

### DIFF
--- a/app/models/fleet_role.rb
+++ b/app/models/fleet_role.rb
@@ -74,6 +74,7 @@ class FleetRole < ApplicationRecord
 
   before_save :update_slugs
   before_create :setup_rank
+  before_destroy :check_if_can_be_destroyed, prepend: true
 
   # Narrowed to this rank: a single mapping cannot affect anyone else.
   after_commit :backfill_discord_member_roles, if: :saved_change_to_discord_role_id?
@@ -151,6 +152,18 @@ class FleetRole < ApplicationRecord
     return if index < 0
 
     move_to(index - 1)
+  end
+
+  # Nullifying would leave the members silently without any privileges, so a
+  # role in use has to be emptied first. Skipped when the whole fleet is going
+  # away -- Fleet destroys its roles before its memberships. Prepended because
+  # the :nullify callback is registered first and would clear the rows we check.
+  private def check_if_can_be_destroyed
+    return if destroyed_by_association
+    return unless fleet_memberships.kept.exists?
+
+    errors.add(:base, I18n.t("activerecord.errors.models.fleet_role.attributes.base.cannot_destroy_with_members"))
+    throw(:abort)
   end
 
   private def resource_access_changed

--- a/config/locales/de/activerecord.yml
+++ b/config/locales/de/activerecord.yml
@@ -245,6 +245,8 @@ de:
       models:
         fleet_role:
           attributes:
+            base:
+              cannot_destroy_with_members: Eine Rolle, die noch Mitgliedern zugewiesen ist, kann nicht gelöscht werden
             resource_access:
               changed: Zugriffsrechte können nicht geändert werden
         fleet_membership:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -262,6 +262,8 @@ en:
               must_be_in_game: name a ship that is not in the game yet
         fleet_role:
           attributes:
+            base:
+              cannot_destroy_with_members: Cannot delete a role that is still assigned to members
             resource_access:
               changed: Access privileges can not be changed
         fleet_membership:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -245,6 +245,8 @@ es:
       models:
         fleet_role:
           attributes:
+            base:
+              cannot_destroy_with_members: No se puede eliminar un rol que todavía está asignado a miembros
             resource_access:
               changed: Los privilegios de acceso no se pueden cambiar
         fleet_membership:

--- a/config/locales/fr/activerecord.yml
+++ b/config/locales/fr/activerecord.yml
@@ -245,6 +245,8 @@ fr:
       models:
         fleet_role:
           attributes:
+            base:
+              cannot_destroy_with_members: Impossible de supprimer un rôle encore attribué à des membres
             resource_access:
               changed: Les privilèges d'accès ne peuvent pas être modifiés
         fleet_membership:

--- a/config/locales/it/activerecord.yml
+++ b/config/locales/it/activerecord.yml
@@ -245,6 +245,8 @@ it:
       models:
         fleet_role:
           attributes:
+            base:
+              cannot_destroy_with_members: Non è possibile eliminare un ruolo ancora assegnato ai membri
             resource_access:
               changed: I privilegi di accesso non possono essere modificati
         fleet_membership:

--- a/config/locales/zh-CN/activerecord.yml
+++ b/config/locales/zh-CN/activerecord.yml
@@ -248,6 +248,8 @@ zh-CN:
       models:
         fleet_role:
           attributes:
+            base:
+              cannot_destroy_with_members: 无法删除仍分配给成员的角色
             resource_access:
               changed: 访问权限无法更改
         fleet_membership:

--- a/config/locales/zh-TW/activerecord.yml
+++ b/config/locales/zh-TW/activerecord.yml
@@ -245,6 +245,8 @@ zh-TW:
       models:
         fleet_role:
           attributes:
+            base:
+              cannot_destroy_with_members: 無法刪除仍指派給成員的角色
             resource_access:
               changed: 存取權限無法變更
         fleet_membership:

--- a/test/models/fleet_role_test.rb
+++ b/test/models/fleet_role_test.rb
@@ -27,4 +27,47 @@ require "test_helper"
 
 class FleetRoleTest < ActiveSupport::TestCase
   should belong_to(:fleet)
+
+  setup do
+    @member_user = create(:user)
+    @fleet = create(:fleet, members: [@member_user])
+    @member_role = @fleet.fleet_roles.ranked.last
+    @officer_role = @fleet.fleet_roles.ranked.second
+  end
+
+  test "#destroy is refused while members are still assigned to the role" do
+    refute @member_role.destroy
+
+    assert_includes @member_role.errors[:base],
+      I18n.t("activerecord.errors.models.fleet_role.attributes.base.cannot_destroy_with_members")
+    assert FleetRole.exists?(@member_role.id)
+    assert_equal @member_role, @fleet.fleet_memberships.find_by(user: @member_user).reload.fleet_role
+  end
+
+  test "#destroy! raises while members are still assigned to the role" do
+    assert_raises ActiveRecord::RecordNotDestroyed do
+      @member_role.destroy!
+    end
+  end
+
+  test "#destroy succeeds for a role nobody is assigned to" do
+    assert @officer_role.destroy
+    refute FleetRole.exists?(@officer_role.id)
+  end
+
+  test "#destroy succeeds when only discarded memberships are assigned to the role" do
+    membership = @fleet.fleet_memberships.find_by(user: @member_user)
+    membership.discard
+
+    assert @member_role.destroy
+    assert_nil membership.reload.fleet_role_id
+  end
+
+  test "#destroy of the fleet still cascades through roles in use" do
+    assert @fleet.destroy
+
+    refute Fleet.exists?(@fleet.id)
+    assert_empty FleetRole.where(fleet_id: @fleet.id)
+    assert_empty FleetMembership.where(fleet_id: @fleet.id)
+  end
 end


### PR DESCRIPTION
## What

`FleetRole` had `has_many :fleet_memberships, dependent: :nullify`. Deleting a role that members were still assigned to left those memberships with `fleet_role_id: NULL`, and `has_access?` returns `false` when `fleet_role` is blank — so the members silently lost every privilege instead of the delete failing.

This guards the destroy instead: a role that is still assigned has to be emptied first.

```ruby
before_destroy :check_if_can_be_destroyed, prepend: true

private def check_if_can_be_destroyed
  return if destroyed_by_association
  return unless fleet_memberships.kept.exists?

  errors.add(:base, I18n.t("activerecord.errors.models.fleet_role.attributes.base.cannot_destroy_with_members"))
  throw(:abort)
end
```

`dependent: :nullify` stays — the fleet cascade needs it.

## Why not `dependent: :restrict_with_error`

That was the obvious first choice, and it breaks `Fleet#destroy`. Verified by setting it and running the cascade: `fleet.destroy` returned `false`, the fleet survived, and `fleet.errors` was **empty**.

`Fleet` destroys `fleet_roles` before `fleet_memberships` (declaration order, `app/models/fleet.rb:63-65`), so the restriction fires in the middle of the fleet's own cascade. `restrict_with_error` does not consult `destroyed_by_association` (`has_many_association.rb:19-24`) — it aborts unconditionally, and the error is added to the role, not to the fleet. That silent failure would also have hit `User#check_fleet_memberships`, which calls `fleet.destroy!` for multi-member fleets when `destroy_fleets` is set.

Two details in the guard are load-bearing:

- **`destroyed_by_association`** lets the guard pass while the whole fleet is going away.
- **`prepend: true`** — a plain `before_destroy` never fired. The `:nullify` callback is registered on line 33, the guard on line 77, and callbacks run in registration order, so nullify had already cleared the rows the guard checks. (`prepend_before_destroy` does not exist; the resulting NoMethodError in the class body surfaces as `PaperTrail::Error: has_paper_trail must be called only once`, because Zeitwerk retries the load.)

## Note on reachability

There is no destroy endpoint for fleet roles today (`config/routes/api/fleets_routes.rb:34` is `only: %i[index]`), so this is not a user-reachable bug right now. The guard is deliberately in the model so a future endpoint cannot skip it; the error format matches the existing guards, so the controller's `ValidationError` path works unchanged.

Out of scope: a `permanent` role with no members assigned can still be deleted, which would leave a fleet without an admin role. That is a separate guard with separate semantics.

## Tests

`test/models/fleet_role_test.rb`, 6 passing:

- destroy refused while a member is assigned, error on `:base`
- `destroy!` raises `ActiveRecord::RecordNotDestroyed`
- a role nobody is assigned to is deletable
- only-discarded memberships do not block, and are still nullified
- **regression:** `fleet.destroy` still cascades through roles in use — this is the one that catches the `restrict_with_error` variant

Also green locally: `fleet_test`, `fleet_discard_test`, `fleet_membership_test`, `fleet_membership_discard_test`, `user_test`, `users_me_test`, `admin/api/v1/users_test`, `fleets_roles_index_test` — 119 tests, 0 failures. `standardrb` clean.

New locale key `cannot_destroy_with_members` added in all seven languages.

🤖
