### PR TITLE
fix(hangar-import): map "MOLE - Talus Edition" to the Talus paint

### DIFF
--- a/app/lib/hangar_importer.rb
+++ b/app/lib/hangar_importer.rb
@@ -246,6 +246,7 @@ class HangarImporter
       "Crusader C1 Spirit" => "C1 Spirit",
       "Crusader E1 Spirit" => "E1 Spirit",
       "MOLE - Carbon Edition" => "Carbon",
+      "MOLE - Talus Edition" => "Talus",
       "Gladius Dunlevy" => "Dunlevy"
     }
   end


### PR DESCRIPTION
Hangar imports warned `Ships not found: MOLE - Talus Edition`. The MOLE itself imported fine — only the paint variant failed to resolve.

## Cause

`hangar_xplor_mapping` gained an entry for the newer uppercase, manufacturer-less export naming in 9ae02bda2, but only for Carbon. The Talus counterpart was never added, so `"MOLE - Talus Edition"` fell through to the normalized lookup for `mole-talus-edition` — and the MOLE has two Talus paint records, neither carrying that slug:

| paint | slug | origin |
| --- | --- | --- |
| `Talus` | `talus` | game data |
| `Mole Talus Edition` | `argo-mole-talus-edition` | RSI store |

The pre-existing `"Argo Mole - Talus Edition"` mapping only catches the legacy name.

## Fix

One mapping entry, pointing at the game-data `Talus` paint to match the Carbon precedent. The store paint would arguably be the more faithful target for a pledge import, but Carbon already chose the game paint, so this keeps the two consistent.

## Verification

Replayed the importer's resolution against a production-shaped local DB:

- before — `model=nil paint=nil` (i.e. the missing-list entry from the report)
- after — `paint="Talus" of "MOLE"`

`test/loaders/hangar_import_hangar_xplor_test.rb` and `test/loaders/hangar_importer_test.rb` pass; rubocop clean.

## No test

`test/fixtures/loader/model_paints.yml` is generated by `rake test_fixtures:generate_loader`, and its snapshot predates the game paints — it has no `Talus` or `Carbon` row at all. Covering this would mean hand-editing a generated file that the next regeneration wipes. The existing Carbon mapping is uncovered for the same reason.

Worth a separate look: two active, unhidden Talus paints (and two Carbon) on the MOLE is its own data problem, and is why "which paint does an import attach to" is a question here at all. 🤖