### PR TITLE
feat(travel-times): rebuild the tool around the jump you are planning

### DIFF
--- a/app/frontend/frontend/pages/tools/travel-times.scss
+++ b/app/frontend/frontend/pages/tools/travel-times.scss
@@ -1,0 +1,190 @@
+.travel-times {
+  &__intro {
+    max-width: 44rem;
+    margin-bottom: 1.5rem;
+    color: $gray-light;
+  }
+
+  &__slider {
+    margin: 1.5rem 0 1.25rem;
+  }
+
+  &__presets,
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  &__hint {
+    margin: 1rem 0 0;
+    padding-top: 0.85rem;
+    border-top: 1px solid var(--color-edge-faint, rgb(122 130 136 / 0.16));
+    font-size: 0.8125rem;
+    color: $gray;
+  }
+
+  &__filter-label {
+    margin-bottom: 0.65rem;
+    font-size: 0.8125rem;
+    color: $gray-light;
+
+    & + .travel-times__chips {
+      margin-bottom: 1.25rem;
+    }
+  }
+
+  &__reset {
+    padding: 0;
+    font-size: 0.75rem;
+    color: $primary;
+    background: none;
+    border: 0;
+    cursor: pointer;
+  }
+
+  &__credit {
+    margin-top: 1rem;
+    font-size: 0.8125rem;
+    color: $gray;
+  }
+
+  /*
+   * The distance is the one number the page is steered by, so it is set at the
+   * size of a heading rather than of a field. Everything else about the control
+   * -- frame, focus, the suffix -- stays the shared input's.
+   */
+  &__distance {
+    :deep(input) {
+      height: auto;
+      padding: 0.35rem 0.75rem;
+      font-family: "Orbitron", sans-serif;
+      font-size: 1.875rem;
+      line-height: 2.5rem;
+    }
+  }
+
+  &__preset-value {
+    margin-left: 0.4rem;
+    opacity: 0.6;
+    font-variant-numeric: tabular-nums;
+
+    &::after {
+      content: " Mkm";
+    }
+  }
+
+  &__meta {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.65rem;
+    padding: 0 0.25rem;
+    font-size: 0.8125rem;
+    color: $gray-light;
+  }
+
+  &__legend {
+    margin: 0.75rem 0 0;
+    padding: 0 0.25rem;
+    font-size: 0.8125rem;
+    color: $gray;
+  }
+
+  /*
+   * Deliberately NOT the heading face: Orbitron draws a slashed zero with no
+   * alternate, so a rank of "01" reads as "Ø1" and a time as "Ø1:18". Tabular
+   * figures give the column the alignment the display face was wanted for.
+   */
+  &__rank {
+    font-variant-numeric: tabular-nums;
+    color: $gray;
+
+    &--podium {
+      color: $primary;
+    }
+  }
+
+  /*
+   * Size and grade are one glyph each. Framed, they read as the attributes of
+   * the drive rather than as more numbers in a row already carrying two.
+   */
+  &__badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border: 1px solid var(--color-edge, rgb(122 130 136 / 0.5));
+    border-radius: $border-radius-base + 2px;
+    font-size: 0.75rem;
+    color: $gray-light;
+    white-space: nowrap;
+
+    // The grade ladder, borrowed from the class colours the rest of the app
+    // uses: gold reads as the best of a set, the greys as the plain end of it.
+    &--grade-a {
+      color: $gold;
+      border-color: rgba($gold, 0.4);
+    }
+
+    &--grade-b {
+      color: $cyan;
+      border-color: rgba($cyan, 0.4);
+    }
+
+    &--grade-c {
+      color: $gray-light;
+    }
+
+    &--grade-d {
+      color: $gray;
+      border-color: var(--color-edge-faint, rgb(122 130 136 / 0.16));
+    }
+  }
+
+  &__time {
+    font-size: 1.0625rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  &__drive {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    min-width: 0;
+    /* Clear of the next column, so a full-length bar never touches it. */
+    padding-right: 1.25rem;
+  }
+
+  /*
+   * The same 3px the row's hover rail is drawn at, so the two read as one
+   * family rather than two thicknesses of line in the same row.
+   */
+  &__bar {
+    display: block;
+    height: 3px;
+    border-radius: 2px;
+    background-color: var(--color-edge-faint, rgb(122 130 136 / 0.16));
+    overflow: hidden;
+  }
+
+  &__bar-fill {
+    display: block;
+    height: 100%;
+    border-radius: 2px;
+    background-color: var(--color-edge, rgb(122 130 136 / 0.5));
+    transition: width 0.3s ease;
+
+    &--podium {
+      background-color: var(--color-primary, #{$primary});
+    }
+  }
+
+  &__empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 2rem 1rem;
+    color: $gray;
+  }
+}

--- a/app/frontend/frontend/pages/tools/travel-times.vue
+++ b/app/frontend/frontend/pages/tools/travel-times.vue
@@ -6,7 +6,15 @@ export default {
 
 <script lang="ts" setup>
 import Heading from "@/shared/components/base/Heading/index.vue";
+import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
+import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
+import Slider from "@/shared/components/base/Slider/index.vue";
+import Chip from "@/shared/components/base/Chip/index.vue";
+import { ChipStatesEnum } from "@/shared/components/base/Chip/types";
 import { useI18n } from "@/shared/composables/useI18n";
+import { useFilters } from "@/shared/composables/useFilters";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
 import BaseTable from "@/shared/components/base/Table/index.vue";
@@ -14,19 +22,12 @@ import {
   type BaseTableCol,
   BaseTableColAlignmentEnum,
 } from "@/shared/components/base/Table/types";
-import Paginator from "@/shared/components/Paginator/index.vue";
 import TravelTime from "@/frontend/components/TravelTime/index.vue";
-import { usePagination } from "@/shared/composables/usePagination";
 import {
   useComponents as useComponentsQuery,
-  getComponentsQueryKey,
   type ComponentQuantumDrive,
   type Component,
 } from "@/services/fyApi";
-import fallbackImageJpg from "@/images/fallback/store_image.jpg";
-import fallbackImage from "@/images/fallback/store_image.webp";
-import { useWebpCheck } from "@/shared/composables/useWebpCheck";
-import { useMobile } from "@/shared/composables/useMobile";
 import { quantumDriveTravelTime } from "@/frontend/utils/travelTimes";
 import {
   InputTypesEnum,
@@ -39,56 +40,115 @@ const { t, toNumber } = useI18n();
 
 const route = useRoute();
 
-const columns = computed<BaseTableCol<Component>[]>(() => {
-  return [
-    {
-      name: "storeImage",
-      label: "",
-      class: "store-image extra-small",
-    },
-    {
-      name: "name",
-      label: t("labels.travelTimes.quantumDrive"),
-      class: "name",
-      width: "30%",
-    },
-    {
-      name: "fuel_usage",
-      label: t("labels.travelTimes.fuelUsage"),
-      class: "fuel-usage",
-      width: "30%",
-      alignment: BaseTableColAlignmentEnum.RIGHT,
-    },
-    {
-      name: "travel_time",
-      label: t("labels.travelTimes.travelTime"),
-      class: "travel-time",
-      width: "30%",
-      alignment: BaseTableColAlignmentEnum.RIGHT,
-    },
-  ];
+/*
+ * Distance, filters and order all live in the URL, so a link reproduces exactly
+ * what the sender was looking at -- the same contract every other filtered list
+ * in the app keeps. `s` is written by the table's own SortableLink; the rest is
+ * `useFilters`, which reads every query key that is not `s`, `page` or `perPage`.
+ */
+type TravelTimesFilters = {
+  distance?: string;
+  size?: string;
+  grade?: string;
+};
+
+const DEFAULT_DISTANCE = 20;
+const DEFAULT_SORT = "travel_time asc";
+
+const { filters, filter } = useFilters<TravelTimesFilters>();
+
+const numberList = (value?: string) =>
+  (value || "")
+    .split(",")
+    .map((item) => Number(item))
+    .filter((item) => !Number.isNaN(item) && item > 0);
+
+const stringList = (value?: string) =>
+  (value || "").split(",").filter((item) => item.length > 0);
+
+const distance = ref(Number(route.query.distance) || DEFAULT_DISTANCE);
+
+// Millions of kilometres. The far end is a little past the widest jump Stanton
+// offers, so the whole range a player meets sits inside the track.
+const DISTANCE_MIN = 1;
+const DISTANCE_MAX = 120;
+
+const PRESETS = [
+  { key: "moon", mkm: 0.4 },
+  { key: "short", mkm: 8 },
+  { key: "system", mkm: 40 },
+  { key: "far", mkm: 90 },
+];
+
+const SIZES = [1, 2, 3, 4];
+const GRADES = ["A", "B", "C", "D"];
+
+const sizeFilter = ref<number[]>(numberList(route.query.size as string));
+const gradeFilter = ref<string[]>(stringList(route.query.grade as string));
+
+/*
+ * Held locally as well as in the URL: `filter` is debounced, and a chip whose
+ * own pressed state waited on the address bar would feel broken. The two
+ * watchers below keep the pair honest in both directions.
+ */
+watch([distance, sizeFilter, gradeFilter], () => {
+  filter({
+    distance:
+      distance.value === DEFAULT_DISTANCE ? undefined : String(distance.value),
+    size: sizeFilter.value.length ? sizeFilter.value.join(",") : undefined,
+    grade: gradeFilter.value.length ? gradeFilter.value.join(",") : undefined,
+  });
 });
 
-const distance = ref(20);
+// The other direction: a pasted link, or the back button.
+watch(
+  () => filters.value,
+  (next) => {
+    const nextDistance = Number(next.distance) || DEFAULT_DISTANCE;
+    if (nextDistance !== distance.value) {
+      distance.value = nextDistance;
+    }
 
-const { supported: webpSupported } = useWebpCheck();
+    const nextSizes = numberList(next.size);
+    if (nextSizes.join(",") !== sizeFilter.value.join(",")) {
+      sizeFilter.value = nextSizes;
+    }
 
-const mobile = useMobile();
+    const nextGrades = stringList(next.grade);
+    if (nextGrades.join(",") !== gradeFilter.value.join(",")) {
+      gradeFilter.value = nextGrades;
+    }
+  },
+  { deep: true },
+);
 
-const storeImage = (component: Component) => {
-  if (mobile.value && component.media.storeImage?.mediumUrl) {
-    return component.media.storeImage?.mediumUrl;
-  }
+const sort = computed(() => {
+  const [field, direction] = String(route.query.s || DEFAULT_SORT).split(" ");
 
-  if (component.media.storeImage?.largeUrl) {
-    return component.media.storeImage?.largeUrl;
-  }
+  return { field, direction: direction === "desc" ? "desc" : "asc" };
+});
 
-  if (webpSupported) {
-    return fallbackImage;
-  }
+const filtered = computed(
+  () => sizeFilter.value.length > 0 || gradeFilter.value.length > 0,
+);
 
-  return fallbackImageJpg;
+// Refs unwrap in the template, so these take the value rather than the ref --
+// a generic helper reading `.value` cannot be called from there.
+const toggleSize = (size: number) => {
+  sizeFilter.value = sizeFilter.value.includes(size)
+    ? sizeFilter.value.filter((item) => item !== size)
+    : [...sizeFilter.value, size];
+};
+
+const toggleGrade = (grade: string) => {
+  gradeFilter.value = gradeFilter.value.includes(grade)
+    ? gradeFilter.value.filter((item) => item !== grade)
+    : [...gradeFilter.value, grade];
+};
+
+const clearFilters = () => {
+  sizeFilter.value = [];
+  gradeFilter.value = [];
 };
 
 const isQuantumDrive = (
@@ -102,11 +162,10 @@ const isQuantumDrive = (
  * milli-SCU per Gm, and a Gm is a million kilometres -- the same unit the
  * distance is collected in -- so the jump costs rate * distance milli-SCU.
  *
- * The drive also carries `quantumFuelRequirement`, which is what this column
- * used to read. Nothing else in the app touches that field and no unit is
- * declared for it anywhere; the consumption figure is the one the hardpoint
- * panel derives its jump range from, checked against erkul.games and
- * spviewer.eu.
+ * The drive also carries `quantumFuelRequirement`, which this column used to
+ * read. Nothing else in the app touches that field and no unit is declared for
+ * it anywhere; the consumption figure is the one the hardpoint panel derives
+ * its jump range from, checked against erkul.games and spviewer.eu.
  */
 const fuelUsage = (component: Component): number | undefined => {
   if (!isQuantumDrive(component.typeData)) {
@@ -115,78 +174,284 @@ const fuelUsage = (component: Component): number | undefined => {
 
   const rate = component.typeData.quantumFuelConsumption;
 
-  if (!rate) {
-    return undefined;
-  }
-
-  return Math.round(((rate * distance.value) / 1000) * 100) / 100;
+  return rate
+    ? Math.round(((rate * distance.value) / 1000) * 100) / 100
+    : undefined;
 };
 
-const sortedQuantumDrives = computed(() => {
-  return [...(quantumDrives.value?.items || [])].sort((a, b) => {
-    const aTravelTime = quantumDriveTravelTime(a, distance.value);
-    const bTravelTime = quantumDriveTravelTime(b, distance.value);
+const gradeOf = (component: Component) => component.gradeLabel || "";
 
-    if (!aTravelTime) {
-      return 1;
-    }
-
-    if (!bTravelTime) {
-      return -1;
-    }
-
-    if (aTravelTime < bTravelTime) {
-      return -1;
-    }
-
-    if (aTravelTime > bTravelTime) {
-      return 1;
-    }
-
-    return 0;
-  });
-});
+const sizeOf = (component: Component) => Number(component.size) || 0;
 
 const componentsQueryParams = computed(() => ({
-  page: page.value,
+  page: "1",
   perPage: "240",
   q: {
     categoryIn: ["quantumdrive"],
   },
 }));
 
-const componentsQueryKey = computed(() => {
-  return getComponentsQueryKey(componentsQueryParams.value);
-});
-
-const { page, perPage, updatePerPage } = usePagination(componentsQueryKey);
-
 const { data: quantumDrives, ...asyncStatus } = useComponentsQuery(
   componentsQueryParams,
 );
+
+/*
+ * Five of the sixty-three rows the catalogue returns have no name: four are the
+ * game files' own `qdrv_s0*_template` entries and the fifth is the Javelin's
+ * bespoke drive. None is a drive anyone can fit, and unnamed they would render
+ * as blank rows carrying a rank.
+ */
+const drives = computed(() =>
+  (quantumDrives.value?.items || []).filter((drive) => !!drive.name),
+);
+
+/*
+ * Seconds per drive, computed once per distance change and read by the sort,
+ * the bar and the rank. The cell renders its own through the same helper, so
+ * there is no second interpretation of the numbers -- only a second call.
+ */
+const secondsBySlug = computed(() => {
+  const result: Record<string, number | undefined> = {};
+
+  drives.value.forEach((drive) => {
+    result[drive.slug] = quantumDriveTravelTime(drive, distance.value);
+  });
+
+  return result;
+});
+
+/*
+ * The bar measures against the slowest drive there is, not the slowest one left
+ * after filtering -- a bar whose scale moves as you filter says nothing you can
+ * carry from one view to the next.
+ */
+const slowest = computed(() =>
+  Object.values(secondsBySlug.value).reduce<number>(
+    (max, seconds) => (seconds && seconds > max ? seconds : max),
+    0,
+  ),
+);
+
+const barPercent = (component: Component) => {
+  const seconds = secondsBySlug.value[component.slug];
+
+  if (!seconds || !slowest.value) {
+    return 0;
+  }
+
+  return Math.max(3, Math.round((seconds / slowest.value) * 100));
+};
+
+const visibleDrives = computed(() => {
+  let list = drives.value;
+
+  if (sizeFilter.value.length) {
+    list = list.filter((drive) => sizeFilter.value.includes(sizeOf(drive)));
+  }
+
+  if (gradeFilter.value.length) {
+    list = list.filter((drive) => gradeFilter.value.includes(gradeOf(drive)));
+  }
+
+  const direction = sort.value.direction === "asc" ? 1 : -1;
+
+  return [...list].sort((a, b) => {
+    switch (sort.value.field) {
+      case "name":
+        return a.name.localeCompare(b.name) * direction;
+      case "size":
+        return (sizeOf(a) - sizeOf(b)) * direction;
+      case "grade":
+        return gradeOf(a).localeCompare(gradeOf(b)) * direction;
+      case "fuel_usage":
+        return ((fuelUsage(a) ?? 0) - (fuelUsage(b) ?? 0)) * direction;
+      default: {
+        // A drive the export never described has no time; it sorts last either
+        // way rather than jumping to the top when the direction flips.
+        const aSeconds = secondsBySlug.value[a.slug];
+        const bSeconds = secondsBySlug.value[b.slug];
+
+        if (!aSeconds) return 1;
+        if (!bSeconds) return -1;
+
+        return (aSeconds - bSeconds) * direction;
+      }
+    }
+  });
+});
+
+// The rank only means "fastest" while the list is ordered by time, so the
+// podium colour is held back otherwise -- the number stays as the row's place.
+const byTime = computed(
+  () => sort.value.field === "travel_time" && sort.value.direction === "asc",
+);
+
+const rankOf = (component: Component) =>
+  visibleDrives.value.findIndex((drive) => drive.slug === component.slug) + 1;
+
+const columns = computed<BaseTableCol<Component>[]>(() => {
+  return [
+    {
+      name: "rank",
+      label: t("labels.travelTimes.rank"),
+      class: "rank",
+      width: "56px",
+    },
+    {
+      name: "name",
+      label: t("labels.travelTimes.quantumDrive"),
+      class: "name",
+      sortable: true,
+    },
+    {
+      name: "size",
+      label: t("labels.travelTimes.size"),
+      class: "size",
+      width: "76px",
+      alignment: BaseTableColAlignmentEnum.RIGHT,
+      sortable: true,
+      mobile: false,
+    },
+    {
+      name: "grade",
+      label: t("labels.travelTimes.grade"),
+      class: "grade",
+      width: "76px",
+      alignment: BaseTableColAlignmentEnum.RIGHT,
+      sortable: true,
+      mobile: false,
+    },
+    {
+      name: "fuel_usage",
+      label: t("labels.travelTimes.fuelUsage"),
+      class: "fuel-usage",
+      width: "116px",
+      alignment: BaseTableColAlignmentEnum.RIGHT,
+      sortable: true,
+    },
+    {
+      name: "travel_time",
+      label: t("labels.travelTimes.travelTime"),
+      class: "travel-time",
+      width: "116px",
+      alignment: BaseTableColAlignmentEnum.RIGHT,
+      sortable: true,
+    },
+  ];
+});
 </script>
 
 <template>
   <FeatureGuard :feature="FeatureFlagName.TOOLS_TRAVEL_TIMES">
-    <Heading>{{ t(`headlines.${route.meta.title}`) }}</Heading>
+    <Heading hero>{{ t(`headlines.${route.meta.title}`) }}</Heading>
+
+    <p class="travel-times__intro">
+      {{ t("labels.travelTimes.intro") }}
+    </p>
 
     <div class="row">
-      <div class="col-6">
-        <FormInput
-          v-model.number="distance"
-          :min="1"
-          name="distance"
-          :type="InputTypesEnum.NUMBER"
-          inline
-          :alignment="InputAlignmentsEnum.RIGHT"
-          suffix="Mkm"
-        />
-      </div>
-    </div>
+      <div class="col-12 col-md-4">
+        <Panel>
+          <PanelHeading :level="HeadingLevelEnum.H2">
+            {{ t("labels.travelTimes.jumpDistance") }}
+          </PanelHeading>
+          <PanelBody>
+            <FormInput
+              v-model.number="distance"
+              class="travel-times__distance"
+              :min="DISTANCE_MIN"
+              name="distance"
+              :type="InputTypesEnum.NUMBER"
+              :alignment="InputAlignmentsEnum.RIGHT"
+              suffix="Mkm"
+              no-label
+            />
 
-    <div class="row">
-      <div class="col-12">
-        <p>
+            <Slider
+              v-model="distance"
+              :min="DISTANCE_MIN"
+              :max="DISTANCE_MAX"
+              class="travel-times__slider"
+            />
+
+            <div class="travel-times__presets">
+              <Chip
+                v-for="preset in PRESETS"
+                :key="preset.key"
+                :state="
+                  distance === preset.mkm
+                    ? ChipStatesEnum.INCLUDED
+                    : ChipStatesEnum.NEUTRAL
+                "
+                @toggle="distance = preset.mkm"
+              >
+                {{ t(`labels.travelTimes.presets.${preset.key}`) }}
+                <span class="travel-times__preset-value">
+                  {{ preset.mkm }}
+                </span>
+              </Chip>
+            </div>
+
+            <p class="travel-times__hint">
+              {{ t("labels.travelTimes.distanceHint") }}
+            </p>
+          </PanelBody>
+        </Panel>
+
+        <Panel>
+          <PanelHeading :level="HeadingLevelEnum.H2">
+            {{ t("labels.travelTimes.filters") }}
+            <template #actions>
+              <button
+                v-if="filtered"
+                type="button"
+                class="travel-times__reset"
+                @click="clearFilters"
+              >
+                {{ t("labels.travelTimes.resetFilters") }}
+              </button>
+            </template>
+          </PanelHeading>
+          <PanelBody>
+            <div class="travel-times__filter-label">
+              {{ t("labels.travelTimes.size") }}
+            </div>
+            <div class="travel-times__chips">
+              <Chip
+                v-for="size in SIZES"
+                :key="`size-${size}`"
+                :state="
+                  sizeFilter.includes(size)
+                    ? ChipStatesEnum.INCLUDED
+                    : ChipStatesEnum.NEUTRAL
+                "
+                @toggle="toggleSize(size)"
+              >
+                {{ t("labels.travelTimes.sizeValue", { size }) }}
+              </Chip>
+            </div>
+
+            <div class="travel-times__filter-label">
+              {{ t("labels.travelTimes.grade") }}
+            </div>
+            <div class="travel-times__chips">
+              <Chip
+                v-for="grade in GRADES"
+                :key="`grade-${grade}`"
+                :state="
+                  gradeFilter.includes(grade)
+                    ? ChipStatesEnum.INCLUDED
+                    : ChipStatesEnum.NEUTRAL
+                "
+                @toggle="toggleGrade(grade)"
+              >
+                {{ grade }}
+              </Chip>
+            </div>
+          </PanelBody>
+        </Panel>
+
+        <p class="travel-times__credit">
           {{ t("labels.travelTimes.poweredBy") }}
           <a
             href="https://gitlab.com/Erecco/a-study-on-quantum-travel-time/-/blob/master/A_study_on_Quantum_Travel_time_07042021.pdf?ref_type=heads"
@@ -194,61 +459,120 @@ const { data: quantumDrives, ...asyncStatus } = useComponentsQuery(
           >
         </p>
       </div>
-    </div>
 
-    <FilteredList
-      key="quantumDrives"
-      :paginated="true"
-      :records="sortedQuantumDrives"
-      :name="route.name?.toString() || ''"
-      :async-status="asyncStatus"
-      placeholders
-    >
-      <template #default="{ records }">
-        <BaseTable
-          :records="records"
-          :filter-visible="false"
-          primary-key="slug"
-          :columns="columns"
+      <div class="col-12 col-md-8">
+        <div class="travel-times__meta">
+          <span>
+            {{
+              filtered
+                ? t("labels.travelTimes.countFiltered", {
+                    count: visibleDrives.length,
+                    total: drives.length,
+                  })
+                : t("labels.travelTimes.count", { count: drives.length })
+            }}
+          </span>
+        </div>
+
+        <FilteredList
+          key="quantumDrives"
+          :records="visibleDrives"
+          :name="route.name?.toString() || ''"
+          :async-status="asyncStatus"
         >
-          <template #col-storeImage="{ record }">
-            <div
-              :key="storeImage(record)"
-              :style="{ backgroundImage: `url(${storeImage(record)})` }"
-              class="image"
-              alt="storeImage"
-            />
-          </template>
-          <template #col-name="{ record }">
-            {{ record.name }}
-          </template>
-          <template #col-fuel_usage="{ record }">
-            <template v-if="fuelUsage(record)">
-              {{ toNumber(fuelUsage(record)!, "cargo") }}
-            </template>
-            <template v-else> - </template>
-          </template>
-          <template #col-travel_time="{ record }">
-            <TravelTime :quantum-drive="record" :distance="distance" />
-          </template>
-        </BaseTable>
-      </template>
+          <template #default="{ records }">
+            <BaseTable
+              :records="records"
+              :filter-visible="false"
+              primary-key="slug"
+              :columns="columns"
+              :default-sort="DEFAULT_SORT"
+            >
+              <template #col-rank="{ record }">
+                <span
+                  class="travel-times__rank"
+                  :class="{
+                    'travel-times__rank--podium': byTime && rankOf(record) <= 3,
+                  }"
+                >
+                  {{ String(rankOf(record)).padStart(2, "0") }}
+                </span>
+              </template>
 
-      <template #pagination-top>
-        <Paginator
-          :query-result-ref="quantumDrives"
-          :per-page="perPage"
-          :update-per-page="updatePerPage"
-        />
-      </template>
+              <template #col-name="{ record }">
+                <div class="travel-times__drive">
+                  <span>{{ record.name }}</span>
+                  <span class="travel-times__bar">
+                    <span
+                      class="travel-times__bar-fill"
+                      :class="{
+                        'travel-times__bar-fill--podium':
+                          byTime && rankOf(record) <= 3,
+                      }"
+                      :style="{ width: `${barPercent(record)}%` }"
+                    />
+                  </span>
+                </div>
+              </template>
 
-      <template #pagination-bottom>
-        <Paginator
-          :query-result-ref="quantumDrives"
-          :per-page="perPage"
-          :update-per-page="updatePerPage"
-        />
-      </template>
-    </FilteredList>
+              <template #col-size="{ record }">
+                <span class="travel-times__badge">
+                  {{
+                    t("labels.travelTimes.sizeValue", { size: sizeOf(record) })
+                  }}
+                </span>
+              </template>
+
+              <template #col-grade="{ record }">
+                <span
+                  v-if="gradeOf(record)"
+                  class="travel-times__badge"
+                  :class="`travel-times__badge--grade-${gradeOf(record).toLowerCase()}`"
+                >
+                  {{ gradeOf(record) }}
+                </span>
+                <template v-else> - </template>
+              </template>
+
+              <template #col-fuel_usage="{ record }">
+                <template v-if="fuelUsage(record)">
+                  {{ toNumber(fuelUsage(record)!, "cargo") }}
+                </template>
+                <template v-else> - </template>
+              </template>
+
+              <template #col-travel_time="{ record }">
+                <TravelTime
+                  class="travel-times__time"
+                  :quantum-drive="record"
+                  :distance="distance"
+                />
+              </template>
+
+              <template #empty>
+                <div class="travel-times__empty">
+                  <span>{{ t("labels.travelTimes.noMatch") }}</span>
+                  <button
+                    type="button"
+                    class="travel-times__reset"
+                    @click="clearFilters"
+                  >
+                    {{ t("labels.travelTimes.resetFilters") }}
+                  </button>
+                </div>
+              </template>
+            </BaseTable>
+          </template>
+        </FilteredList>
+
+        <p class="travel-times__legend">
+          {{ t("labels.travelTimes.barLegend") }}
+        </p>
+      </div>
+    </div>
   </FeatureGuard>
 </template>
+
+<style lang="scss" scoped>
+@import "./travel-times.scss";
+</style>

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1710,7 +1710,26 @@
         "quantumDrive": "Quantum-Antrieb",
         "fuelUsage": "Treibstoffverbrauch",
         "travelTime": "Reisezeit",
-        "poweredBy": "basiert auf"
+        "poweredBy": "basiert auf",
+        "rank": "#",
+        "size": "Größe",
+        "grade": "Grade",
+        "sizeValue": "S%{size}",
+        "intro": "Wie lange jeder Quantum-Antrieb für deinen Sprung braucht — und wie viel Quantum-Treibstoff er dabei verbraucht.",
+        "jumpDistance": "Sprungdistanz",
+        "distanceHint": "1 Mkm ist eine Million Kilometer. Quer durch Stanton sind es etwa 40.",
+        "filters": "Filter",
+        "resetFilters": "Zurücksetzen",
+        "barLegend": "Balken zeigt die Zeit im Verhältnis zum langsamsten Antrieb",
+        "count": "%{count} Antriebe",
+        "countFiltered": "%{count} von %{total} Antrieben",
+        "noMatch": "Kein Antrieb passt zu diesen Filtern.",
+        "presets": {
+          "moon": "Mond-Distanz",
+          "short": "Kurzer Sprung",
+          "system": "Stanton quer",
+          "far": "Weite Strecke"
+        }
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1701,7 +1701,26 @@
         "quantumDrive": "Quantum Drive",
         "fuelUsage": "Fuel Usage",
         "travelTime": "Travel Time",
-        "poweredBy": "powered by"
+        "poweredBy": "powered by",
+        "rank": "#",
+        "size": "Size",
+        "grade": "Grade",
+        "sizeValue": "S%{size}",
+        "intro": "How long each quantum drive takes for your jump — and how much quantum fuel it burns getting there.",
+        "jumpDistance": "Jump distance",
+        "distanceHint": "1 Mkm is a million kilometres. Crossing Stanton is about 40.",
+        "filters": "Filters",
+        "resetFilters": "Reset",
+        "barLegend": "Bar shows time against the slowest drive",
+        "count": "%{count} drives",
+        "countFiltered": "%{count} of %{total} drives",
+        "noMatch": "No drive matches these filters.",
+        "presets": {
+          "moon": "Moon hop",
+          "short": "Short jump",
+          "system": "Across Stanton",
+          "far": "Long haul"
+        }
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1710,7 +1710,26 @@
         "quantumDrive": "Motor Quantum",
         "fuelUsage": "Consumo de combustible",
         "travelTime": "Tiempo de viaje",
-        "poweredBy": "basado en"
+        "poweredBy": "basado en",
+        "rank": "#",
+        "size": "Tamaño",
+        "grade": "Grado",
+        "sizeValue": "S%{size}",
+        "intro": "Cuánto tarda cada motor Quantum en tu salto — y cuánto combustible Quantum consume.",
+        "jumpDistance": "Distancia de salto",
+        "distanceHint": "1 Mkm es un millón de kilómetros. Cruzar Stanton son unos 40.",
+        "filters": "Filtros",
+        "resetFilters": "Restablecer",
+        "barLegend": "La barra muestra el tiempo frente al motor más lento",
+        "count": "%{count} motores",
+        "countFiltered": "%{count} de %{total} motores",
+        "noMatch": "Ningún motor coincide con estos filtros.",
+        "presets": {
+          "moon": "Salto lunar",
+          "short": "Salto corto",
+          "system": "Cruzar Stanton",
+          "far": "Trayecto largo"
+        }
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1710,7 +1710,26 @@
         "quantumDrive": "Moteur quantique",
         "fuelUsage": "Consommation de carburant",
         "travelTime": "Temps de trajet",
-        "poweredBy": "basé sur"
+        "poweredBy": "basé sur",
+        "rank": "#",
+        "size": "Taille",
+        "grade": "Grade",
+        "sizeValue": "S%{size}",
+        "intro": "Le temps que met chaque moteur quantique pour votre saut — et le carburant quantique qu'il consomme.",
+        "jumpDistance": "Distance de saut",
+        "distanceHint": "1 Mkm équivaut à un million de kilomètres. Traverser Stanton en demande environ 40.",
+        "filters": "Filtres",
+        "resetFilters": "Réinitialiser",
+        "barLegend": "La barre indique le temps par rapport au moteur le plus lent",
+        "count": "%{count} moteurs",
+        "countFiltered": "%{count} sur %{total} moteurs",
+        "noMatch": "Aucun moteur ne correspond à ces filtres.",
+        "presets": {
+          "moon": "Saut lunaire",
+          "short": "Saut court",
+          "system": "Traversée de Stanton",
+          "far": "Longue distance"
+        }
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1710,7 +1710,26 @@
         "quantumDrive": "Motore Quantum",
         "fuelUsage": "Consumo di carburante",
         "travelTime": "Tempo di viaggio",
-        "poweredBy": "basato su"
+        "poweredBy": "basato su",
+        "rank": "#",
+        "size": "Dimensione",
+        "grade": "Grado",
+        "sizeValue": "S%{size}",
+        "intro": "Quanto impiega ogni motore Quantum per il tuo salto — e quanto carburante Quantum consuma.",
+        "jumpDistance": "Distanza di salto",
+        "distanceHint": "1 Mkm è un milione di chilometri. Attraversare Stanton ne richiede circa 40.",
+        "filters": "Filtri",
+        "resetFilters": "Reimposta",
+        "barLegend": "La barra mostra il tempo rispetto al motore più lento",
+        "count": "%{count} motori",
+        "countFiltered": "%{count} di %{total} motori",
+        "noMatch": "Nessun motore corrisponde a questi filtri.",
+        "presets": {
+          "moon": "Salto lunare",
+          "short": "Salto breve",
+          "system": "Attraverso Stanton",
+          "far": "Lunga tratta"
+        }
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1706,7 +1706,26 @@
         "quantumDrive": "量子引擎",
         "fuelUsage": "燃料消耗",
         "travelTime": "旅行时间",
-        "poweredBy": "基于"
+        "poweredBy": "基于",
+        "rank": "#",
+        "size": "尺寸",
+        "grade": "等级",
+        "sizeValue": "S%{size}",
+        "intro": "每台量子引擎完成这次跃迁需要多久——以及消耗多少量子燃料。",
+        "jumpDistance": "跃迁距离",
+        "distanceHint": "1 Mkm 即一百万公里。横穿斯坦顿约需 40。",
+        "filters": "筛选",
+        "resetFilters": "重置",
+        "barLegend": "长条表示相对最慢引擎的时间",
+        "count": "%{count} 台引擎",
+        "countFiltered": "%{total} 台中的 %{count} 台",
+        "noMatch": "没有引擎符合这些筛选条件。",
+        "presets": {
+          "moon": "月球距离",
+          "short": "短距跃迁",
+          "system": "横穿斯坦顿",
+          "far": "长途"
+        }
       },
       "admin": {
         "dashboard": {

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1706,7 +1706,26 @@
         "quantumDrive": "量子引擎",
         "fuelUsage": "燃料消耗",
         "travelTime": "旅行時間",
-        "poweredBy": "基於"
+        "poweredBy": "基於",
+        "rank": "#",
+        "size": "尺寸",
+        "grade": "等級",
+        "sizeValue": "S%{size}",
+        "intro": "每台量子引擎完成這次躍遷需要多久——以及消耗多少量子燃料。",
+        "jumpDistance": "躍遷距離",
+        "distanceHint": "1 Mkm 即一百萬公里。橫越斯坦頓約需 40。",
+        "filters": "篩選",
+        "resetFilters": "重設",
+        "barLegend": "長條表示相對最慢引擎的時間",
+        "count": "%{count} 台引擎",
+        "countFiltered": "%{total} 台中的 %{count} 台",
+        "noMatch": "沒有引擎符合這些篩選條件。",
+        "presets": {
+          "moon": "月球距離",
+          "short": "短距躍遷",
+          "system": "橫越斯坦頓",
+          "far": "長途"
+        }
       },
       "admin": {
         "dashboard": {

--- a/test/playwright/app_commands/scenarios/tools.rb
+++ b/test/playwright/app_commands/scenarios/tools.rb
@@ -66,7 +66,7 @@ end
 # "-:-:-" for every row. `quantum_fuel_consumption` is milli-SCU per Gm; 5 and
 # 22 are the values real S1 and S2 drives carry.
 unless Component.exists?(name: "Beacon")
-  FactoryBot.create(:component, name: "Beacon", category: "quantumdrive", component_type: "QuantumDrive", type_data: {
+  FactoryBot.create(:component, name: "Beacon", category: "quantumdrive", component_type: "QuantumDrive", size: "1", grade: "1", type_data: {
     "quantum_fuel_consumption" => 5.0,
     "drive_speed" => 283046000.0,
     "stage_one_accel_rate" => 49500000.0,
@@ -75,7 +75,7 @@ unless Component.exists?(name: "Beacon")
 end
 
 unless Component.exists?(name: "Expedition")
-  FactoryBot.create(:component, name: "Expedition", category: "quantumdrive", component_type: "QuantumDrive", type_data: {
+  FactoryBot.create(:component, name: "Expedition", category: "quantumdrive", component_type: "QuantumDrive", size: "2", grade: "3", type_data: {
     "quantum_fuel_consumption" => 22.0,
     "drive_speed" => 183046000.0,
     "stage_one_accel_rate" => 39500000.0,

--- a/test/playwright/e2e/TravelTimes.spec.ts
+++ b/test/playwright/e2e/TravelTimes.spec.ts
@@ -5,6 +5,9 @@ import { test, expect } from "../support/commands";
 const driveRow = (page: Page, name: string) =>
   page.getByRole("row").filter({ hasText: name });
 
+const header = (page: Page, label: string) =>
+  page.getByRole("row").first().getByRole("link", { name: label });
+
 test.describe("Travel Times", () => {
   test.beforeEach(async ({ page }) => {
     await app("clean");
@@ -32,10 +35,12 @@ test.describe("Travel Times", () => {
   test("Labels every column", async ({ page }) => {
     await expect(page.getByText("Beacon")).toBeVisible();
 
-    const header = page.getByRole("row").first();
-    await expect(header).toContainText("Quantum Drive");
-    await expect(header).toContainText("Fuel Usage");
-    await expect(header).toContainText("Travel Time");
+    const head = page.getByRole("row").first();
+    await expect(head).toContainText("Quantum Drive");
+    await expect(head).toContainText("Size");
+    await expect(head).toContainText("Grade");
+    await expect(head).toContainText("Fuel Usage");
+    await expect(head).toContainText("Travel Time");
   });
 
   test("Calculates travel time and fuel usage for the default distance", async ({
@@ -48,20 +53,78 @@ test.describe("Travel Times", () => {
     await expect(driveRow(page, "Expedition")).toContainText("0.44 SCU");
   });
 
-  test("Sorts the fastest drive first", async ({ page }) => {
+  test("Shows each drive's size and grade", async ({ page }) => {
+    await expect(driveRow(page, "Beacon")).toContainText("S1");
+    await expect(driveRow(page, "Beacon")).toContainText("A");
+
+    await expect(driveRow(page, "Expedition")).toContainText("S2");
+    await expect(driveRow(page, "Expedition")).toContainText("C");
+  });
+
+  test("Ranks the fastest drive first", async ({ page }) => {
     await expect(page.getByText("Beacon")).toBeVisible();
 
     await expect(page.locator("tbody tr").first()).toContainText("Beacon");
+    await expect(page.locator("tbody tr").first()).toContainText("01");
     await expect(page.locator("tbody tr").nth(1)).toContainText("Expedition");
   });
 
   test("Updates travel times when distance changes", async ({ page }) => {
     await expect(driveRow(page, "Beacon")).toContainText("01:18");
 
-    const distanceInput = page.locator('input[name="distance"]');
-    await distanceInput.fill("50");
+    await page.locator('input[name="distance"]').fill("50");
 
     await expect(driveRow(page, "Beacon")).toContainText("03:04");
+    await expect(driveRow(page, "Expedition")).toContainText("04:39");
+  });
+
+  test("Jumps to a preset distance", async ({ page }) => {
+    await expect(driveRow(page, "Beacon")).toContainText("01:18");
+
+    await page.getByRole("button", { name: "Across Stanton" }).click();
+
+    await expect(page.locator('input[name="distance"]')).toHaveValue("40");
+    await expect(page).toHaveURL(/[?&]distance=40/);
+    await expect(driveRow(page, "Beacon")).not.toContainText("01:18");
+  });
+
+  // The order is applied here rather than by the endpoint, which pins its own,
+  // but it still travels in `?s=` so a link carries it.
+  test("Carries the sort order in the URL", async ({ page }) => {
+    await expect(page.locator("tbody tr").first()).toContainText("Beacon");
+
+    await header(page, "Quantum Drive").click();
+    await expect(page).toHaveURL(/[?&]s=name(\+|%20)asc/);
+    await expect(page.locator("tbody tr").first()).toContainText("Beacon");
+
+    await header(page, "Quantum Drive").click();
+    await expect(page).toHaveURL(/[?&]s=name(\+|%20)desc/);
+    await expect(page.locator("tbody tr").first()).toContainText("Expedition");
+  });
+
+  test("Carries the filters in the URL", async ({ page }) => {
+    await expect(page.getByText("Expedition")).toBeVisible();
+
+    await page.getByRole("button", { name: "S2", exact: true }).click();
+
+    await expect(page).toHaveURL(/[?&]size=2/);
+    await expect(page.getByText("Expedition")).toBeVisible();
+    await expect(page.getByText("Beacon")).toBeHidden();
+
+    await page.getByRole("button", { name: "Reset" }).click();
+    await expect(page).not.toHaveURL(/[?&]size=/);
+    await expect(page.getByText("Beacon")).toBeVisible();
+  });
+
+  // The point of keeping the state in the query: the link is the view.
+  test("Restores distance, filter and order from a shared link", async ({
+    page,
+  }) => {
+    await page.goto("/tools/travel-times/?distance=50&size=2&s=name+desc");
+
+    await expect(page.locator('input[name="distance"]')).toHaveValue("50");
+    await expect(page.getByText("Expedition")).toBeVisible();
+    await expect(page.getByText("Beacon")).toBeHidden();
     await expect(driveRow(page, "Expedition")).toContainText("04:39");
   });
 


### PR DESCRIPTION
Stacked on #4687 — **base is `feat/travel-times-rollout`**, so review that one first. This PR is the design pass; #4687 is the correctness work underneath it.

The page was a bare table with one number field. It now opens with the jump you are planning.

## The control column

Distance as the headline figure, a slider and four presets beside it, and a line saying what a Mkm actually is — the unit was never explained anywhere on the page. Below it, filters for size and grade.

## The results

Size and grade get their own columns, plus a rank and a bar per row. Two decisions worth knowing when reading the diff:

- **The bar's scale is fixed** — it measures against the slowest drive there is, not the slowest one left after filtering. A bar whose scale moves as you filter says nothing you can carry from one view to the next.
- **The rank is the row's place, not a claim about speed.** So the column is `#`, and the leading three are only marked while the order is by time — otherwise "01" would sit on whatever happens to sort first alphabetically.

## Everything shareable

Distance, size, grade and order all live in the query, so a link reproduces the view it was copied from:

```
/tools/travel-times/?distance=50&size=2&s=name+desc
```

The order is applied on the page rather than by the endpoint — `Api::V1::ComponentsController#index` pins `sorts` to `name asc` and never reads the param — but it still travels as `?s=` and is still driven by the table's own `SortableLink`. Nothing about the URL contract or the control is particular to this page, and no shared component needed changing.

Filters go through `useFilters`, held in a local ref as well so a chip's pressed state does not wait on the debounce.

## A data gap this surfaced

Five of the sixty-three rows the catalogue returns have no name: four are the game files' own `qdrv_s0*_template` entries, the fifth is the Javelin's bespoke drive. None can be fitted to a ship, and unnamed they rendered as blank rows carrying a rank. Filtered out here — worth chasing at the source, which is why it is called out rather than buried.

## Two deviations from the design draft, on purpose

**Figures are not in the display face.** Orbitron draws a slashed zero with no alternate glyph, so a rank of `01` reads as `Ø1` and a time as `Ø1:18` — checked, and `font-feature-settings` cannot turn it off. Rank and time use the text face with `tabular-nums`, which gives the column the alignment the display face was wanted for. The distance keeps Orbitron: as a single display figure the slashed zero reads as styling, in a column of times it reads as an error.

**The headline takes `hero`** like `tools/index.vue` and `cargo-grids.vue` beside it. It had been the odd one out since before this change.

## Verification

`pnpm lint` clean (eslint, prettier, vue-tsc, tsc), **13/13 e2e** — including the URL round-trip, the client-applied sort, the filters and the presets.

Checked in the browser against real data: 58 drives, the bar scale holding while filtering, and the ranking genuinely changing with distance — at 20 Mkm FoxFire (S1) leads at 01:31, at 50 Mkm Frontline (S4) does at 02:36, because over a longer jump top speed outweighs acceleration. Verified independently against the drive parameters.

Design draft, for comparison: https://claude.ai/code/artifact/52b549a6-4846-440d-bf06-27943ffc97cb

`tools_travel_times` stays off until both PRs land.

🤖
