### PR TITLE
feat(lists): hold a loading list open with placeholders

### DIFF
--- a/app/frontend/admin/components/Images/List.vue
+++ b/app/frontend/admin/components/Images/List.vue
@@ -220,6 +220,7 @@ const columns: BaseTableCol<Image>[] = [
     primary-key="id"
     class="images"
     :is-filter-selected="isFilterSelected"
+    placeholders
   >
     <template v-if="filterable" #filter>
       <FilterForm />

--- a/app/frontend/admin/pages/fleets/[id]/inventories.vue
+++ b/app/frontend/admin/pages/fleets/[id]/inventories.vue
@@ -85,16 +85,15 @@ const columns: BaseTableCol<FleetInventory>[] = [
   </Heading>
 
   <FilteredList
-    v-if="inventories"
     name="admin-fleet-inventories"
-    :records="inventories.items || []"
+    :records="inventories?.items || []"
     :async-status="asyncStatus"
     hide-loading
     hide-empty
   >
     <template #default="{ loading, refetching, emptyVisible }">
       <BaseTable
-        :records="inventories.items || []"
+        :records="inventories?.items || []"
         primary-key="id"
         :columns="columns"
         :loading="loading || refetching"

--- a/app/frontend/admin/pages/fleets/[id]/members.vue
+++ b/app/frontend/admin/pages/fleets/[id]/members.vue
@@ -123,16 +123,15 @@ const columns: BaseTableCol<AdminFleetMember>[] = [
   </Heading>
 
   <FilteredList
-    v-if="members"
     name="admin-fleet-members"
-    :records="members.items || []"
+    :records="members?.items || []"
     :async-status="asyncStatus"
     hide-loading
     hide-empty
   >
     <template #default="{ loading, refetching, emptyVisible }">
       <BaseTable
-        :records="members.items || []"
+        :records="members?.items || []"
         primary-key="id"
         :columns="columns"
         :loading="loading || refetching"

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -11,6 +11,8 @@ import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import ListSkeleton from "@/shared/components/ListSkeleton/index.vue";
+import { useReportListGeometry } from "@/shared/composables/useListGeometry";
 import BulkSelectionBar from "@/shared/components/BulkSelectionBar/index.vue";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import Detail from "@/admin/components/Notifications/Detail/index.vue";
@@ -127,6 +129,16 @@ watch([sorts, archive], async () => {
 const { data: unreadCount } = useAdminNotificationsUnreadCount();
 
 const records = computed(() => notifications.value?.items || []);
+
+const list = ref<ComponentPublicInstance>();
+
+// What the placeholders of the next load stand as tall as: a row of this list
+// is as tall as its own two lines or the controls beside them, whichever wins,
+// and only the rendered row knows which.
+useReportListGeometry("row", list, {
+  ready: () => !!records.value.length,
+  pick: (host) => host.firstElementChild,
+});
 
 const totalCount = computed(
   () => notifications.value?.meta.pagination?.totalCount,
@@ -403,6 +415,10 @@ const destroySelected = () =>
         }}
       </Btn>
     </template>
+    <template #skeleton>
+      <ListSkeleton />
+    </template>
+
     <template #default="{ records: shown }">
       <BulkSelectionBar
         class="admin-notifications__bulk"
@@ -474,6 +490,7 @@ const destroySelected = () =>
         <TransitionGroup
           tag="ul"
           name="fade-list"
+          ref="list"
           class="admin-notifications__list"
         >
           <li

--- a/app/frontend/admin/pages/users/[id]/fleets.vue
+++ b/app/frontend/admin/pages/users/[id]/fleets.vue
@@ -95,16 +95,15 @@ const columns: BaseTableCol<AdminUserFleet>[] = [
   </Heading>
 
   <FilteredList
-    v-if="fleets"
     name="admin-user-fleets"
-    :records="fleets.items || []"
+    :records="fleets?.items || []"
     :async-status="asyncStatus"
     hide-loading
     hide-empty
   >
     <template #default="{ loading, refetching, emptyVisible }">
       <BaseTable
-        :records="fleets.items || []"
+        :records="fleets?.items || []"
         primary-key="id"
         :columns="columns"
         :loading="loading || refetching"

--- a/app/frontend/admin/pages/users/[id]/inventories.vue
+++ b/app/frontend/admin/pages/users/[id]/inventories.vue
@@ -66,16 +66,15 @@ const columns: BaseTableCol<Inventory>[] = [
   </Heading>
 
   <FilteredList
-    v-if="inventories"
     name="admin-user-inventories"
-    :records="inventories.items || []"
+    :records="inventories?.items || []"
     :async-status="asyncStatus"
     hide-loading
     hide-empty
   >
     <template #default="{ loading, refetching, emptyVisible }">
       <BaseTable
-        :records="inventories.items || []"
+        :records="inventories?.items || []"
         primary-key="id"
         :columns="columns"
         :loading="loading || refetching"

--- a/app/frontend/admin/pages/users/index.vue
+++ b/app/frontend/admin/pages/users/index.vue
@@ -131,9 +131,8 @@ const columns: BaseTableCol<User>[] = [
   </Heading>
 
   <FilteredList
-    v-if="users"
     name="admin-users"
-    :records="users.items || []"
+    :records="users?.items || []"
     :async-status="asyncStatus"
     hide-loading
     hide-empty
@@ -143,7 +142,7 @@ const columns: BaseTableCol<User>[] = [
     </template>
     <template #default="{ loading, refetching, emptyVisible }">
       <BaseTable
-        :records="users.items || []"
+        :records="users?.items || []"
         primary-key="id"
         :columns="columns"
         :loading="loading || refetching"

--- a/app/frontend/entrypoints/tailwind.css
+++ b/app/frontend/entrypoints/tailwind.css
@@ -191,6 +191,14 @@
   --field-h: 43px;
   --field-h-md: 48px;
   --field-h-lg: 55px;
+
+  /*
+   * A picture in a gallery grid, which is as tall as this whatever the column
+   * width is. Named because the placeholder a loading gallery holds its place
+   * with has to stand exactly as tall - see GridSkeleton's `image` variant -
+   * and two copies of a number are one too many.
+   */
+  --gallery-image-height: 250px;
 }
 
 /*

--- a/app/frontend/frontend/components/Fleets/InvitesList/index.vue
+++ b/app/frontend/frontend/components/Fleets/InvitesList/index.vue
@@ -25,6 +25,7 @@ type Props = {
   members: FleetMember[];
   capabilities?: FleetMembershipCapabilities;
   emptyVisible?: boolean;
+  loading?: boolean;
 };
 
 const props = defineProps<Props>();
@@ -82,6 +83,7 @@ const tableColumns = computed<BaseTableCol<FleetMember>[]>(() => [
 <template>
   <BaseTable
     :records="members"
+    :loading="loading"
     primary-key="id"
     :columns="tableColumns"
     :row-clickable="mobile"

--- a/app/frontend/frontend/components/Fleets/MembersList/index.vue
+++ b/app/frontend/frontend/components/Fleets/MembersList/index.vue
@@ -25,6 +25,7 @@ type Props = {
   members: FleetMember[];
   capabilities?: FleetMembershipCapabilities;
   emptyVisible?: boolean;
+  loading?: boolean;
 };
 
 const props = defineProps<Props>();
@@ -94,6 +95,7 @@ const tableColumns = computed<BaseTableCol<FleetMember>[]>(() => [
     :columns="tableColumns"
     :row-clickable="mobile"
     :empty-visible="emptyVisible"
+    :loading="loading"
     @row-click="onRowClick"
   >
     <template #col-username="{ record }">

--- a/app/frontend/frontend/components/Fleets/PublicShipsList/index.vue
+++ b/app/frontend/frontend/components/Fleets/PublicShipsList/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import FleetVehiclePanel from "@/frontend/components/Fleets/VehiclePanel/index.vue";
@@ -143,6 +144,13 @@ const refetch = async () => {
       <template #filter>
         <PublicFleetVehiclesFilterForm />
       </template>
+      <template v-if="gridView" #skeleton="{ filterVisible }">
+        <GridSkeleton
+          :details="detailsVisible"
+          :filter-visible="filterVisible"
+        />
+      </template>
+
       <template #default="{ records, loading, filterVisible, emptyVisible }">
         <Grid
           v-if="gridView"

--- a/app/frontend/frontend/components/Fleets/ShipsList/index.vue
+++ b/app/frontend/frontend/components/Fleets/ShipsList/index.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import type { Subscription } from "@rails/actioncable";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnDropdown from "@/shared/components/base/BtnDropdown/index.vue";
@@ -317,6 +318,13 @@ const {
         <template #filter>
           <FleetVehiclesFilterForm />
         </template>
+        <template v-if="gridView" #skeleton="{ filterVisible }">
+          <GridSkeleton
+            :details="detailsVisible"
+            :filter-visible="filterVisible"
+          />
+        </template>
+
         <template #default="{ records, loading, filterVisible, emptyVisible }">
           <Grid
             v-if="gridView"

--- a/app/frontend/frontend/components/Models/Table/index.vue
+++ b/app/frontend/frontend/components/Models/Table/index.vue
@@ -29,6 +29,7 @@ type Props = {
   wishlist?: boolean;
   loading?: boolean;
   emptyVisible?: boolean;
+  skeletonRows?: number;
 };
 
 defineProps<Props>();
@@ -61,6 +62,9 @@ const extraImageColumns = computed(() => {
         label: "",
         width: col.endsWith("Wide") ? "270px" : "120px",
         centered: true,
+        // The heights of the LazyImage variants these cells render, so a
+        // loading table reserves the row the thumbnail will need.
+        skeletonMedia: col.endsWith("Wide") ? "100px" : "50px",
       };
     })
     .filter((col) => {
@@ -105,6 +109,7 @@ const angledImage = (record: Model) => {
       :columns="tableColumns"
       :loading="loading"
       :empty-visible="emptyVisible"
+      :skeleton-rows="skeletonRows"
     >
       <template #col-storeImage="{ record }">
         <ViewImage

--- a/app/frontend/frontend/pages/fleets/[slug]/events/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/events/index.vue
@@ -12,6 +12,7 @@ import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import EventPanel from "@/frontend/components/Fleets/Events/EventPanel/index.vue";
 import CalendarGrid from "@/frontend/components/Fleets/Events/CalendarGrid/index.vue";
 import {
@@ -331,6 +332,10 @@ const crumbs = computed<Crumb[]>(() => [
     :async-status="asyncStatus"
     hide-empty
   >
+    <template #skeleton="{ filterVisible }">
+      <GridSkeleton :filter-visible="filterVisible" />
+    </template>
+
     <template #default="{ records }">
       <Grid :records="records as FleetEvent[]" primary-key="id">
         <template #default="{ record }">

--- a/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/index.vue
@@ -190,16 +190,18 @@ const crumbs = computed<Crumb[]>(() => {
     :async-status="asyncStatus"
     :is-filter-selected="isFilterSelected"
     hide-empty
+    placeholders
   >
     <template #filter>
       <FleetMembersFilterForm variant="members" />
     </template>
 
-    <template #default="{ emptyVisible }">
+    <template #default="{ emptyVisible, loading }">
       <FleetMembersList
         :members="memberItems"
         :capabilities="props.membership?.capabilities"
         :empty-visible="emptyVisible"
+        :loading="loading"
       />
     </template>
 

--- a/app/frontend/frontend/pages/fleets/[slug]/members/invites.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/members/invites.vue
@@ -193,16 +193,18 @@ const openInviteModal = () => {
     :async-status="asyncStatus"
     :is-filter-selected="isFilterSelected"
     hide-empty
+    placeholders
   >
     <template #filter>
       <FleetMembersFilterForm variant="invites" />
     </template>
 
-    <template #default="{ emptyVisible }">
+    <template #default="{ emptyVisible, loading }">
       <FleetInvitesList
         :members="memberItems"
         :capabilities="props.membership?.capabilities"
         :empty-visible="emptyVisible"
+        :loading="loading"
       />
     </template>
   </FilteredList>

--- a/app/frontend/frontend/pages/fleets/[slug]/missions/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/missions/index.vue
@@ -12,6 +12,7 @@ import Btn from "@/shared/components/base/Btn/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import MissionPanel from "@/frontend/components/Fleets/Missions/MissionPanel/index.vue";
 import {
   type Fleet,
@@ -138,6 +139,10 @@ const crumbs = computed<Crumb[]>(() => [
           {{ t("labels.fleets.missions.archivedTab") }}
         </Btn>
       </BtnGroup>
+    </template>
+
+    <template #skeleton="{ filterVisible }">
+      <GridSkeleton :filter-visible="filterVisible" />
     </template>
 
     <template #default="{ records }">

--- a/app/frontend/frontend/pages/hangar/[username]/index.vue
+++ b/app/frontend/frontend/pages/hangar/[username]/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import HangarPublicHeading from "@/frontend/components/Hangar/PublicHeading/index.vue";
@@ -282,6 +283,10 @@ useSubscription({
           <span>{{ t("labels.fleetchart") }}</span>
         </Btn>
       </BtnDropdown>
+    </template>
+
+    <template #skeleton="{ filterVisible }">
+      <GridSkeleton :filter-visible="filterVisible" />
     </template>
 
     <template #default="{ records, loading }">

--- a/app/frontend/frontend/pages/hangar/[username]/wishlist.vue
+++ b/app/frontend/frontend/pages/hangar/[username]/wishlist.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import HangarPublicHeading from "@/frontend/components/Hangar/PublicHeading/index.vue";
@@ -192,6 +193,10 @@ onMounted(async () => {
           <span>{{ t("labels.fleetchart") }}</span>
         </Btn>
       </BtnDropdown>
+    </template>
+
+    <template #skeleton="{ filterVisible }">
+      <GridSkeleton :filter-visible="filterVisible" />
     </template>
 
     <template #default="{ records, loading }">

--- a/app/frontend/frontend/pages/hangar/index.vue
+++ b/app/frontend/frontend/pages/hangar/index.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import PrimaryAction from "@/shared/components/PrimaryAction/index.vue";
@@ -533,6 +534,10 @@ const openDisplayOptionsModal = () => {
 
     <template #filter>
       <FilterForm />
+    </template>
+
+    <template v-if="gridView" #skeleton="{ filterVisible }">
+      <GridSkeleton :details="detailsVisible" :filter-visible="filterVisible" />
     </template>
 
     <template #default="{ records, loading, filterVisible, emptyVisible }">

--- a/app/frontend/frontend/pages/hangar/wishlist.vue
+++ b/app/frontend/frontend/pages/hangar/wishlist.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
@@ -313,6 +314,10 @@ const openDisplayOptionsModal = () => {
 
     <template #filter>
       <FilterForm />
+    </template>
+
+    <template v-if="gridView" #skeleton="{ filterVisible }">
+      <GridSkeleton :details="detailsVisible" :filter-visible="filterVisible" />
     </template>
 
     <template #default="{ records, loading, filterVisible, emptyVisible }">

--- a/app/frontend/frontend/pages/images.vue
+++ b/app/frontend/frontend/pages/images.vue
@@ -8,6 +8,7 @@ export default {
 import LazyImage from "@/shared/components/LazyImage/index.vue";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useGallery } from "@/shared/composables/useGallery";
@@ -48,6 +49,10 @@ useGallery(".images");
     class="images"
     data-test="images-list"
   >
+    <template #skeleton="{ filterVisible }">
+      <GridSkeleton variant="image" :filter-visible="filterVisible" />
+    </template>
+
     <template #default="{ records, loading, filterVisible }">
       <Grid
         :records="records"

--- a/app/frontend/frontend/pages/notifications.vue
+++ b/app/frontend/frontend/pages/notifications.vue
@@ -11,6 +11,8 @@ import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import ListSkeleton from "@/shared/components/ListSkeleton/index.vue";
+import { useReportListGeometry } from "@/shared/composables/useListGeometry";
 import BulkSelectionBar from "@/shared/components/BulkSelectionBar/index.vue";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import Detail from "@/frontend/components/Notifications/Detail/index.vue";
@@ -125,6 +127,16 @@ watch([sorts, archive], async () => {
 const { data: unreadCount } = useNotificationsUnreadCount();
 
 const records = computed(() => notifications.value?.items || []);
+
+const list = ref<ComponentPublicInstance>();
+
+// What the placeholders of the next load stand as tall as: a row of this list
+// is as tall as its own two lines or the controls beside them, whichever wins,
+// and only the rendered row knows which.
+useReportListGeometry("row", list, {
+  ready: () => !!records.value.length,
+  pick: (host) => host.firstElementChild,
+});
 
 const totalCount = computed(
   () => notifications.value?.meta.pagination?.totalCount,
@@ -405,6 +417,10 @@ const destroySelected = () =>
         }}
       </Btn>
     </template>
+    <template #skeleton>
+      <ListSkeleton />
+    </template>
+
     <template #default="{ records: shown }">
       <BulkSelectionBar
         class="notifications__bulk"
@@ -473,7 +489,12 @@ const destroySelected = () =>
         class="notifications"
         :class="{ 'notifications--reading': !!selected }"
       >
-        <TransitionGroup tag="ul" name="fade-list" class="notifications__list">
+        <TransitionGroup
+          tag="ul"
+          name="fade-list"
+          ref="list"
+          class="notifications__list"
+        >
           <li
             v-for="notification in shown"
             :key="notification.id"

--- a/app/frontend/frontend/pages/ships/[slug]/images.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/images.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
 import { type Crumb } from "@/shared/components/BreadCrumbs/types";
@@ -145,6 +146,10 @@ useGallery(".images");
     primary-key="id"
     class="images"
   >
+    <template #skeleton="{ filterVisible }">
+      <GridSkeleton variant="image" :filter-visible="filterVisible" />
+    </template>
+
     <template #default="{ records, loading, filterVisible }">
       <Grid
         :records="records"

--- a/app/frontend/frontend/pages/ships/[slug]/videos.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/videos.vue
@@ -6,6 +6,7 @@ export default {
 
 <script lang="ts" setup>
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
 import { type Crumb } from "@/shared/components/BreadCrumbs/types";
@@ -121,6 +122,14 @@ const updateTitle = () => {
     primary-key="id"
     class="videos"
   >
+    <template #skeleton="{ filterVisible }">
+      <GridSkeleton
+        variant="embed"
+        grid-base="2"
+        :filter-visible="filterVisible"
+      />
+    </template>
+
     <template #default="{ records, loading, filterVisible }">
       <Grid
         :records="records"

--- a/app/frontend/frontend/pages/ships/index.vue
+++ b/app/frontend/frontend/pages/ships/index.vue
@@ -8,6 +8,7 @@ export default {
 import Btn from "@/shared/components/base/Btn/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import ModelPanel from "@/frontend/components/Models/Panel/index.vue";
 import ModelsTable from "@/frontend/components/Models/Table/index.vue";
 import Empty from "@/shared/components/Empty/index.vue";
@@ -117,6 +118,7 @@ const openDisplayOptionsModal = () => {
     :records="models?.items || []"
     :async-status="asyncStatus"
     :is-filter-selected="isFilterSelected"
+    placeholders
   >
     <template #actions-right>
       <Btn
@@ -137,6 +139,13 @@ const openDisplayOptionsModal = () => {
         :per-page="perPage"
         :update-per-page="updatePerPage"
       />
+    </template>
+
+    <!-- Only the card grid needs saying: a grid renders nothing from an empty
+         set. In table view the slot is gone and `placeholders` lets the table
+         itself draw its header and a page of placeholder rows. -->
+    <template v-if="gridView" #skeleton="{ filterVisible }">
+      <GridSkeleton :details="detailsVisible" :filter-visible="filterVisible" />
     </template>
 
     <template #default="{ records, loading, filterVisible, emptyVisible }">

--- a/app/frontend/frontend/pages/tools/travel-times.vue
+++ b/app/frontend/frontend/pages/tools/travel-times.vue
@@ -179,6 +179,7 @@ const { data: quantumDrives, ...asyncStatus } = useComponentsQuery(
       :records="sortedQuantumDrives"
       :name="route.name?.toString() || ''"
       :async-status="asyncStatus"
+      placeholders
     >
       <template #default="{ records }">
         <BaseTable

--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -8,6 +8,10 @@ export default {
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BaseText from "@/shared/components/base/Text/index.vue";
 import Empty from "@/shared/components/Empty/index.vue";
+import Grid from "@/shared/components/base/Grid/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
+import ModelPanel from "@/frontend/components/Models/Panel/index.vue";
+import ModelsTable from "@/frontend/components/Models/Table/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
 import Forbidden from "@/shared/components/Forbidden/index.vue";
 import NotAuthorized from "@/shared/components/NotAuthorized/index.vue";
@@ -26,8 +30,15 @@ import {
   useModelsLatest as useLatestModelsQuery,
 } from "@/services/fyApi";
 
-const { isFetching: latestModelsFetching, refetch: refetchLatestModels } =
-  useLatestModelsQuery();
+const {
+  data: latestModels,
+  isFetching: latestModelsFetching,
+  refetch: refetchLatestModels,
+} = useLatestModelsQuery();
+
+const skeletonDetails = ref(false);
+
+const comparisonModels = computed(() => (latestModels.value || []).slice(0, 2));
 
 const progress = ref(35);
 
@@ -174,6 +185,54 @@ const updatePerPage = (value: number | string) => {
         Show fixed loader (2s)
       </Btn>
       <Loader :loading="fixedLoaderVisible" fixed />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">GridSkeleton</Heading>
+  <p>
+    The placeholder cards a grid list holds itself open with while it loads,
+    beside the real cards that replace them - a placeholder of a different
+    height moves the page under the reader once the records land, which is the
+    whole thing it is there to prevent. <code>details</code> follows the display
+    option the ships list carries.
+  </p>
+  <div class="row">
+    <div class="col-12">
+      <Btn
+        data-test="toggle-skeleton-details"
+        @click="skeletonDetails = !skeletonDetails"
+      >
+        {{ skeletonDetails ? "Hide details" : "Show details" }}
+      </Btn>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <BaseText muted no-spacing>placeholders</BaseText>
+      <GridSkeleton :count="2" :details="skeletonDetails" grid-base="2" />
+    </div>
+    <div class="col-12 col-lg-6">
+      <BaseText muted no-spacing>the cards they stand in for</BaseText>
+      <Grid :records="comparisonModels" primary-key="slug" grid-base="2">
+        <template #default="{ record }">
+          <ModelPanel :model="record" :details="skeletonDetails" />
+        </template>
+      </Grid>
+    </div>
+  </div>
+  <p>
+    The same list in table view: the placeholder rows are the real table with
+    nothing in it yet, so the header, the column widths and the row height are
+    the ones the records arrive into.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <BaseText muted no-spacing>placeholder rows</BaseText>
+      <ModelsTable :models="[]" loading :skeleton-rows="3" />
+    </div>
+    <div class="col-12 col-lg-6">
+      <BaseText muted no-spacing>the rows they stand in for</BaseText>
+      <ModelsTable :models="comparisonModels" />
     </div>
   </div>
 

--- a/app/frontend/shared/components/FilteredList/index.scss
+++ b/app/frontend/shared/components/FilteredList/index.scss
@@ -11,6 +11,15 @@
     flex-wrap: wrap;
   }
 
+  // A list mid-load renders no records, and the loader is absolutely positioned
+  // - so nothing holds the column open and the two paginators land on top of
+  // each other until the records arrive. Reserves the height the table already
+  // reserves with `.base-table__inner`, and centres the loader in it.
+  &__loader {
+    position: relative;
+    min-height: 180px;
+  }
+
   &__actions-left,
   &__actions-right {
     display: flex;

--- a/app/frontend/shared/components/FilteredList/index.spec.ts
+++ b/app/frontend/shared/components/FilteredList/index.spec.ts
@@ -1,5 +1,6 @@
 import { mountWithDefaults } from "@/shared/utils/TestUtils";
 import { beforeEach, describe, expect, it } from "vitest";
+import { createRouter, createWebHashHistory } from "vue-router";
 import { ref } from "vue";
 import Component from "./index.vue";
 import type { AsyncStatus } from "@/shared/components/AsyncData.types";
@@ -24,7 +25,12 @@ const failedWith = (status: number) =>
 // FilteredList is a generic SFC, which is not a plain constructor type; this
 // names the props and slots the test uses without reaching for `any`.
 const ListComponent = Component as unknown as new (...args: unknown[]) => {
-  $props: { name: string; records: unknown[]; asyncStatus: AsyncStatus };
+  $props: {
+    name: string;
+    records: unknown[];
+    asyncStatus: AsyncStatus;
+    placeholders?: boolean;
+  };
   $slots: Record<string, unknown>;
 };
 
@@ -38,6 +44,44 @@ const loaded = () =>
     isRefetching: ref(false),
     error: ref(undefined),
   }) as unknown as AsyncStatus;
+
+const loading = () =>
+  ({
+    fetchStatus: ref("fetching"),
+    isError: ref(false),
+    isPending: ref(true),
+    isLoading: ref(true),
+    isFetching: ref(true),
+    isRefetching: ref(false),
+    error: ref(undefined),
+  }) as unknown as AsyncStatus;
+
+// Per-page is stored per route name, so the placeholder count is only readable
+// from a list that is actually on a named route.
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: "/ships",
+      name: "ships",
+      component: { template: "<div />" },
+    },
+  ],
+});
+
+const mountOnRoute = async (
+  slots: Record<string, string>,
+  initialState?: Record<string, unknown>,
+) => {
+  await router.push({ name: "ships" });
+
+  return mountWithDefaults<typeof ListComponent>(ListComponent, {
+    props: { name: "test-list", records: [], asyncStatus: loading() },
+    slots,
+    initialState,
+    plugins: [router],
+  });
+};
 
 const mount = (status: number) =>
   mountWithDefaults<typeof ListComponent>(ListComponent, {
@@ -91,6 +135,118 @@ describe("FilteredList", () => {
       wrapper.get(".filtered-list__pagination-top").element.parentElement
         ?.className,
     ).toContain("filtered-list__actions");
+  });
+
+  // The loader is absolutely positioned, so a loading list holds its column
+  // open only through the box around it - without one the paginator above the
+  // list and the one below it sit on top of each other.
+  it("reserves the list's height while it loads", async () => {
+    const wrapper = await mountWithDefaults<typeof ListComponent>(
+      ListComponent,
+      {
+        props: { name: "test-list", records: [], asyncStatus: loading() },
+        slots: {
+          "pagination-top": '<nav data-test="pager-top">pager</nav>',
+          "pagination-bottom": '<nav data-test="pager-bottom">pager</nav>',
+          default: '<div data-test="records">records</div>',
+        },
+      },
+    );
+
+    expect(wrapper.find('[data-test="records"]').exists()).toBe(false);
+
+    const loader = wrapper.get(".filtered-list__loader");
+
+    expect(loader.findComponent({ name: "LoaderComponent" }).props()).toEqual(
+      expect.objectContaining({ loading: true, relative: true }),
+    );
+  });
+
+  // The count is the reservation: too few placeholders and the page still grows
+  // under the reader when the records land.
+  it("sizes the placeholder grid from the list's page size", async () => {
+    const wrapper = await mountOnRoute(
+      { skeleton: '<template #skeleton="{ count }">{{ count }}</template>' },
+      { pagination: { perPage: { ships: 20 } } },
+    );
+
+    expect(wrapper.get(".filtered-list__loader").text()).toContain("20");
+  });
+
+  // A page size is an upper bound, not a promise: a list that has only ever
+  // held two records would otherwise reserve a full page of them.
+  it("never reserves more than the list has ever held", async () => {
+    const wrapper = await mountOnRoute(
+      { skeleton: '<template #skeleton="{ count }">{{ count }}</template>' },
+      {
+        pagination: { perPage: { ships: 20 } },
+        listGeometry: { counts: { "test-list": 2 } },
+      },
+    );
+
+    expect(wrapper.get(".filtered-list__loader").text()).toContain("2");
+  });
+
+  it("falls back to the first page-size step before one is picked", async () => {
+    const wrapper = await mountOnRoute({
+      skeleton: '<template #skeleton="{ count }">{{ count }}</template>',
+    });
+
+    expect(wrapper.get(".filtered-list__loader").text()).toContain("10");
+  });
+
+  // A table draws its own waiting state out of an empty record set - header,
+  // column widths, a page of placeholder rows - so the list hands it the slot
+  // rather than replacing it with a spinner.
+  it("renders the list itself while it loads when asked to", async () => {
+    const wrapper = await mountWithDefaults<typeof ListComponent>(
+      ListComponent,
+      {
+        props: {
+          name: "test-list",
+          records: [],
+          asyncStatus: loading(),
+          placeholders: true,
+        },
+        slots: {
+          default:
+            '<template #default="{ loading }"><div data-test="list">{{ loading }}</div></template>',
+        },
+      },
+    );
+
+    expect(wrapper.get('[data-test="list"]').text()).toBe("true");
+    expect(wrapper.findComponent({ name: "LoaderComponent" }).props()).toEqual(
+      expect.objectContaining({ fixed: true }),
+    );
+  });
+
+  it("leaves a list that did not ask for it with the spinner", async () => {
+    const wrapper = await mountWithDefaults<typeof ListComponent>(
+      ListComponent,
+      {
+        props: { name: "test-list", records: [], asyncStatus: loading() },
+        slots: { default: '<div data-test="list">records</div>' },
+      },
+    );
+
+    expect(wrapper.find('[data-test="list"]').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: "LoaderComponent" }).props()).toEqual(
+      expect.objectContaining({ relative: true }),
+    );
+  });
+
+  // A list that brings placeholders wants the spinner over them, not centred in
+  // a box the placeholders have already filled.
+  it("puts the spinner over the placeholders it was given", async () => {
+    const wrapper = await mountOnRoute({
+      skeleton: '<div data-test="placeholders">cards</div>',
+    });
+
+    expect(wrapper.find('[data-test="placeholders"]').exists()).toBe(true);
+    expect(wrapper.findComponent({ name: "LoaderComponent" }).props()).toEqual(
+      expect.objectContaining({ loading: true, fixed: true }),
+    );
   });
 
   it("renders no block for a slot it was not given", async () => {

--- a/app/frontend/shared/components/FilteredList/index.vue
+++ b/app/frontend/shared/components/FilteredList/index.vue
@@ -11,6 +11,9 @@ import Empty from "@/shared/components/Empty/index.vue";
 import ServerError from "@/shared/components/ServerError/index.vue";
 import Forbidden from "@/shared/components/Forbidden/index.vue";
 import { useFiltersStore } from "@/shared/stores/filters";
+import { usePaginationStore } from "@/shared/stores/pagination";
+import { provideListGeometry } from "@/shared/composables/useListGeometry";
+import { useListGeometryStore } from "@/shared/stores/listGeometry";
 import {
   type AsyncStatus,
   ErrorTypesEnum,
@@ -29,6 +32,11 @@ type Props = {
   hideEmpty?: boolean;
   hideLoading?: boolean;
   isFilterSelected?: boolean;
+  // Render the list itself while its first page loads rather than a spinner in
+  // an empty box. It is handed no records, which is what a table needs to draw
+  // its header and a page of placeholder rows; a list of cards renders nothing
+  // from an empty set and brings a `skeleton` slot instead.
+  placeholders?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -36,6 +44,7 @@ const props = withDefaults(defineProps<Props>(), {
   hideEmpty: false,
   hideLoading: false,
   isFilterSelected: false,
+  placeholders: false,
 });
 
 const loading = computed(() => {
@@ -100,6 +109,60 @@ const paginationOnly = computed(
     !hasFilterSlot.value &&
     !slots["actions-left"] &&
     !slots["actions-right"],
+);
+
+const paginationStore = usePaginationStore();
+
+const geometryStore = useListGeometryStore();
+
+// Once the answer is in, whatever it held - including nothing. `isPending` is
+// what separates "the list is empty" from "the list has not answered yet", and
+// only the first of those is worth remembering.
+watch(
+  [() => props.records.length, () => props.asyncStatus.isPending.value],
+  ([count, pending]) => {
+    if (!pending) {
+      geometryStore.recordCount(props.name, count);
+    }
+  },
+  { immediate: true },
+);
+
+// Per-page lives in the store keyed by route, the same place usePagination
+// reads it - so a list opts into placeholders without also having to pass its
+// pagination down. It is unset until somebody picks a size, and the first step
+// of the dropdown is what the API falls back to.
+//
+// Capped by the most this list has ever held, because a page size is an upper
+// bound and not a promise: a ship's videos are two, and ten placeholders the
+// height of a video embed is a screen and a half of nothing. On a list that
+// fills its pages the two agree.
+const skeletonCount = computed(() => {
+  const perPage =
+    Number(paginationStore.findByKey((route.name as string) || "")) ||
+    undefined;
+
+  const seen = geometryStore.countByKey(props.name);
+
+  // Nobody has picked a size, so the API's default is in force - and the count
+  // of the last answer is the only reading of what that is.
+  if (perPage === undefined) {
+    return seen ?? 10;
+  }
+
+  return seen === undefined ? perPage : Math.min(perPage, seen);
+});
+
+// Offered to whatever renders inside: the count above, and how tall one record
+// was the last time this list drew any. The list reports its own measurement
+// back, so neither a table nor a grid carries a height written by hand.
+//
+// The spinner goes with it, because a list told to hide this one - a table view
+// that would rather use its own - has to know that it is on its own.
+provideListGeometry(
+  () => props.name,
+  skeletonCount,
+  computed(() => !props.hideLoading && loading.value),
 );
 
 const { t } = useI18n();
@@ -265,13 +328,45 @@ const toggleFilter = () => {
             </transition>
           </slot>
 
-          <slot
+          <div
             v-else-if="!hideLoading && loading"
-            name="loader"
-            :loading="loading"
+            class="filtered-list__loader"
           >
-            <Loader :loading="loading" fixed />
-          </slot>
+            <!-- `slots` is read at render time rather than through a computed:
+                 a call site is free to gate its placeholders behind a
+                 condition, and `slots` is not reactive, so a computed would
+                 answer from the render before that condition changed. -->
+            <template v-if="slots.skeleton">
+              <Loader :loading="loading" fixed />
+
+              <slot
+                name="skeleton"
+                :count="skeletonCount"
+                :filter-visible="filterVisible"
+              />
+            </template>
+
+            <!-- The list draws its own waiting state: a table hands its header
+                 and a page of placeholder rows straight out of an empty record
+                 set, which is closer to what arrives than anything written
+                 beside it could be. -->
+            <template v-else-if="props.placeholders">
+              <Loader :loading="loading" fixed />
+
+              <slot
+                name="default"
+                :records="props.records"
+                :filter-visible="filterVisible"
+                :loading="loading"
+                :refetching="refetching"
+                :empty-visible="false"
+              />
+            </template>
+
+            <slot v-else name="loader" :loading="loading">
+              <Loader :loading="loading" relative />
+            </slot>
+          </div>
 
           <slot
             v-else-if="!hideEmpty && emptyVisible"

--- a/app/frontend/shared/components/GridSkeleton/index.scss
+++ b/app/frontend/shared/components/GridSkeleton/index.scss
@@ -1,0 +1,113 @@
+// Row heights come from the same partial the real expanded card uses, so a
+// skeleton row and a metric row are the same height without repeating a number.
+@import "@/shared/components/metricsCard";
+@import "@/shared/components/skeleton";
+
+.grid-skeleton {
+  // A picture or an embed standing in a cell on its own. Both take a measured
+  // height when there is one; what differs is the shape they hold before that,
+  // and a wrong guess there is loud - a full-width cell at 16:9 is half a
+  // screen where a gallery picture is 250px.
+  &__bare {
+    // The height a gallery picture keeps at any column width. Same token
+    // LazyImage's own `.gallery-image` reads.
+    &--image {
+      height: var(--gallery-image-height, 250px);
+      // The gap between rows of the real gallery is this margin, so without it
+      // the placeholders stack tighter than the pictures will.
+      margin-bottom: 20px;
+    }
+
+    &--embed {
+      aspect-ratio: 16 / 9;
+    }
+  }
+
+  // Once the card's own height is known, the well takes whatever the card
+  // leaves it rather than standing on the floor below: the floor is a guess for
+  // the first load only, and a card measured shorter than it would be held open
+  // by it.
+  &__panel--measured {
+    display: flex;
+    flex-direction: column;
+
+    .grid-skeleton__media {
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+  }
+
+  // A card on the ships grid passes no body, so its height is exactly the
+  // image floor - which is the one measurement a placeholder has to match, and
+  // the reason the bars inside it need no height of their own.
+  &__media {
+    position: relative;
+    min-height: var(--panel-image-height, 286px);
+    // The card's own inner radius, not the well's default: the photo region is
+    // capped to the frame it sits in.
+    border-radius: $panelContentBorderRadius;
+
+    // The photo is capped on the inward edge only while details are open, the
+    // same way PanelBgImage is handed `rounded-top` by an expanded card.
+    &--open {
+      border-bottom-right-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+  }
+
+  // Mirrors PanelHeading's own `16px 18px 12px` and its top scrim: the bars
+  // stand in for a title that sits over the photo, not beside it.
+  &__heading {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 16px 18px 12px;
+    border-top-left-radius: $panelContentBorderRadius;
+    border-top-right-radius: $panelContentBorderRadius;
+    background: linear-gradient(
+      to bottom,
+      rgb(0 0 0 / 0.8),
+      rgb(0 0 0 / 0.55) 55%,
+      transparent
+    );
+  }
+
+  &__status {
+    padding: 9px 16px;
+    background: rgba(#000, 0.12);
+    border-bottom: 1px solid rgba($gray-light, 0.28);
+  }
+
+  &__metrics {
+    padding: 14px 16px 16px;
+  }
+
+  // Widths and type only - the bar itself is the shared primitive, and the type
+  // is what gives it its height.
+  .skeleton-bar {
+    &--title {
+      width: 62%;
+      font-size: 22px;
+    }
+
+    &--subtitle {
+      width: 38%;
+      font-size: 13px;
+    }
+
+    &--status {
+      display: block;
+      width: 42%;
+      font-size: 10px;
+    }
+  }
+
+  .metrics-card__row__label {
+    width: 58px;
+  }
+
+  .metrics-card__row__value {
+    width: 68px;
+  }
+}

--- a/app/frontend/shared/components/GridSkeleton/index.spec.ts
+++ b/app/frontend/shared/components/GridSkeleton/index.spec.ts
@@ -1,0 +1,44 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import Component from "./index.vue";
+
+const mount = (props: { count: number; details?: boolean }) =>
+  mountWithDefaults<typeof Component>(Component, { props });
+
+describe("GridSkeleton", () => {
+  it("renders one placeholder per record the page will hold", async () => {
+    const wrapper = await mount({ count: 7 });
+
+    expect(wrapper.findAll(".grid-skeleton__media")).toHaveLength(7);
+  });
+
+  // The cells are the real grid's, so the placeholders break onto rows exactly
+  // where the cards will - a placeholder in a column of its own reserves the
+  // wrong height however tall it is.
+  it("lays the placeholders out in the grid's own cells", async () => {
+    const wrapper = await mount({ count: 1 });
+
+    expect(wrapper.get(".base-grid__cell").classes()).toEqual(
+      expect.arrayContaining(["col-12", "col-md-6", "col-lg-4"]),
+    );
+  });
+
+  it("stands in for the expanded card only when the list is expanded", async () => {
+    const compact = await mount({ count: 1 });
+
+    expect(compact.find(".grid-skeleton__metrics").exists()).toBe(false);
+
+    const expanded = await mount({ count: 1, details: true });
+
+    expect(expanded.find(".grid-skeleton__metrics").exists()).toBe(true);
+    expect(expanded.findAll(".metrics-card__row")).toHaveLength(9);
+  });
+
+  it("keeps the placeholders out of the reading order", async () => {
+    const wrapper = await mount({ count: 2 });
+
+    expect(
+      wrapper.get('[data-test="grid-skeleton"]').attributes("aria-hidden"),
+    ).toBe("true");
+  });
+});

--- a/app/frontend/shared/components/GridSkeleton/index.vue
+++ b/app/frontend/shared/components/GridSkeleton/index.vue
@@ -1,0 +1,144 @@
+<script lang="ts">
+export default {
+  name: "GridSkeleton",
+};
+</script>
+
+<script lang="ts" setup>
+import Grid from "@/shared/components/base/Grid/index.vue";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import { useListGeometry } from "@/shared/composables/useListGeometry";
+
+type Props = {
+  // Both come from the list this stands in for when it is inside one.
+  count?: number;
+  details?: boolean;
+  filterVisible?: boolean;
+  gridBase?: "2" | "3";
+  // What the cells of this grid hold. `panel` is a card - a photo with a title
+  // over it and a frame around it. The other two are bare: `image` a gallery
+  // picture, which is as tall as its token whatever the column width, and
+  // `embed` a video, which is 16:9 of it.
+  variant?: "panel" | "image" | "embed";
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  count: undefined,
+  details: false,
+  filterVisible: false,
+  gridBase: "3",
+  variant: "panel",
+});
+
+const geometry = useListGeometry();
+
+// `??`, not `||`: a remembered zero means this list has been seen empty, and
+// reserving nothing for it is the right answer rather than a missing one.
+const count = computed(() => props.count ?? geometry?.count.value ?? 10);
+
+// Nothing until this grid has been seen once, and then exactly what a card of
+// it measured: the image floor below only has to carry the very first load.
+const cardHeight = computed(() => {
+  const remembered = geometry?.heightFor("card");
+
+  return remembered ? `${remembered}px` : undefined;
+});
+
+// Grid keys its cells off a field of the record, so the placeholders need one -
+// the index, which is stable for as long as the count is.
+const cells = computed(() =>
+  Array.from({ length: count.value }, (_, index) => ({
+    key: `grid-skeleton-${index}`,
+  })),
+);
+
+// What an expanded ship card carries: focus, crew and speed above the divider,
+// then the five dimensions and the price in two columns. See
+// useModelMetricRows.
+const summaryRows = 3;
+const dimensionRows = 6;
+</script>
+
+<template>
+  <Grid
+    :records="cells"
+    primary-key="key"
+    :grid-base="props.gridBase"
+    :filter-visible="props.filterVisible"
+    class="grid-skeleton"
+    aria-hidden="true"
+    data-test="grid-skeleton"
+  >
+    <!-- No frame and no title: a cell of the image grid holds the picture
+         itself, and one of the video grid the embed. -->
+    <span
+      v-if="props.variant !== 'panel'"
+      class="grid-skeleton__bare skeleton-well"
+      :class="`grid-skeleton__bare--${props.variant}`"
+      :style="{ height: cardHeight }"
+    />
+
+    <!-- A height, not a minimum: a measured card can be shorter than the image
+         floor below - an image card is - and a floor it cannot go under would
+         hold the placeholder taller than the card it stands in for. -->
+    <Panel
+      v-else
+      class="grid-skeleton__panel"
+      :class="{ 'grid-skeleton__panel--measured': !!cardHeight }"
+      :style="{ height: cardHeight }"
+    >
+      <template #default>
+        <div
+          class="grid-skeleton__media skeleton-well"
+          :class="{ 'grid-skeleton__media--open': props.details }"
+        >
+          <div class="grid-skeleton__heading">
+            <span class="skeleton-bar skeleton-bar--title" />
+            <span class="skeleton-bar skeleton-bar--subtitle" />
+          </div>
+        </div>
+      </template>
+
+      <template v-if="props.details" #footer>
+        <div class="grid-skeleton__status">
+          <span class="skeleton-bar skeleton-bar--status" />
+        </div>
+        <div class="grid-skeleton__metrics">
+          <div class="metrics-card__rows">
+            <div
+              v-for="row in summaryRows"
+              :key="`grid-skeleton__summary-${row}`"
+              class="metrics-card__row"
+            >
+              <span class="metrics-card__row__label">
+                <span class="skeleton-bar" />
+              </span>
+              <span class="metrics-card__row__value">
+                <span class="skeleton-bar" />
+              </span>
+            </div>
+          </div>
+          <div class="metrics-card__divider" />
+          <div class="metrics-card__rows metrics-card__rows--split">
+            <div
+              v-for="row in dimensionRows"
+              :key="`grid-skeleton__dimension-${row}`"
+              class="metrics-card__row"
+            >
+              <span class="metrics-card__row__label">
+                <span class="skeleton-bar" />
+              </span>
+              <span class="metrics-card__row__value">
+                <span class="skeleton-bar" />
+              </span>
+            </div>
+          </div>
+        </div>
+      </template>
+    </Panel>
+  </Grid>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/shared/components/LazyImage/index.scss
+++ b/app/frontend/shared/components/LazyImage/index.scss
@@ -87,7 +87,7 @@
 }
 
 .gallery-image {
-  height: 250px !important;
+  height: var(--gallery-image-height, 250px) !important;
   margin-bottom: 20px;
 }
 

--- a/app/frontend/shared/components/ListSkeleton/index.scss
+++ b/app/frontend/shared/components/ListSkeleton/index.scss
@@ -1,0 +1,58 @@
+@import "@/shared/components/skeleton";
+
+.list-skeleton {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  &__item {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 10px 16px;
+    border-bottom: 1px solid rgba($gray-light, 0.16);
+    // A row of this kind carries controls on its right, so it is at least as
+    // tall as those - the same token they are sized from rather than a number
+    // copied out of Btn. Only until the list has been measured once.
+    min-height: calc(var(--field-h, 43px) + 20px);
+
+    &:last-child {
+      border-bottom: 0;
+    }
+
+    // A measured row can be shorter than that floor, and a floor it cannot go
+    // under would hold the placeholder taller than the row it stands in for.
+    &--measured {
+      min-height: 0;
+    }
+  }
+
+  &__icon {
+    flex: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+  }
+
+  &__lines {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+  }
+
+  // Widths and type only - the bars themselves are the shared primitive, and
+  // the type is what gives them their height.
+  .skeleton-bar {
+    &--title {
+      width: 42%;
+      font-size: 15px;
+    }
+
+    &--meta {
+      width: 24%;
+      font-size: 12px;
+    }
+  }
+}

--- a/app/frontend/shared/components/ListSkeleton/index.spec.ts
+++ b/app/frontend/shared/components/ListSkeleton/index.spec.ts
@@ -1,0 +1,39 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import Component from "./index.vue";
+
+const mount = (props?: { count?: number }) =>
+  mountWithDefaults<typeof Component>(Component, { props });
+
+const items = (wrapper: Awaited<ReturnType<typeof mount>>) =>
+  wrapper.findAll(".list-skeleton__item");
+
+describe("ListSkeleton", () => {
+  it("renders one placeholder per row the page will hold", async () => {
+    const wrapper = await mount({ count: 6 });
+
+    expect(items(wrapper)).toHaveLength(6);
+  });
+
+  // A list that has been seen empty reserves nothing: a count of zero is an
+  // answer, and the `10` below is only for a list nobody has seen yet.
+  it("reserves nothing for a list known to be empty", async () => {
+    const wrapper = await mount({ count: 0 });
+
+    expect(items(wrapper)).toHaveLength(0);
+  });
+
+  it("falls back to a page of rows before anything is known", async () => {
+    const wrapper = await mount();
+
+    expect(items(wrapper)).toHaveLength(10);
+  });
+
+  it("keeps the placeholders out of the reading order", async () => {
+    const wrapper = await mount({ count: 2 });
+
+    expect(
+      wrapper.get('[data-test="list-skeleton"]').attributes("aria-hidden"),
+    ).toBe("true");
+  });
+});

--- a/app/frontend/shared/components/ListSkeleton/index.vue
+++ b/app/frontend/shared/components/ListSkeleton/index.vue
@@ -1,0 +1,54 @@
+<script lang="ts">
+export default {
+  name: "ListSkeleton",
+};
+</script>
+
+<script lang="ts" setup>
+import { useListGeometry } from "@/shared/composables/useListGeometry";
+
+type Props = {
+  // Comes from the list this stands in for when it is inside one.
+  count?: number;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  count: undefined,
+});
+
+const geometry = useListGeometry();
+
+// `??`, not `||`: a remembered zero means this list has been seen empty, and
+// reserving nothing for it is the right answer rather than a missing one.
+const count = computed(() => props.count ?? geometry?.count.value ?? 10);
+
+// Nothing until this list has been seen once, and then exactly what one of its
+// rows measured. The floor in the stylesheet only has to carry the first load.
+const itemHeight = computed(() => {
+  const remembered = geometry?.heightFor("row");
+
+  return remembered ? `${remembered}px` : undefined;
+});
+</script>
+
+<template>
+  <ul class="list-skeleton" aria-hidden="true" data-test="list-skeleton">
+    <li
+      v-for="item in count"
+      :key="`list-skeleton-${item}`"
+      class="list-skeleton__item"
+      :class="{ 'list-skeleton__item--measured': !!itemHeight }"
+      :style="{ height: itemHeight }"
+    >
+      <span class="skeleton-well list-skeleton__icon" />
+      <span class="list-skeleton__lines">
+        <span class="skeleton-bar list-skeleton__bar--title" />
+        <span class="skeleton-bar list-skeleton__bar--meta" />
+      </span>
+    </li>
+  </ul>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/shared/components/base/Grid/index.vue
+++ b/app/frontend/shared/components/base/Grid/index.vue
@@ -5,6 +5,9 @@ export default {
 </script>
 
 <script lang="ts" setup generic="T">
+import { useReportListGeometry } from "@/shared/composables/useListGeometry";
+import type { ComponentPublicInstance } from "vue";
+
 type Props = {
   records: T[];
   primaryKey: keyof T;
@@ -47,10 +50,36 @@ const cssClasses = computed(() => {
 const primaryValue = (record: T) => {
   return record[props.primaryKey] as string | number;
 };
+
+// The transition group is a component, so the row it renders is reached through
+// its root rather than by the ref itself.
+const cells = ref<ComponentPublicInstance>();
+
+// What the placeholder cards of the next load stand as tall as. A card's height
+// is its content's - a longer name, an open details panel, the column count at
+// this width - so the card itself is the only thing that knows.
+const { report } = useReportListGeometry("card", cells, {
+  ready: () => !!props.records.length,
+  // The card, not the cell around it: a cell carries the card's outer margin as
+  // well, and a placeholder given that height would stand taller than the card
+  // it stands in for by exactly that margin.
+  pick: (host) =>
+    host.querySelector<HTMLElement>(".base-grid__cell")?.firstElementChild,
+});
+
+// The filter panel takes a column away from the grid, which makes every card in
+// it narrower and most of them taller.
+watch(() => props.filterVisible, report);
 </script>
 
 <template>
-  <transition-group name="fade-list" class="row" tag="div" :appear="true">
+  <transition-group
+    ref="cells"
+    name="fade-list"
+    class="row"
+    tag="div"
+    :appear="true"
+  >
     <div
       v-for="(record, index) in records"
       :key="primaryValue(record)"

--- a/app/frontend/shared/components/base/Table/index.scss
+++ b/app/frontend/shared/components/base/Table/index.scss
@@ -1,3 +1,7 @@
+// The placeholders are slotted into TableCol, which keeps them in this
+// component's scope.
+@import "@/shared/components/skeleton";
+
 .base-table {
   &__outer-wrapper {
     position: relative;
@@ -19,6 +23,15 @@
 
     > * {
       margin-top: -20px;
+    }
+  }
+
+  // A row whose last cell holds buttons is as tall as those buttons, not as
+  // tall as its text - so the placeholders take the same token the controls in
+  // that cell are sized from rather than a number copied out of Btn.
+  &__skeleton-row--with-controls {
+    :deep(.base-table-col__inner) {
+      min-height: var(--field-h, 43px);
     }
   }
 

--- a/app/frontend/shared/components/base/Table/index.spec.ts
+++ b/app/frontend/shared/components/base/Table/index.spec.ts
@@ -1,0 +1,158 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import Component from "./index.vue";
+import { type BaseTableCol } from "./types";
+
+type Row = { slug: string; name: string };
+
+const columns: BaseTableCol<Row>[] = [
+  { name: "name", label: "Name", width: "200px" },
+  { name: "focus", label: "Focus" },
+];
+
+// A generic SFC is not a plain constructor type; this names the props the tests
+// use without reaching for `any`.
+const TableComponent = Component as unknown as new (...args: unknown[]) => {
+  $props: {
+    records: Row[];
+    columns: BaseTableCol<Row>[];
+    primaryKey: keyof Row;
+    loading?: boolean;
+    skeletonRows?: number;
+  };
+};
+
+const mount = (props: {
+  records: Row[];
+  loading?: boolean;
+  skeletonRows?: number;
+}) =>
+  mountWithDefaults<typeof TableComponent>(TableComponent, {
+    props: { columns, primaryKey: "slug", ...props },
+  });
+
+const skeletonRows = (wrapper: Awaited<ReturnType<typeof mount>>) =>
+  wrapper.findAll('[data-test="base-table-skeleton-row"]');
+
+describe("BaseTable", () => {
+  it("holds the table open with placeholder rows on the first load", async () => {
+    const wrapper = await mount({
+      records: [],
+      loading: true,
+      skeletonRows: 5,
+    });
+
+    expect(skeletonRows(wrapper)).toHaveLength(5);
+  });
+
+  // A refetch keeps what it has on screen, and the records hold the table open
+  // better than placeholders would.
+  it("leaves the records in place while they are refetched", async () => {
+    const wrapper = await mount({
+      records: [{ slug: "avenger", name: "Avenger" }],
+      loading: true,
+      skeletonRows: 5,
+    });
+
+    expect(skeletonRows(wrapper)).toHaveLength(0);
+  });
+
+  it("stays out of the way of a table that did not ask for it", async () => {
+    const wrapper = await mount({ records: [], loading: true });
+
+    expect(skeletonRows(wrapper)).toHaveLength(0);
+  });
+
+  // Without the columns' own widths the placeholders lay out a second, narrower
+  // table under the header they are meant to be waiting beneath.
+  it("gives the placeholder cells the columns' widths", async () => {
+    const wrapper = await mount({
+      records: [],
+      loading: true,
+      skeletonRows: 1,
+    });
+
+    const cells = skeletonRows(wrapper)[0].findAll(".base-table-col");
+
+    expect(cells).toHaveLength(columns.length);
+    expect(cells[0].attributes("style")).toContain("width: 200px");
+  });
+
+  // A cell holding a thumbnail is both taller and a different shape than a line
+  // of text, so a bar stands in for neither its height nor what it holds.
+  it("stands in for a column's media with a well of its height", async () => {
+    const wrapper = await mountWithDefaults<typeof TableComponent>(
+      TableComponent,
+      {
+        props: {
+          records: [],
+          loading: true,
+          skeletonRows: 1,
+          primaryKey: "slug",
+          columns: [
+            { name: "image", label: "", skeletonMedia: "50px" },
+            ...columns,
+          ],
+        },
+      },
+    );
+
+    const row = wrapper.get('[data-test="base-table-skeleton-row"]');
+    const wells = row.findAll(".skeleton-well");
+
+    expect(wells).toHaveLength(1);
+    expect(wells[0].attributes("style")).toContain("height: 50px");
+    expect(row.findAll(".skeleton-bar")).toHaveLength(columns.length);
+  });
+
+  // The last cell of a row with actions holds buttons, and those set the row's
+  // height rather than the text beside them.
+  it("reserves the control height for a table that carries actions", async () => {
+    const withActions = await mountWithDefaults<typeof TableComponent>(
+      TableComponent,
+      {
+        props: {
+          records: [],
+          loading: true,
+          skeletonRows: 1,
+          primaryKey: "slug",
+          columns,
+        },
+        slots: { actions: "<button>edit</button>" },
+      },
+    );
+
+    expect(
+      withActions.get('[data-test="base-table-skeleton-row"]').classes(),
+    ).toContain("base-table__skeleton-row--with-controls");
+
+    const plain = await mount({ records: [], loading: true, skeletonRows: 1 });
+
+    expect(
+      plain.get('[data-test="base-table-skeleton-row"]').classes(),
+    ).not.toContain("base-table__skeleton-row--with-controls");
+  });
+
+  // A table on its own keeps its spinner over its placeholders - nothing else
+  // is going to say it is loading. Holding it back is the job of a list that
+  // shows one already, and that case lives in useListGeometry's spec.
+  it("keeps its own spinner over placeholders it stands alone with", async () => {
+    const wrapper = await mount({
+      records: [],
+      loading: true,
+      skeletonRows: 3,
+    });
+
+    expect(wrapper.find(".base-table__loader").exists()).toBe(true);
+  });
+
+  it("keeps the placeholders out of the reading order", async () => {
+    const wrapper = await mount({
+      records: [],
+      loading: true,
+      skeletonRows: 2,
+    });
+
+    expect(skeletonRows(wrapper)[0].attributes("aria-hidden")).toBe("true");
+  });
+});

--- a/app/frontend/shared/components/base/Table/index.vue
+++ b/app/frontend/shared/components/base/Table/index.vue
@@ -19,6 +19,10 @@ import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import Loader from "@/shared/components/Loader/index.vue";
 import { type AsyncStatus } from "@/shared/components/AsyncData.types";
 import { useMobile } from "@/shared/composables/useMobile";
+import {
+  useListGeometry,
+  useReportListGeometry,
+} from "@/shared/composables/useListGeometry";
 import TableHeader from "./Header/index.vue";
 import TableRow from "./Row/index.vue";
 import TableCol from "./Col/index.vue";
@@ -42,6 +46,10 @@ type Props = {
   rowDisabled?: (record: T) => boolean;
   fillHeight?: boolean;
   admin?: boolean;
+  // Placeholder rows to hold the table open with while it waits for its first
+  // records. A table inside a list takes the count from the list instead, so
+  // this is only for one standing on its own.
+  skeletonRows?: number;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -59,6 +67,7 @@ const props = withDefaults(defineProps<Props>(), {
   rowDisabled: undefined,
   fillHeight: false,
   admin: false,
+  skeletonRows: undefined,
 });
 
 const isLoading = computed(() => {
@@ -74,6 +83,60 @@ const isLoading = computed(() => {
 const internalSelected = ref<string[]>([]);
 
 const mobile = useMobile();
+
+// A list frames the table with its own page size and with what a row of this
+// very table measured last time; a table standing on its own is told.
+const geometry = useListGeometry();
+
+const skeletonRowCount = computed(
+  () => props.skeletonRows ?? geometry?.count.value ?? 0,
+);
+
+// Only for the first load. A refetch keeps the records it already has on
+// screen, and they hold the table open better than placeholders would.
+const skeletonVisible = computed(
+  () => !!skeletonRowCount.value && isLoading.value && !props.records.length,
+);
+
+// Held back only where the list around the table is already showing one over
+// the placeholder rows. A table left to load on its own - a list that hides the
+// outer spinner in favour of this one, or a table with no list at all - keeps
+// it.
+const ownLoaderVisible = computed(() => {
+  if (!isLoading.value || props.records.length) {
+    return false;
+  }
+
+  return !(skeletonVisible.value && !!geometry?.spinnerVisible.value);
+});
+
+// Nothing until this table has been seen once, and then exactly what it was:
+// the fallbacks below - a line of text, the control height where the row has
+// buttons - only have to carry the very first load.
+const skeletonRowHeight = computed(() => {
+  const remembered = geometry?.heightFor("row");
+
+  return remembered ? `${remembered}px` : undefined;
+});
+
+const inner = ref<HTMLElement>();
+
+// The measurement the next load reserves from. Taken from the first real row
+// once one exists, which is the only place the answer is: the tallest cell of a
+// row wins, and which cell that is - a wrapped name, a thumbnail, a cell of
+// buttons - is a question about this table's data at this width.
+useReportListGeometry("row", inner, {
+  ready: () => !!props.records.length,
+  // The head is skipped rather than the body selected: the header is a row of
+  // this same class - shorter than a record, and no indication of how tall one
+  // is - and the body is a transition group, which a test env stubs away.
+  pick: (host) =>
+    Array.from(
+      host.querySelectorAll<HTMLElement>(
+        ".base-table-row:not([data-test='base-table-skeleton-row'])",
+      ),
+    ).find((candidate) => !candidate.closest(".base-table-header")),
+});
 
 const filteredColumns = computed(() => {
   return props.columns.filter((column) => {
@@ -175,15 +238,12 @@ const resetSelected = () => {
     </BulkActions>
     <div class="base-table__outer-wrapper">
       <div class="base-table__wrapper w-full">
-        <div
-          class="base-table__loader"
-          v-if="isLoading && !props.records.length"
-        >
+        <div class="base-table__loader" v-if="ownLoaderVisible">
           <slot name="loader" :loading="isLoading">
             <Loader :loading="isLoading" :admin="props.admin" />
           </slot>
         </div>
-        <table class="base-table__inner">
+        <table ref="inner" class="base-table__inner">
           <TableHeader
             :id="props.id"
             :col-key="colKey"
@@ -212,6 +272,42 @@ const resetSelected = () => {
                 </slot>
               </TableCol>
             </TableRow>
+            <!-- The cells carry the columns' own widths, so the placeholders
+                 line up under the header they are waiting beneath rather than
+                 laying out a second, narrower table. -->
+            <template v-else-if="skeletonVisible">
+              <TableRow
+                v-for="row in skeletonRowCount"
+                :key="`base-table__skeleton-${row}`"
+                class="base-table__skeleton-row"
+                :class="{
+                  'base-table__skeleton-row--with-controls': !!slots.actions,
+                }"
+                :style="{ height: skeletonRowHeight }"
+                aria-hidden="true"
+                data-test="base-table-skeleton-row"
+              >
+                <TableCol v-if="props.selectable" variant="selection" />
+                <TableCol
+                  v-for="column in filteredColumns"
+                  :key="`base-table__skeleton-${colKey}-${column.name}`"
+                  :alignment="column.alignment"
+                  :style="{
+                    'flex-grow': column.flexGrow,
+                    width: column.width,
+                    'min-width': column.minWidth,
+                  }"
+                >
+                  <span
+                    v-if="column.skeletonMedia"
+                    class="skeleton-well"
+                    :style="{ height: column.skeletonMedia }"
+                  />
+                  <span v-else class="skeleton-bar" />
+                </TableCol>
+                <TableCol v-if="slots.actions" variant="actions" />
+              </TableRow>
+            </template>
             <TableRow
               v-for="record in props.records"
               v-else

--- a/app/frontend/shared/components/base/Table/types.ts
+++ b/app/frontend/shared/components/base/Table/types.ts
@@ -23,4 +23,9 @@ export type BaseTableCol<T> = {
   alignment?: `${BaseTableColAlignmentEnum}`;
   sortable?: boolean;
   attributeKey?: keyof T | string;
+  // The height of the media this column holds, which turns its placeholder
+  // from a line into an image well of that height. Only needed where a cell
+  // holds a thumbnail: a bar the height of a line stands in for neither its
+  // shape nor its height.
+  skeletonMedia?: string;
 };

--- a/app/frontend/shared/components/skeleton.scss
+++ b/app/frontend/shared/components/skeleton.scss
@@ -1,0 +1,54 @@
+// The two shapes a list waiting for records is made of, shared by the
+// placeholder cards and the placeholder table rows so a card and a row read as
+// the same thing waiting.
+
+// A line that has not arrived yet.
+//
+// Deliberately still: a table page reserves per-page rows times columns of
+// these, and animating a hundred of them to say what the one spinner over them
+// already says is not a trade worth making. The wells carry the movement.
+.skeleton-bar {
+  display: inline-block;
+  width: 100%;
+  border-radius: 3px;
+  background: rgba($gray-light, 0.18);
+
+  // A non-breaking space, so a bar is exactly as tall as the line it stands in
+  // for - inheriting the font of whatever it sits in rather than carrying a
+  // height that has to be kept in step with it by hand.
+  &::before {
+    content: "\00a0";
+  }
+}
+
+// An image that has not arrived yet.
+//
+// A well rather than a lighter block: --color-surface is byte-identical to
+// $gray-darker, so a placeholder built from that colour is the same tone as the
+// surface holding it, and all that reads is whatever sits over it. Darkening is
+// also what the photo region already does - see PanelBgImage - so the area
+// reads as somewhere an image goes.
+.skeleton-well {
+  display: block;
+  width: 100%;
+  border-radius: $border-radius-base;
+  background-color: rgba(#000, 0.45);
+  background-image: linear-gradient(
+    90deg,
+    transparent 20%,
+    rgba($gray-light, 0.22) 50%,
+    transparent 80%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-sweep 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-sweep {
+  0% {
+    background-position: 200% 0;
+  }
+
+  100% {
+    background-position: -200% 0;
+  }
+}

--- a/app/frontend/shared/composables/useListGeometry.spec.ts
+++ b/app/frontend/shared/composables/useListGeometry.spec.ts
@@ -1,0 +1,206 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, ref, type Component } from "vue";
+import BaseTable from "@/shared/components/base/Table/index.vue";
+import Grid from "@/shared/components/base/Grid/index.vue";
+import { provideListGeometry } from "./useListGeometry";
+import { useListGeometryStore } from "@/shared/stores/listGeometry";
+import type { BaseTableCol } from "@/shared/components/base/Table/types";
+
+type Row = { slug: string; name: string };
+
+const columns: BaseTableCol<Row>[] = [
+  { name: "name", label: "Name" },
+  { name: "focus", label: "Focus" },
+];
+
+const record = { slug: "avenger", name: "Avenger" };
+
+// A real store rather than the testing one: what is under test is the round
+// trip through it, and the testing pinia stubs the action that writes.
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const render = async (component: Component) => {
+  const wrapper = mount(component, {
+    global: { directives: { Tooltip: {} } },
+  });
+
+  await flushPromises();
+
+  return wrapper;
+};
+
+// Stands in for FilteredList: the geometry only reaches a list through whatever
+// frames it.
+const listHost = (records: Row[], frameSpinner = true) =>
+  defineComponent({
+    components: { BaseTable: BaseTable as unknown as Component },
+    setup() {
+      provideListGeometry("ships", ref(4), ref(frameSpinner));
+
+      return { columns, records, loading: !records.length };
+    },
+    template: `
+      <BaseTable
+        :records="records"
+        :columns="columns"
+        primary-key="slug"
+        :loading="loading"
+      />
+    `,
+  });
+
+const gridHost = (records: Row[]) =>
+  defineComponent({
+    components: { Grid: Grid as unknown as Component },
+    setup() {
+      provideListGeometry("ships", ref(4), ref(true));
+
+      return { records };
+    },
+    template: `
+      <Grid :records="records" primary-key="slug">
+        <template #default="{ record }">
+          <div class="card">{{ record.name }}</div>
+        </template>
+      </Grid>
+    `,
+  });
+
+const stubHeight = (height: number) =>
+  vi
+    .spyOn(Element.prototype, "getBoundingClientRect")
+    .mockReturnValue({ height } as DOMRect);
+
+const heights = () => Object.values(useListGeometryStore().heights);
+
+describe("useListGeometry", () => {
+  it("hands a table the page size of the list around it", async () => {
+    const wrapper = await render(listHost([]));
+
+    expect(
+      wrapper.findAll('[data-test="base-table-skeleton-row"]'),
+    ).toHaveLength(4);
+  });
+
+  // The measurement is the whole point: a row's height comes from its own
+  // content, so the table that rendered it is the only thing that knows.
+  it("remembers what a rendered row measured", async () => {
+    stubHeight(93);
+
+    await render(listHost([record]));
+
+    expect(heights()).toEqual([93]);
+  });
+
+  // The header is a row of the same class, and it is both shorter than a record
+  // and no indication of how tall one is.
+  it("measures a record's row rather than the header", async () => {
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: Element) {
+        return {
+          height: this.closest(".base-table-header") ? 45 : 93,
+        } as DOMRect;
+      },
+    );
+
+    await render(listHost([record]));
+
+    expect(heights()).toEqual([93]);
+  });
+
+  it("reserves that height for the next load's placeholders", async () => {
+    stubHeight(93);
+    await render(listHost([record]));
+    vi.restoreAllMocks();
+
+    const wrapper = await render(listHost([]));
+
+    expect(
+      wrapper.get('[data-test="base-table-skeleton-row"]').attributes("style"),
+    ).toContain("height: 93px");
+  });
+
+  // A cell carries the card's outer margin as well, so measuring the cell would
+  // reserve that margin twice over.
+  it("measures a grid's card rather than the cell around it", async () => {
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: Element) {
+        return {
+          height: this.classList.contains("card") ? 286 : 307,
+        } as DOMRect;
+      },
+    );
+
+    await render(gridHost([record]));
+
+    expect(heights()).toEqual([286]);
+  });
+
+  // One list can be drawn both ways - the ships list is a grid or a table on
+  // the reader's say - and a card is not as tall as a row. Under one key the
+  // second shape to render would hand its height to the first.
+  it("keeps a card's height apart from a row's", async () => {
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: Element) {
+        return {
+          height: this.classList.contains("card") ? 290 : 93,
+        } as DOMRect;
+      },
+    );
+
+    await render(gridHost([record]));
+    await render(listHost([record]));
+
+    const byShape = Object.fromEntries(
+      Object.entries(useListGeometryStore().heights).map(([key, height]) => [
+        key.split(":")[1],
+        height,
+      ]),
+    );
+
+    expect(byShape).toEqual({ card: 290, row: 93 });
+  });
+
+  // One spinner between them: the frame's, over the placeholders, unless the
+  // list is one of those that hides it in favour of the table's own.
+  it("holds back the table's spinner while the frame shows one", async () => {
+    const framed = await render(listHost([]));
+
+    expect(framed.find(".base-table__loader").exists()).toBe(false);
+
+    const alone = await render(listHost([], false));
+
+    expect(alone.find(".base-table__loader").exists()).toBe(true);
+  });
+
+  it("stays out of the way of a table with no list around it", async () => {
+    const wrapper = await render(
+      defineComponent({
+        components: { BaseTable: BaseTable as unknown as Component },
+        setup() {
+          return { columns, records: [] as Row[] };
+        },
+        template: `
+          <BaseTable
+            :records="records"
+            :columns="columns"
+            primary-key="slug"
+            loading
+          />
+        `,
+      }),
+    );
+
+    expect(
+      wrapper.findAll('[data-test="base-table-skeleton-row"]'),
+    ).toHaveLength(0);
+  });
+});

--- a/app/frontend/shared/composables/useListGeometry.ts
+++ b/app/frontend/shared/composables/useListGeometry.ts
@@ -1,0 +1,111 @@
+import { useListGeometryStore } from "@/shared/stores/listGeometry";
+import { useMobile } from "@/shared/composables/useMobile";
+import type {
+  ComponentPublicInstance,
+  ComputedRef,
+  InjectionKey,
+  MaybeRefOrGetter,
+  Ref,
+} from "vue";
+
+// One list can be drawn more than one way - the ships list is a card grid or a
+// table, on the reader's say - and a card is not as tall as a row. Each shape
+// remembers its own height.
+export type ListGeometryKindType = "row" | "card";
+
+export type ListGeometry = {
+  // How many records the answer on its way is expected to hold.
+  count: Ref<number> | ComputedRef<number>;
+  // What one of them was as tall as the last time this list drew any, which is
+  // the only honest source for it: the height comes from the content - a name
+  // that wraps, a thumbnail, a cell of buttons - and no rule written ahead of
+  // time knows which of those wins in a given list at a given width.
+  heightFor: (kind: ListGeometryKindType) => number | undefined;
+  report: (kind: ListGeometryKindType, height: number) => void;
+  // Whether the frame is showing a spinner of its own already, so a list that
+  // has one too can hold it back rather than put up the second.
+  spinnerVisible: Ref<boolean> | ComputedRef<boolean>;
+};
+
+const listGeometryKey = Symbol("listGeometry") as InjectionKey<ListGeometry>;
+
+// Offered by whatever frames a list - FilteredList - and picked up by the list
+// that renders inside it, so a table or a grid needs to be told neither how
+// many placeholders to draw nor how tall.
+export const provideListGeometry = (
+  name: MaybeRefOrGetter<string>,
+  count: Ref<number> | ComputedRef<number>,
+  spinnerVisible: Ref<boolean> | ComputedRef<boolean>,
+): ListGeometry => {
+  const store = useListGeometryStore();
+  const mobile = useMobile();
+
+  const keyFor = (kind: ListGeometryKindType) =>
+    `${toValue(name)}:${kind}:${mobile.value ? "mobile" : "desktop"}`;
+
+  const geometry: ListGeometry = {
+    count,
+    spinnerVisible,
+    heightFor: (kind) => store.findByKey(keyFor(kind)),
+    report: (kind, measured) => {
+      const key = keyFor(kind);
+
+      if (measured > 0 && measured !== store.findByKey(key)) {
+        store.setByKey(key, measured);
+      }
+    },
+  };
+
+  provide(listGeometryKey, geometry);
+
+  return geometry;
+};
+
+export const useListGeometry = () => inject(listGeometryKey, undefined);
+
+// The reporting half, for whatever actually drew the records: a table, a grid,
+// or a page with a list of its own. `pick` names the element to measure, since
+// only the caller knows which of its children stands for one record.
+export const useReportListGeometry = (
+  kind: ListGeometryKindType,
+  root: Ref<HTMLElement | ComponentPublicInstance | undefined>,
+  options: {
+    ready: () => boolean;
+    pick: (host: HTMLElement) => Element | null | undefined;
+  },
+) => {
+  const geometry = useListGeometry();
+  const mobile = useMobile();
+
+  const report = async () => {
+    if (!geometry || !options.ready()) {
+      return;
+    }
+
+    await nextTick();
+
+    const element = root.value;
+    // A ref on a component - a transition group, say - holds the instance, and
+    // the element it rendered hangs off it.
+    const host = (element && "$el" in element ? element.$el : element) as
+      HTMLElement | undefined;
+
+    const measured = host ? options.pick(host) : undefined;
+
+    if (measured) {
+      geometry.report(
+        kind,
+        Math.round(measured.getBoundingClientRect().height),
+      );
+    }
+  };
+
+  watch(() => options.ready(), report);
+  // A row that wraps on a phone is not the row it is on a desktop, and the two
+  // are remembered apart - so crossing the breakpoint has to take a new reading.
+  watch(mobile, report);
+
+  onMounted(report);
+
+  return { report };
+};

--- a/app/frontend/shared/stores/listGeometry.ts
+++ b/app/frontend/shared/stores/listGeometry.ts
@@ -1,0 +1,50 @@
+import { defineStore } from "pinia";
+
+type ListGeometryState = {
+  // How tall one record of a list turned out to be, so the next load can
+  // reserve the same. Keyed by list and viewport class: a cell that wraps on a
+  // phone is not the cell the same list draws on a desktop.
+  heights: {
+    [key: string]: number;
+  };
+  // The most records a list has ever shown at once, capped by its page size
+  // when it is read. A list that only ever holds two - a ship's videos - should
+  // not reserve a full page of them, and nothing in the first answer says so.
+  counts: {
+    [key: string]: number;
+  };
+};
+
+export const useListGeometryStore = defineStore("listGeometry", {
+  state: (): ListGeometryState => ({
+    heights: {},
+    counts: {},
+  }),
+  getters: {
+    findByKey: (store) => (key: string) => store.heights[key],
+    countByKey: (store) => (key: string) => store.counts[key],
+  },
+  actions: {
+    setByKey(key: string, height: number) {
+      this.heights[key] = height;
+    },
+    // The high-water mark, not the last reading: the final page of a list holds
+    // fewer records than the ones before it, and reserving from that would
+    // leave every earlier page short.
+    //
+    // Zero is a reading like any other, and worth keeping: a ship with no
+    // videos should reserve no room for them.
+    recordCount(key: string, count: number) {
+      const seen = this.counts[key];
+
+      if (seen === undefined || count > seen) {
+        this.counts[key] = count;
+      }
+    },
+  },
+  // Persisted, because the load that benefits most from knowing all this is the
+  // first one after opening the page.
+  persist: {
+    pick: ["heights", "counts"],
+  },
+});


### PR DESCRIPTION
A list mid-load rendered a spinner and nothing else. The spinner is absolutely positioned, so the column it sits in collapsed: the paginator above the records and the one below landed on top of each other — visible since #4672 took the `v-if` guards off the control — and the page jumped by its own height once the answer came in.

## What stands in for the records

Three shapes, from two shared primitives — a bar for a line of text, a well for a picture:

- **Tables** draw their own: the table that is already there renders its header, its column widths and a page of placeholder rows out of an empty record set. Closer to what arrives than anything written beside it could be.
- **Card grids** get placeholder cards. A gallery and the video grid get bare ones instead — their cells hold the picture or the embed itself, with no frame and no title over it.
- **Lists a page draws itself** (both notification lists) get placeholder rows of their own shape.

A list that brings none of the three keeps a reserved box with the spinner centred in it, which is enough to keep the two paginators apart.

## Heights are measured, not guessed

A row is as tall as the tallest thing in it, and which cell that is — a name that wraps, a thumbnail, a cell of buttons — is a question about this list's data at this width. No rule written ahead of time answers it: on the ships table the height comes from the name column wrapping, which changes with the viewport.

So each list reports what it actually rendered, keyed by list, by shape and by viewport class, and the next load reserves exactly that. Verified against the running app:

| | real | reserved |
|---|---|---|
| ships, table | 93px per row | **93px** |
| ships, cards | 290px | **290px** |
| images, 1440 / 1180 / 900 / 390px | 540×250 / 410×250 / 870×250 / 360×250 | **identical at all four** |
| a ship's videos (empty) | 0 | **0** |

The count is remembered the same way and capped by the page size: a page size is an upper bound, not a promise. A ship with two videos should not reserve a page of them, and one with none should reserve nothing.

The fallbacks only have to carry the very first load, and they come from tokens rather than numbers — `--field-h` where a row carries buttons, `--gallery-image-height` for a gallery picture (extracted here, so `LazyImage` and the placeholder read one definition).

## Where the lists stand

Every list is covered. Most admin tables needed no change at all — they already render while loading, so they pick up the count and the height from the list around them. Five were gated on their own data (`v-if="users"`) and so did not exist while the answer was on its way; the gate goes and the records read through optionals.

One spinner between them: the frame's own goes over the placeholders, except where a list hides it in favour of the table's — which is why the geometry says whether one is up already.

## Notes for review

- **No delay before the placeholders appear.** Measured this list at 643 / 673 / 796 / 968 ms per request; a flash needs answers under ~150ms. A delay would push every real load 150ms later for a case that does not occur here.
- **Arriving *at* a final page still over-reserves.** Nothing predicts that without the `totalCount` only the answer carries.
- **Not verified in the browser:** the notification lists and the fleet member lists, both behind a login. Their placeholders are unit-tested; the first-load fallback height is the control-height token until the list measures itself once.
- `visual-tests/states` gained a section that puts the placeholders next to the cards and rows they stand in for.

🤖
