### PR TITLE
fix(travel-times): make the tool work against current data

### DIFF
--- a/app/frontend/frontend/components/TravelTime/index.vue
+++ b/app/frontend/frontend/components/TravelTime/index.vue
@@ -5,8 +5,8 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { type Component, type ComponentQuantumDrive } from "@/services/fyApi";
-import { calculateTravelTime } from "@/frontend/utils/travelTimes";
+import { type Component } from "@/services/fyApi";
+import { quantumDriveTravelTime } from "@/frontend/utils/travelTimes";
 import { toTime } from "@/shared/utils/Time";
 
 type Props = {
@@ -16,30 +16,9 @@ type Props = {
 
 const props = defineProps<Props>();
 
-const typeData = computed(
-  () => props.quantumDrive.typeData as ComponentQuantumDrive | undefined,
+const travelTime = computed(() =>
+  quantumDriveTravelTime(props.quantumDrive, props.distance),
 );
-
-const stage1Acceleration = computed(() => {
-  return (typeData.value?.stageOneAccelRate || 0) / 1000;
-});
-
-const stage2Acceleration = computed(() => {
-  return (typeData.value?.stageTwoAccelRate || 0) / 1000;
-});
-
-const speed = computed(() => {
-  return (typeData.value?.driveSpeed || 0) / 1000;
-});
-
-const travelTime = computed(() => {
-  return calculateTravelTime(
-    stage1Acceleration.value,
-    stage2Acceleration.value,
-    speed.value,
-    props.distance,
-  );
-});
 </script>
 
 <template>

--- a/app/frontend/frontend/pages/tools/travel-times.vue
+++ b/app/frontend/frontend/pages/tools/travel-times.vue
@@ -43,9 +43,24 @@ const columns = computed<BaseTableCol<Component>[]>(() => {
       label: "",
       class: "store-image extra-small",
     },
-    { name: "name", label: "", class: "name", width: "30%" },
-    { name: "fuel_usage", label: "", class: "fuel-usage", width: "30%" },
-    { name: "travel_time", label: "", class: "travel-time", width: "30%" },
+    {
+      name: "name",
+      label: t("labels.travelTimes.quantumDrive"),
+      class: "name",
+      width: "30%",
+    },
+    {
+      name: "fuel_usage",
+      label: t("labels.travelTimes.fuelUsage"),
+      class: "fuel-usage",
+      width: "30%",
+    },
+    {
+      name: "travel_time",
+      label: t("labels.travelTimes.travelTime"),
+      class: "travel-time",
+      width: "30%",
+    },
   ];
 });
 
@@ -149,7 +164,7 @@ const { data: quantumDrives, ...asyncStatus } = useComponentsQuery(
     <div class="row">
       <div class="col-12">
         <p>
-          powered by
+          {{ t("labels.travelTimes.poweredBy") }}
           <a
             href="https://gitlab.com/Erecco/a-study-on-quantum-travel-time/-/blob/master/A_study_on_Quantum_Travel_time_07042021.pdf?ref_type=heads"
             >Erec</a

--- a/app/frontend/frontend/pages/tools/travel-times.vue
+++ b/app/frontend/frontend/pages/tools/travel-times.vue
@@ -10,7 +10,10 @@ import { useI18n } from "@/shared/composables/useI18n";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
 import BaseTable from "@/shared/components/base/Table/index.vue";
-import { type BaseTableCol } from "@/shared/components/base/Table/types";
+import {
+  type BaseTableCol,
+  BaseTableColAlignmentEnum,
+} from "@/shared/components/base/Table/types";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import TravelTime from "@/frontend/components/TravelTime/index.vue";
 import { usePagination } from "@/shared/composables/usePagination";
@@ -32,7 +35,7 @@ import {
 import FeatureGuard from "@/frontend/components/FeatureGuard.vue";
 import { FeatureFlagName } from "@/services/fyApi";
 
-const { t } = useI18n();
+const { t, toNumber } = useI18n();
 
 const route = useRoute();
 
@@ -54,12 +57,14 @@ const columns = computed<BaseTableCol<Component>[]>(() => {
       label: t("labels.travelTimes.fuelUsage"),
       class: "fuel-usage",
       width: "30%",
+      alignment: BaseTableColAlignmentEnum.RIGHT,
     },
     {
       name: "travel_time",
       label: t("labels.travelTimes.travelTime"),
       class: "travel-time",
       width: "30%",
+      alignment: BaseTableColAlignmentEnum.RIGHT,
     },
   ];
 });
@@ -89,14 +94,32 @@ const storeImage = (component: Component) => {
 const isQuantumDrive = (
   typeData?: Component["typeData"],
 ): typeData is ComponentQuantumDrive => {
-  return !!typeData && "quantumFuelRequirement" in typeData;
+  return !!typeData && "quantumFuelConsumption" in typeData;
 };
 
-const getFuelRate = (component: Component): number | undefined => {
-  if (isQuantumDrive(component.typeData)) {
-    return component.typeData.quantumFuelRequirement;
+/*
+ * Quantum fuel burnt over the jump, in SCU. `quantumFuelConsumption` is
+ * milli-SCU per Gm, and a Gm is a million kilometres -- the same unit the
+ * distance is collected in -- so the jump costs rate * distance milli-SCU.
+ *
+ * The drive also carries `quantumFuelRequirement`, which is what this column
+ * used to read. Nothing else in the app touches that field and no unit is
+ * declared for it anywhere; the consumption figure is the one the hardpoint
+ * panel derives its jump range from, checked against erkul.games and
+ * spviewer.eu.
+ */
+const fuelUsage = (component: Component): number | undefined => {
+  if (!isQuantumDrive(component.typeData)) {
+    return undefined;
   }
-  return undefined;
+
+  const rate = component.typeData.quantumFuelConsumption;
+
+  if (!rate) {
+    return undefined;
+  }
+
+  return Math.round(((rate * distance.value) / 1000) * 100) / 100;
 };
 
 const sortedQuantumDrives = computed(() => {
@@ -200,8 +223,8 @@ const { data: quantumDrives, ...asyncStatus } = useComponentsQuery(
             {{ record.name }}
           </template>
           <template #col-fuel_usage="{ record }">
-            <template v-if="getFuelRate(record)">
-              {{ Math.round(getFuelRate(record)! * distance * 100) / 100.0 }}
+            <template v-if="fuelUsage(record)">
+              {{ toNumber(fuelUsage(record)!, "cargo") }}
             </template>
             <template v-else> - </template>
           </template>

--- a/app/frontend/frontend/pages/tools/travel-times.vue
+++ b/app/frontend/frontend/pages/tools/travel-times.vue
@@ -128,7 +128,7 @@ const componentsQueryParams = computed(() => ({
   page: page.value,
   perPage: "240",
   q: {
-    itemTypeIn: ["quantum_drives"],
+    categoryIn: ["quantumdrive"],
   },
 }));
 

--- a/app/frontend/frontend/pages/tools/travel-times.vue
+++ b/app/frontend/frontend/pages/tools/travel-times.vue
@@ -17,7 +17,6 @@ import { usePagination } from "@/shared/composables/usePagination";
 import {
   useComponents as useComponentsQuery,
   getComponentsQueryKey,
-  ComponentTypeEnum,
   type ComponentQuantumDrive,
   type Component,
 } from "@/services/fyApi";
@@ -25,7 +24,7 @@ import fallbackImageJpg from "@/images/fallback/store_image.jpg";
 import fallbackImage from "@/images/fallback/store_image.webp";
 import { useWebpCheck } from "@/shared/composables/useWebpCheck";
 import { useMobile } from "@/shared/composables/useMobile";
-import { calculateTravelTime } from "@/frontend/utils/travelTimes";
+import { quantumDriveTravelTime } from "@/frontend/utils/travelTimes";
 import {
   InputTypesEnum,
   InputAlignmentsEnum,
@@ -85,24 +84,10 @@ const getFuelRate = (component: Component): number | undefined => {
   return undefined;
 };
 
-const travelTime = (quantumDrive: Component) => {
-  if (quantumDrive.type !== ComponentTypeEnum.QUANTUM_DRIVE) {
-    return undefined;
-  }
-
-  const typeData = quantumDrive.typeData as ComponentQuantumDrive;
-
-  const a1 = (typeData.stageOneAccelRate || 0) / 1000;
-  const a2 = (typeData.stageTwoAccelRate || 0) / 1000;
-  const speed = (typeData.driveSpeed || 0) / 1000;
-
-  return calculateTravelTime(a1, a2, speed, distance.value);
-};
-
 const sortedQuantumDrives = computed(() => {
   return [...(quantumDrives.value?.items || [])].sort((a, b) => {
-    const aTravelTime = travelTime(a);
-    const bTravelTime = travelTime(b);
+    const aTravelTime = quantumDriveTravelTime(a, distance.value);
+    const bTravelTime = quantumDriveTravelTime(b, distance.value);
 
     if (!aTravelTime) {
       return 1;
@@ -206,10 +191,7 @@ const { data: quantumDrives, ...asyncStatus } = useComponentsQuery(
             <template v-else> - </template>
           </template>
           <template #col-travel_time="{ record }">
-            <TravelTime
-              :quantum-drive="record"
-              :distance="distance * 1000000"
-            />
+            <TravelTime :quantum-drive="record" :distance="distance" />
           </template>
         </BaseTable>
       </template>

--- a/app/frontend/frontend/utils/travelTimes.spec.ts
+++ b/app/frontend/frontend/utils/travelTimes.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { type Component } from "@/services/fyApi";
+import { quantumDriveTravelTime } from "./travelTimes";
+
+// Only the fields the calculation reads, in the units the sc_data parser
+// writes them: metres and metres per second.
+const drive = (typeData: Record<string, number> | undefined) =>
+  ({ typeData }) as unknown as Component;
+
+const beacon = drive({
+  driveSpeed: 283046000,
+  stageOneAccelRate: 49500000,
+  stageTwoAccelRate: 1500000,
+});
+
+const expedition = drive({
+  driveSpeed: 183046000,
+  stageOneAccelRate: 39500000,
+  stageTwoAccelRate: 1200000,
+});
+
+describe("quantumDriveTravelTime", () => {
+  it("reads the distance as millions of kilometres", () => {
+    expect(quantumDriveTravelTime(beacon, 20)).toBeCloseTo(78.277, 2);
+    expect(quantumDriveTravelTime(expedition, 20)).toBeCloseTo(115.436, 2);
+  });
+
+  it("takes longer over a longer distance", () => {
+    expect(quantumDriveTravelTime(beacon, 50)!).toBeGreaterThan(
+      quantumDriveTravelTime(beacon, 20)!,
+    );
+  });
+
+  // The unit the distance arrives in decided the ordering: fed kilometres
+  // instead of millions of them, the formula returned negative times and
+  // ranked the slower drive first.
+  it("ranks the faster drive below the slower one", () => {
+    expect(quantumDriveTravelTime(beacon, 20)!).toBeGreaterThan(0);
+    expect(quantumDriveTravelTime(beacon, 20)!).toBeLessThan(
+      quantumDriveTravelTime(expedition, 20)!,
+    );
+  });
+
+  it("has no answer for a drive the export never described", () => {
+    expect(quantumDriveTravelTime(drive(undefined), 20)).toBeUndefined();
+    expect(quantumDriveTravelTime(drive({ jumpRange: 1 }), 20)).toBeUndefined();
+  });
+});

--- a/app/frontend/frontend/utils/travelTimes.ts
+++ b/app/frontend/frontend/utils/travelTimes.ts
@@ -1,3 +1,7 @@
+import { type Component, type ComponentQuantumDrive } from "@/services/fyApi";
+
+const KM_PER_MKM = 1000000;
+
 export const calculateTravelTime = (
   a1: number,
   a2: number,
@@ -32,5 +36,27 @@ export const calculateTravelTime = (
     (4 * vmax) / (a1 + a2) +
     distance / vmax -
     (4 * vmax * (2 * a1 + a2)) / (3 * (a1 + a2) ** 2)
+  );
+};
+
+// The drive's rates are stored in metres and metres per second, the formula
+// works in kilometres, and the tool asks for a distance in millions of them.
+// Both the table cell and the sort go through here, so the two cannot drift
+// onto different units.
+export const quantumDriveTravelTime = (
+  quantumDrive: Component,
+  distanceInMkm: number,
+): number | undefined => {
+  const typeData = quantumDrive.typeData as ComponentQuantumDrive | undefined;
+
+  if (!typeData?.driveSpeed) {
+    return undefined;
+  }
+
+  return calculateTravelTime(
+    (typeData.stageOneAccelRate || 0) / 1000,
+    (typeData.stageTwoAccelRate || 0) / 1000,
+    typeData.driveSpeed / 1000,
+    distanceInMkm * KM_PER_MKM,
   );
 };

--- a/app/frontend/shared/components/base/Table/Col/index.scss
+++ b/app/frontend/shared/components/base/Table/Col/index.scss
@@ -87,8 +87,25 @@
     }
   }
 
+  /*
+   * `__inner` is a flex row, so the alignment a column asks for has to move the
+   * flex items -- `text-align` alone leaves a lone child sitting at the start,
+   * which is why `right` did nothing at all and `center` only ever centred text
+   * that already filled the cell. `--selection` and `--actions` below already
+   * spelled it this way; these two had been the odd ones out.
+   */
   &--center {
-    text-align: center;
+    .base-table-col__inner {
+      text-align: center;
+      justify-content: center;
+    }
+  }
+
+  &--right {
+    .base-table-col__inner {
+      text-align: right;
+      justify-content: flex-end;
+    }
   }
 
   &--selection {

--- a/app/frontend/shared/components/base/Table/Header/index.vue
+++ b/app/frontend/shared/components/base/Table/Header/index.vue
@@ -70,6 +70,7 @@ const cssClasses = (column: BaseTableCol<T>) => {
         v-for="(column, index) in props.columns"
         :key="`base-table__header-${colKey}-${index}-${column.name}`"
         as="th"
+        :alignment="column.alignment"
         :class="cssClasses(column)"
         :style="{
           'flex-grow': column.flexGrow,

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1706,6 +1706,12 @@
         "removeShip": "Entfernen",
         "autoFillShip": "Auto-Fill"
       },
+      "travelTimes": {
+        "quantumDrive": "Quantum-Antrieb",
+        "fuelUsage": "Treibstoffverbrauch",
+        "travelTime": "Reisezeit",
+        "poweredBy": "basiert auf"
+      },
       "admin": {
         "dashboard": {
           "quickStats": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1697,6 +1697,12 @@
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },
+      "travelTimes": {
+        "quantumDrive": "Quantum Drive",
+        "fuelUsage": "Fuel Usage",
+        "travelTime": "Travel Time",
+        "poweredBy": "powered by"
+      },
       "admin": {
         "dashboard": {
           "quickStats": {

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1706,6 +1706,12 @@
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },
+      "travelTimes": {
+        "quantumDrive": "Motor Quantum",
+        "fuelUsage": "Consumo de combustible",
+        "travelTime": "Tiempo de viaje",
+        "poweredBy": "basado en"
+      },
       "admin": {
         "dashboard": {
           "quickStats": {

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1706,6 +1706,12 @@
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },
+      "travelTimes": {
+        "quantumDrive": "Moteur quantique",
+        "fuelUsage": "Consommation de carburant",
+        "travelTime": "Temps de trajet",
+        "poweredBy": "basé sur"
+      },
       "admin": {
         "dashboard": {
           "quickStats": {

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1706,6 +1706,12 @@
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },
+      "travelTimes": {
+        "quantumDrive": "Motore Quantum",
+        "fuelUsage": "Consumo di carburante",
+        "travelTime": "Tempo di viaggio",
+        "poweredBy": "basato su"
+      },
       "admin": {
         "dashboard": {
           "quickStats": {

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1702,6 +1702,12 @@
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },
+      "travelTimes": {
+        "quantumDrive": "量子引擎",
+        "fuelUsage": "燃料消耗",
+        "travelTime": "旅行时间",
+        "poweredBy": "基于"
+      },
       "admin": {
         "dashboard": {
           "quickStats": {

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1702,6 +1702,12 @@
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },
+      "travelTimes": {
+        "quantumDrive": "量子引擎",
+        "fuelUsage": "燃料消耗",
+        "travelTime": "旅行時間",
+        "poweredBy": "基於"
+      },
       "admin": {
         "dashboard": {
           "quickStats": {

--- a/test/playwright/app_commands/scenarios/tools.rb
+++ b/test/playwright/app_commands/scenarios/tools.rb
@@ -61,12 +61,13 @@ unless Model.exists?(name: "Aurora MR")
 end
 
 # Quantum drives (for travel times). The travel times page selects on
-# `category`, and the calculation reads the flat `drive_speed` /
-# `stage_*_accel_rate` keys the sc_data parser writes -- mirroring a loaded
-# drive here, or the page renders "-:-:-" for every row.
+# `category`, and reads the flat `drive_speed` / `stage_*_accel_rate` keys the
+# sc_data parser writes -- mirroring a loaded drive here, or the page renders
+# "-:-:-" for every row. `quantum_fuel_consumption` is milli-SCU per Gm; 5 and
+# 22 are the values real S1 and S2 drives carry.
 unless Component.exists?(name: "Beacon")
   FactoryBot.create(:component, name: "Beacon", category: "quantumdrive", component_type: "QuantumDrive", type_data: {
-    "quantum_fuel_requirement" => 0.04,
+    "quantum_fuel_consumption" => 5.0,
     "drive_speed" => 283046000.0,
     "stage_one_accel_rate" => 49500000.0,
     "stage_two_accel_rate" => 1500000.0
@@ -75,7 +76,7 @@ end
 
 unless Component.exists?(name: "Expedition")
   FactoryBot.create(:component, name: "Expedition", category: "quantumdrive", component_type: "QuantumDrive", type_data: {
-    "quantum_fuel_requirement" => 0.02,
+    "quantum_fuel_consumption" => 22.0,
     "drive_speed" => 183046000.0,
     "stage_one_accel_rate" => 39500000.0,
     "stage_two_accel_rate" => 1200000.0

--- a/test/playwright/app_commands/scenarios/tools.rb
+++ b/test/playwright/app_commands/scenarios/tools.rb
@@ -60,26 +60,25 @@ unless Model.exists?(name: "Aurora MR")
   FactoryBot.create(:model, :with_legacy_images, name: "Aurora MR", production_status: "flight-ready", manufacturer: rsi)
 end
 
-# Quantum drives (for travel times)
+# Quantum drives (for travel times). The travel times page selects on
+# `category`, and the calculation reads the flat `drive_speed` /
+# `stage_*_accel_rate` keys the sc_data parser writes -- mirroring a loaded
+# drive here, or the page renders "-:-:-" for every row.
 unless Component.exists?(name: "Beacon")
-  FactoryBot.create(:component, name: "Beacon", item_type: "quantum_drives", type_data: {
-    "fuel_rate" => 80.0,
-    "standard_jump" => {
-      "speed" => 283046000,
-      "stage_1_acceleration_rate" => 49500000,
-      "stage_2_acceleration_rate" => 1500000
-    }
+  FactoryBot.create(:component, name: "Beacon", category: "quantumdrive", component_type: "QuantumDrive", type_data: {
+    "quantum_fuel_requirement" => 0.04,
+    "drive_speed" => 283046000.0,
+    "stage_one_accel_rate" => 49500000.0,
+    "stage_two_accel_rate" => 1500000.0
   })
 end
 
 unless Component.exists?(name: "Expedition")
-  FactoryBot.create(:component, name: "Expedition", item_type: "quantum_drives", type_data: {
-    "fuel_rate" => 60.0,
-    "standard_jump" => {
-      "speed" => 183046000,
-      "stage_1_acceleration_rate" => 39500000,
-      "stage_2_acceleration_rate" => 1200000
-    }
+  FactoryBot.create(:component, name: "Expedition", category: "quantumdrive", component_type: "QuantumDrive", type_data: {
+    "quantum_fuel_requirement" => 0.02,
+    "drive_speed" => 183046000.0,
+    "stage_one_accel_rate" => 39500000.0,
+    "stage_two_accel_rate" => 1200000.0
   })
 end
 

--- a/test/playwright/e2e/TravelTimes.spec.ts
+++ b/test/playwright/e2e/TravelTimes.spec.ts
@@ -1,5 +1,9 @@
+import type { Page } from "@playwright/test";
 import { app, appScenario } from "../support/on-rails";
 import { test, expect } from "../support/commands";
+
+const driveRow = (page: Page, name: string) =>
+  page.getByRole("row").filter({ hasText: name });
 
 test.describe("Travel Times", () => {
   test.beforeEach(async ({ page }) => {
@@ -21,22 +25,35 @@ test.describe("Travel Times", () => {
   });
 
   test("Shows quantum drives list", async ({ page }) => {
-    // Wait for quantum drives to load
     await expect(page.getByText("Beacon")).toBeVisible();
     await expect(page.getByText("Expedition")).toBeVisible();
   });
 
-  test("Updates travel times when distance changes", async ({ page }) => {
-    // Wait for initial load
+  test("Calculates travel time and fuel usage for the default distance", async ({
+    page,
+  }) => {
+    await expect(driveRow(page, "Beacon")).toContainText("01:18");
+    await expect(driveRow(page, "Beacon")).toContainText("0.8");
+
+    await expect(driveRow(page, "Expedition")).toContainText("01:55");
+    await expect(driveRow(page, "Expedition")).toContainText("0.4");
+  });
+
+  test("Sorts the fastest drive first", async ({ page }) => {
     await expect(page.getByText("Beacon")).toBeVisible();
 
-    // Change the distance
+    await expect(page.locator("tbody tr").first()).toContainText("Beacon");
+    await expect(page.locator("tbody tr").nth(1)).toContainText("Expedition");
+  });
+
+  test("Updates travel times when distance changes", async ({ page }) => {
+    await expect(driveRow(page, "Beacon")).toContainText("01:18");
+
     const distanceInput = page.locator('input[name="distance"]');
     await distanceInput.fill("50");
 
-    // The table should still show quantum drives
-    await expect(page.getByText("Beacon")).toBeVisible();
-    await expect(page.getByText("Expedition")).toBeVisible();
+    await expect(driveRow(page, "Beacon")).toContainText("03:04");
+    await expect(driveRow(page, "Expedition")).toContainText("04:39");
   });
 
   test("Shows powered by attribution", async ({ page }) => {

--- a/test/playwright/e2e/TravelTimes.spec.ts
+++ b/test/playwright/e2e/TravelTimes.spec.ts
@@ -29,6 +29,15 @@ test.describe("Travel Times", () => {
     await expect(page.getByText("Expedition")).toBeVisible();
   });
 
+  test("Labels every column", async ({ page }) => {
+    await expect(page.getByText("Beacon")).toBeVisible();
+
+    const header = page.getByRole("row").first();
+    await expect(header).toContainText("Quantum Drive");
+    await expect(header).toContainText("Fuel Usage");
+    await expect(header).toContainText("Travel Time");
+  });
+
   test("Calculates travel time and fuel usage for the default distance", async ({
     page,
   }) => {

--- a/test/playwright/e2e/TravelTimes.spec.ts
+++ b/test/playwright/e2e/TravelTimes.spec.ts
@@ -42,10 +42,10 @@ test.describe("Travel Times", () => {
     page,
   }) => {
     await expect(driveRow(page, "Beacon")).toContainText("01:18");
-    await expect(driveRow(page, "Beacon")).toContainText("0.8");
+    await expect(driveRow(page, "Beacon")).toContainText("0.1 SCU");
 
     await expect(driveRow(page, "Expedition")).toContainText("01:55");
-    await expect(driveRow(page, "Expedition")).toContainText("0.4");
+    await expect(driveRow(page, "Expedition")).toContainText("0.44 SCU");
   });
 
   test("Sorts the fastest drive first", async ({ page }) => {


### PR DESCRIPTION
Makes the travel times tool work against current data. **Not ready to ship** — the flag stays off, see "What still needs work".

## Why it wasn't working

The tool has been behind `tools_travel_times` since the Vue 3 migration, and two bugs explain why.

**The table was empty.** It selected drives with `q[itemTypeIn]`. Components split into two disjoint generations: the 58 rows carrying `item_type` are the pre-sc_data import and have no version, so no build — and `#index` defaults `current_version` to true and inner-joins the build. They were filtered out before ransack saw them. The 63 rows the parser writes carry `component_type` and `category` instead. No error surfaced on any layer; the page just rendered nothing.

**The sort was inverted.** The calculation existed twice and the copies disagreed on units — the cell passed `distance * 1000000`, the comparator passed the raw `distance.value`. Fed kilometres where the formula wants millions of them it returns *negative* times, so the slower drive ranked first.

The e2e fixture described drives in the legacy shape too, which is why five green tests never caught either one — they only asserted that two names rendered.

## The fuel column had no meaning

It read `quantumFuelRequirement` — a field nothing else in the app touches and for which no unit is declared anywhere, so the number it printed could not be labelled.

`quantumFuelConsumption` is the figure `useHardpointStats` already derives its jump range from, documented in the parser as **milli-SCU per Gm** and checked against erkul.games and spviewer.eu. A Gm is a million kilometres — the same unit the distance is collected in — so a jump costs `rate × distance` milli-SCU. The column shows SCU now.

They are not two spellings of one number: their ratio ranges from 0.25 to 4.66 across the 58 drives, so this changes the values shown.

## `alignment` was inert app-wide

Right-aligning the numeric columns turned up a bug in the shared table. `alignment` is declared on eleven tables and did essentially nothing:

- `__inner` is a flex row, so moving its single child needs `justify-content`. Only `--selection` and `--actions` spelled it that way.
- `--center` set `text-align` alone, which does not move a flex item.
- `--right` **had no rule anywhere at all** — every right-aligned column in the app has been rendering left-aligned.
- The header never forwarded `alignment` to its cell.

Both fixed together, because either alone looks like a bug: a header that aligns over cells that do not, or the reverse.

**Now visibly different, all previously inert** — worth a look when reviewing:

| where | columns |
| --- | --- |
| admin commodities / components / equipment | `buyPrice`, `sellPrice` — right |
| logistics ledger | `quality`, `netQuantity`, `quantity` — right |
| fleet members / invites | `links` — right |
| admin images, fleets, manufacturers, models/modules, vehicles, maintenance | image and status columns — centre |

Columns that set no alignment keep `space-between` and are untouched.

## Changes

| | |
| --- | --- |
| `pages/tools/travel-times.vue` | select on `categoryIn`, sort through the shared helper, column labels, fuel from consumption, right-aligned numerics |
| `utils/travelTimes.ts` | `quantumDriveTravelTime` — one place that owns the unit conversion |
| `components/TravelTime/index.vue` | uses the helper; `distance` prop is now Mkm |
| `utils/travelTimes.spec.ts` | new, 4 tests pinning the units and the ordering |
| `base/Table/Col/index.scss` | adds the missing `--right`, fixes `--center` |
| `base/Table/Header/index.vue` | forwards `alignment` to the header cell |
| `scenarios/tools.rb` | fixture mirrors a loaded drive instead of the legacy shape |
| `e2e/TravelTimes.spec.ts` | 5 → 8 tests, asserts rendered times and order |
| `translations/*/labels.json` | `travelTimes` block in all seven locales |

## Verification

`pnpm lint` clean, 4/4 unit, 8/8 e2e.

Against the real 63 drives: all times finite and positive, 01:31 (FoxFire, S1) to 02:35 (Drifter, S3) at 20 Mkm, correctly ordered. Alignment checked in the browser — both `--center` and `--right` resolve on a live cell, unaligned columns unchanged.

```
Quantum Drive              Fuel Usage    Travel Time
FoxFire                       0.1 SCU          01:31
Atlas                        0.15 SCU          01:33
SunFire                      0.44 SCU          01:37
```

## What still needs work

The tool is correct now, not finished. A design pass is drafted but not built:

- the layout is a bare table with a lone number input — no framing, no sense of what the tool is for
- distance is a raw number field: no presets, no slider, no sense of scale, and "Mkm" is never explained
- no size or grade column, so 63 rows are hard to compare, and the columns are not sortable
- **5 of the 63 drives have no name in the database** and render as blank rows — belongs in its own change

Keeping `tools_travel_times` off until that lands.

🤖
