### PR TITLE
fix(filtered-list): keep a lone paginator on the right edge on a desktop

### DIFF
--- a/app/frontend/shared/components/FilteredList/index.scss
+++ b/app/frontend/shared/components/FilteredList/index.scss
@@ -42,28 +42,11 @@
 
 .filtered-list--pagination-only {
   // Hidden rather than left empty: the flex gap counts an empty box as a
-  // sibling and would push the paginator off centre by half of it.
+  // sibling and would push the paginator off centre by half of it. The row
+  // itself needs no other change on a desktop - the auto margin the toolbar
+  // hands the block already holds the right edge every other row aligns to.
   .filtered-list__actions-left {
     display: none;
-  }
-
-  .filtered-list__actions {
-    justify-content: center;
-  }
-
-  // The toolbar hands its right-hand blocks an auto margin, which would swallow
-  // the free space before `justify-content` could split it; and below the
-  // desktop breakpoint the block grows and pins the control to the right edge.
-  // Neither holds for a row that has nothing else on it.
-  .filtered-list__pagination-top {
-    margin-left: 0;
-    justify-content: center;
-  }
-
-  // The bottom paginator is alone in its row on every list; it follows the top
-  // one so the two ends of the same list do not disagree.
-  :deep(.pagination) {
-    justify-content: center;
   }
 }
 
@@ -113,6 +96,16 @@
       flex: 1 1 auto;
       min-width: 0;
       justify-content: flex-end;
+    }
+  }
+
+  // Nothing shares the row, so there is no left-hand side to align away from
+  // and the control reads as centred instead - the same thing the paginator
+  // under the list does on a phone. On a desktop it stays on the right edge.
+  .filtered-list--pagination-only {
+    .filtered-list__actions,
+    .filtered-list__pagination-top {
+      justify-content: center;
     }
   }
 }

--- a/app/frontend/shared/components/FilteredList/index.spec.ts
+++ b/app/frontend/shared/components/FilteredList/index.spec.ts
@@ -103,7 +103,7 @@ describe("FilteredList", () => {
     expect(wrapper.find(".filtered-list__pagination-top").exists()).toBe(false);
   });
 
-  it("centres a toolbar that carries nothing but the paginator", async () => {
+  it("marks a toolbar that carries nothing but the paginator", async () => {
     const wrapper = await mountWithSlots({
       "pagination-top": () => "pages",
     });


### PR DESCRIPTION
## What

A list toolbar that carries nothing but the paginator — the images page, and every other page with no actions beside the control — centres it. The reasoning was that there is no left-hand side to align away from, which reads right on a phone and wrong on a desktop: the control sits in the middle of a 1400px row while every other list on the site, and every row below it including the grid it paginates, holds the right edge.

`Paginator` already draws itself the way we want it: `justify-content: flex-end` from the desktop breakpoint up, `center` below it. The `--pagination-only` modifier was overriding that at every width rather than only where the two disagreed.

## How

Centre below the desktop breakpoint only.

- The base modifier block now does nothing but hide the empty `actions-left` box — it still has to go, because the flex gap counts an empty sibling and would push the control off centre by half of it. Without the `justify-content: center` and the `margin-left: 0`, the auto margin the toolbar hands `__pagination-top` holds the right edge, the same one the other rows align to.
- A new block inside the existing `max-width: $desktop-breakpoint` query centres the toolbar and the paginator block. The auto margin resolves to nothing there — `flex: 1 1 auto` consumes the free space before a margin can claim it — so `justify-content` is all that is needed.
- The `:deep(.pagination) { justify-content: center }` override on the bottom paginator goes away entirely. It existed to keep the two ends of the list from disagreeing; with the top one back on the component's own alignment they agree without being told to.

## Verification

Measured with a static flex harness — the component's compiled SCSS over a hand-written toolbar, measured in Playwright at three viewport widths. Distance from the paginator's leading edge to each side of its row:

**Top paginator, `--pagination-only`**

| viewport | before | after |
| --- | --- | --- |
| 1400px | 660 / 660 (centred) | **1320 / 0 (right)** |
| 800px | 360 / 360 (centred) | 360 / 360 (centred) |
| 375px | 148 / 148 (centred) | 148 / 148 (centred) |

**Bottom paginator, same list**

| viewport | before | after |
| --- | --- | --- |
| 1400px | 661 / 713 (centred) | **1322 / 52 (right)** |
| 800px | 361 / 413 (centred) | 361 / 413 (centred) |
| 375px | 149 / 201 (centred) | 149 / 201 (centred) |

Only the desktop row moves; both mobile widths are identical before and after, and the two paginators now land on the same edge at every width. A toolbar that *does* have actions beside the paginator measures `right: 0` at all three widths both ways — #4683's wrapping fix is untouched.

`vitest` passes for `FilteredList` and `Paginator` (12 tests). One spec was renamed — `centres a toolbar that carries nothing but the paginator` → `marks a toolbar…` — since it only ever asserted the modifier class, and centring is no longer what that class unconditionally means. No test was added: jsdom cannot measure a flex line, and SCSS is not linted in this repo.

🤖
