### PR TITLE
fix(filtered-list): keep the toolbar buttons together when the paginator wraps

### DIFF
--- a/app/frontend/shared/components/FilteredList/index.scss
+++ b/app/frontend/shared/components/FilteredList/index.scss
@@ -91,6 +91,17 @@
         justify-content: flex-end;
         gap: 10px;
       }
+
+      // The auto margin that holds the right edge is only ever paid for by the
+      // paginator: while the two share a row it grows into the free space and
+      // the margin resolves to nothing, and once it wraps below the margin is
+      // all that is left - stranding the filter button on its own with the
+      // actions pinned to the far edge of an otherwise empty row. Drop it where
+      // a paginator follows, so the buttons stay the one cluster they are when
+      // the row fits, and let the paginator do the pushing while it can.
+      &-right:has(+ .filtered-list__pagination-top) {
+        margin-left: 0;
+      }
     }
 
     // Takes the row it wraps onto, and holds the right edge of it - the same


### PR DESCRIPTION
## What

Below the desktop breakpoint the list toolbar's right-hand actions block still carries the `margin-left: auto` that splits the row into a left and a right half on a desktop. While the paginator fits on the row, that margin costs nothing — the paginator has `flex: 1 1 auto` and grows into the free space, so there is none left for the margin to claim, and the filter button and the actions read as one cluster 10px apart.

Once the paginator is wide enough to wrap, the free space comes back and the margin spends all of it: the filter button is stranded on the left of an otherwise empty row with the actions pinned to the far edge. On a 368px row, 120 per page is only ~15px wider than 60 — enough to flip it.

| 60 per page | 120 per page |
| --- | --- |
| filter + actions together, paginator right | filter alone, actions 229px away, paginator below |

## How

Drop the auto margin where a paginator follows (`:has(+ …)`). The buttons stay the cluster they already are when the row fits, and the paginator keeps doing the pushing for as long as it shares the row. A toolbar with no paginator is untouched and still holds the right edge.

## Verification

Measured with a static flex harness — the component's compiled SCSS over a hand-written toolbar, measured in Playwright at several container widths. Gap between the filter button and the action pair:

| container | per page | before | after |
| --- | --- | --- | --- |
| 320px | 60 | 181px | 10px |
| 345px | 60 | 206px | 10px |
| 368px | 60 | 10px (fits) | 10px (fits) |
| 368px | 120 | **229px** | 10px |
| 400px | 120 | 10px (fits) | 10px (fits) |

Rows that already fit are byte-identical before and after, and a paginator-less toolbar measures `249–345` both ways. The four existing `FilteredList` specs pass; they assert DOM structure, and a jsdom unit test cannot measure a flex line, so no test was added there.

🤖
