### PR TITLE
fix(lists): make a loading list look like the list it becomes

### DIFF
--- a/app/frontend/frontend/pages/visual-tests/notification-center.vue
+++ b/app/frontend/frontend/pages/visual-tests/notification-center.vue
@@ -10,6 +10,7 @@ import BaseText from "@/shared/components/base/Text/index.vue";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import NotificationsListItem from "@/frontend/components/Notifications/ListItem/index.vue";
 import NotificationsDetail from "@/frontend/components/Notifications/Detail/index.vue";
+import ListSkeleton from "@/shared/components/ListSkeleton/index.vue";
 import { NotificationTypeEnum, type Notification } from "@/services/fyApi";
 
 /*
@@ -168,6 +169,25 @@ const record = (entry: string) => {
     <NotificationsListItem :notification="longTitle" />
   </div>
 
+  <Heading :level="HeadingLevelEnum.H2">ListItem | Waiting</Heading>
+  <p>
+    What the list puts up while its first page is on its way, beside the rows it
+    stands in for. The two are the check on each other: same surface, same
+    spacing, same height, so nothing moves when the records land.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <ul class="vt-notifications" data-test="waiting-rows">
+        <li v-for="item in listed" :key="item.id">
+          <NotificationsListItem :notification="item" />
+        </li>
+      </ul>
+    </div>
+    <div class="col-12 col-lg-6">
+      <ListSkeleton :count="listed.length" />
+    </div>
+  </div>
+
   <Heading :level="HeadingLevelEnum.H2">Detail | With a notification</Heading>
   <p>
     The reading pane. Its body is markdown, so the cases worth having are a
@@ -253,3 +273,17 @@ const record = (entry: string) => {
     </div>
   </div>
 </template>
+
+<style lang="scss" scoped>
+// The real page's list markup, which lives in the page rather than a component:
+// the placeholders beside it are only worth looking at against the spacing they
+// actually have to match.
+.vt-notifications {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+</style>

--- a/app/frontend/shared/components/FilteredList/index.vue
+++ b/app/frontend/shared/components/FilteredList/index.vue
@@ -13,6 +13,7 @@ import Forbidden from "@/shared/components/Forbidden/index.vue";
 import { useFiltersStore } from "@/shared/stores/filters";
 import { usePaginationStore } from "@/shared/stores/pagination";
 import { provideListGeometry } from "@/shared/composables/useListGeometry";
+import { useMinimumDuration } from "@/shared/composables/useMinimumDuration";
 import { useListGeometryStore } from "@/shared/stores/listGeometry";
 import {
   type AsyncStatus,
@@ -47,13 +48,19 @@ const props = withDefaults(defineProps<Props>(), {
   placeholders: false,
 });
 
-const loading = computed(() => {
+const fetching = computed(() => {
   return (
     (props.asyncStatus.isFetching.value &&
       !props.asyncStatus.isRefetching.value) ||
     props.asyncStatus.isLoading.value
   );
 });
+
+// Held on the way down: a list that answers as fast as a cached page does puts
+// its placeholders up and takes them away again inside a frame or two, and a
+// box that fills with grey bars and empties reads as a glitch rather than as a
+// load. See useMinimumDuration.
+const loading = useMinimumDuration(() => fetching.value);
 
 const refetching = computed(() => {
   return props.asyncStatus.isRefetching.value;

--- a/app/frontend/shared/components/ListSkeleton/index.scss
+++ b/app/frontend/shared/components/ListSkeleton/index.scss
@@ -1,36 +1,44 @@
 @import "@/shared/components/skeleton";
 
+// Built to the recipe of the row it stands in for - a framed panel in a gapped
+// column, see NotificationsListItem and the two notification pages - rather
+// than to a height written by hand: the same surface, the same insets, and the
+// same type on each of the two lines. The height then falls out of the same
+// arithmetic the row's does, so the first load reserves the right space without
+// having measured anything yet.
 .list-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   margin: 0;
   padding: 0;
   list-style: none;
 
   &__item {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: 12px;
-    padding: 10px 16px;
-    border-bottom: 1px solid rgba($gray-light, 0.16);
-    // A row of this kind carries controls on its right, so it is at least as
-    // tall as those - the same token they are sized from rather than a number
-    // copied out of Btn. Only until the list has been measured once.
-    min-height: calc(var(--field-h, 43px) + 20px);
-
-    &:last-child {
-      border-bottom: 0;
-    }
-
-    // A measured row can be shorter than that floor, and a floor it cannot go
-    // under would hold the placeholder taller than the row it stands in for.
-    &--measured {
-      min-height: 0;
-    }
+    // The row splits the same insets between itself and the button it wraps -
+    // 4px and 8px vertically, 14px to the icon. A placeholder has no button, so
+    // it carries the total, less the 1px its border already contributes.
+    padding: 12px 12px 12px 14px;
+    overflow: hidden;
+    background: $panel-bg;
+    border: 1px solid rgba(#fff, 0.1);
+    border-radius: 6px;
   }
 
+  // A round glyph the size of the row's icon, which sits 2px below the top of
+  // the first line rather than on it. The bar's fill rather than a well's: at
+  // 18px across, the well's sweep is a bright sliver crossing the dot every
+  // second and a half, which is exactly the flicker the placeholders are here
+  // to avoid.
   &__icon {
     flex: none;
-    width: 24px;
-    height: 24px;
+    width: 18px;
+    height: 18px;
+    margin-top: 3px;
+    background: rgba($gray-light, 0.18);
     border-radius: 50%;
   }
 
@@ -38,21 +46,33 @@
     display: flex;
     flex: 1 1 auto;
     flex-direction: column;
-    gap: 6px;
+    gap: 3px;
     min-width: 0;
+  }
+
+  // The row's second line is a type and a timestamp side by side, so it is two
+  // bars rather than one long one.
+  &__meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
   // Widths and type only - the bars themselves are the shared primitive, and
   // the type is what gives them their height.
   .skeleton-bar {
     &--title {
-      width: 42%;
-      font-size: 15px;
+      width: 58%;
     }
 
-    &--meta {
-      width: 24%;
-      font-size: 12px;
+    &--type {
+      width: 26%;
+      font-size: 0.8em;
+    }
+
+    &--time {
+      width: 16%;
+      font-size: 0.8em;
     }
   }
 }

--- a/app/frontend/shared/components/ListSkeleton/index.vue
+++ b/app/frontend/shared/components/ListSkeleton/index.vue
@@ -23,7 +23,9 @@ const geometry = useListGeometry();
 const count = computed(() => props.count ?? geometry?.count.value ?? 10);
 
 // Nothing until this list has been seen once, and then exactly what one of its
-// rows measured. The floor in the stylesheet only has to carry the first load.
+// rows measured - a row whose title runs to two lines is taller than the one
+// the stylesheet's arithmetic builds. Unmeasured, the placeholder stands as
+// tall as a single-line row on its own.
 const itemHeight = computed(() => {
   const remembered = geometry?.heightFor("row");
 
@@ -37,13 +39,15 @@ const itemHeight = computed(() => {
       v-for="item in count"
       :key="`list-skeleton-${item}`"
       class="list-skeleton__item"
-      :class="{ 'list-skeleton__item--measured': !!itemHeight }"
       :style="{ height: itemHeight }"
     >
-      <span class="skeleton-well list-skeleton__icon" />
+      <span class="list-skeleton__icon" />
       <span class="list-skeleton__lines">
-        <span class="skeleton-bar list-skeleton__bar--title" />
-        <span class="skeleton-bar list-skeleton__bar--meta" />
+        <span class="skeleton-bar skeleton-bar--title" />
+        <span class="list-skeleton__meta">
+          <span class="skeleton-bar skeleton-bar--type" />
+          <span class="skeleton-bar skeleton-bar--time" />
+        </span>
       </span>
     </li>
   </ul>

--- a/app/frontend/shared/composables/useMinimumDuration.spec.ts
+++ b/app/frontend/shared/composables/useMinimumDuration.spec.ts
@@ -1,0 +1,131 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, h, ref, type Ref } from "vue";
+import { useMinimumDuration } from "./useMinimumDuration";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// A component, because the composable registers a watcher and hangs its
+// clean-up off the surrounding scope.
+const render = async (source: Ref<boolean>, minimum?: number) => {
+  const held = ref(false);
+
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        const flag = useMinimumDuration(() => source.value, minimum);
+
+        return () => {
+          held.value = flag.value;
+
+          return h("div");
+        };
+      },
+    }),
+  );
+
+  await flushPromises();
+
+  return { held, wrapper };
+};
+
+const advance = async (ms: number) => {
+  vi.advanceTimersByTime(ms);
+
+  await flushPromises();
+};
+
+describe("useMinimumDuration", () => {
+  it("goes up the moment the source does", async () => {
+    const source = ref(false);
+    const { held } = await render(source);
+
+    expect(held.value).toBe(false);
+
+    source.value = true;
+
+    await flushPromises();
+
+    expect(held.value).toBe(true);
+  });
+
+  it("holds an answer that arrives too fast to be seen", async () => {
+    const source = ref(true);
+    const { held } = await render(source, 400);
+
+    source.value = false;
+
+    await advance(50);
+
+    expect(held.value).toBe(true);
+
+    await advance(400);
+
+    expect(held.value).toBe(false);
+  });
+
+  it("lets go the moment a slow answer arrives", async () => {
+    const source = ref(true);
+    const { held } = await render(source, 400);
+
+    await advance(500);
+
+    expect(held.value).toBe(true);
+
+    source.value = false;
+
+    await flushPromises();
+
+    expect(held.value).toBe(false);
+  });
+
+  it("starts the hold again for a second wait", async () => {
+    const source = ref(false);
+    const { held } = await render(source, 400);
+
+    source.value = true;
+
+    await advance(10);
+
+    source.value = false;
+
+    await advance(200);
+
+    expect(held.value).toBe(true);
+
+    source.value = true;
+
+    await advance(200);
+
+    // The release the first wait scheduled is not allowed to land on the
+    // second one.
+    expect(held.value).toBe(true);
+
+    source.value = false;
+
+    await advance(400);
+
+    expect(held.value).toBe(false);
+  });
+
+  it("drops its pending release with the scope", async () => {
+    const source = ref(true);
+    const { wrapper } = await render(source, 400);
+
+    source.value = false;
+
+    await flushPromises();
+
+    expect(vi.getTimerCount()).toBe(1);
+
+    wrapper.unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/app/frontend/shared/composables/useMinimumDuration.ts
+++ b/app/frontend/shared/composables/useMinimumDuration.ts
@@ -1,0 +1,53 @@
+// How long a waiting state has to stay up once it has gone up. A list that
+// answers in 40ms would otherwise fill with placeholder bars and empty again
+// before the eye settles, which reads as the page glitching rather than as the
+// page loading - and the reader is left having seen something without being
+// able to say what. Long enough to register as deliberate, short enough that a
+// slow answer is still the thing being waited for.
+export const MINIMUM_WAIT_MS = 400;
+
+// Passes a flag through unchanged on the way up and holds it on the way down.
+export const useMinimumDuration = (
+  source: () => boolean,
+  minimum = MINIMUM_WAIT_MS,
+) => {
+  const held = ref(source());
+
+  let releaseAt = held.value ? Date.now() + minimum : 0;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const clear = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = undefined;
+    }
+  };
+
+  watch(source, (active) => {
+    clear();
+
+    if (active) {
+      releaseAt = Date.now() + minimum;
+      held.value = true;
+
+      return;
+    }
+
+    const remaining = releaseAt - Date.now();
+
+    if (remaining <= 0) {
+      held.value = false;
+
+      return;
+    }
+
+    timeout = setTimeout(() => {
+      timeout = undefined;
+      held.value = false;
+    }, remaining);
+  });
+
+  onScopeDispose(clear);
+
+  return held;
+};


### PR DESCRIPTION
The notification list's placeholders were too small, and they blinked.

## Too small

`ListSkeleton` drew a hairline-separated row with no fill of its own, so the
page's background photo showed straight through it — the placeholders read as a
few faint bars floating in space rather than as the framed rows they replace.
They carried no row gap either, while both notification lists gap theirs by
10px, so the reserved column came out 10px a row short of the list that
replaced it.

It is now built to the row's own recipe: the panel fill, the same border and
radius, the row's insets split back together, and the two lines at the type
sizes the row uses. The height falls out of the same arithmetic the row's does,
so it is right on the very first load with nothing measured yet.

| | row | placeholder |
|---|---|---|
| before | 72px, 10px gap | 75px, no gap |
| after | 72px, 10px gap | **72px, 10px gap** |

Two things turned up on the way. The bar modifiers had never applied — the
template asked for `list-skeleton__bar--title` where the stylesheet compiles
`.skeleton-bar--title`, so both bars had been running at full width. And the
icon is the still fill rather than the animated well, because at 18px across
the well's sweep is a bright sliver crossing the dot every second and a half,
which is the same flicker the placeholders are here to avoid.

## Blinked

`FilteredList` drove its loading branch straight off the query status, so a list
answering in 40ms filled with bars and emptied again inside two frames. A box
that flickers reads as the page glitching rather than as the page loading.

`useMinimumDuration` passes the flag through unchanged on the way up and holds
it 400ms on the way down — a fast answer still shows a wait that reads as
deliberate, and a slow one is not delayed. Measured against
`/visual-tests/lists/`:

```
answer after  30ms -> placeholders released at 413ms
answer after 150ms -> placeholders released at 410ms
answer after 900ms -> placeholders released at 915ms
```

## Checks

`lint:js`, `lint:ts` and prettier clean. Five new specs for the composable,
plus the existing ListSkeleton / FilteredList / Table / useListGeometry specs —
38 passing. Every number above was measured in the browser against the running
dev server, through the new `ListItem | Waiting` section on
`/visual-tests/notification-center/`, which puts the placeholders beside the
rows they stand in for.

## Not done here

- **No e2e spec.** A height-parity assertion on the visual-tests page is the
  right guard, but the e2e server was occupied while this was written and an
  unrun spec is worse than none.
- **The placeholders are still full width.** The loaded list is `flex: 0 0 38%`
  with the reading pane beside it, so the rows narrow when the records land.
  Closing that means wrapping the `#skeleton` slot in the two-pane frame on both
  notification pages, and it would make the placeholders narrower rather than
  larger — the opposite of the complaint that started this.

🤖
