### PR TITLE
feat(cargo-grids): pick ships with the picker compare uses

### DIFF
--- a/app/controllers/api/v1/filters/models_controller.rb
+++ b/app/controllers/api/v1/filters/models_controller.rb
@@ -4,6 +4,8 @@ module Api
   module V1
     module Filters
       class ModelsController < ::Api::PublicBaseController
+        include ModelCargoFiltersConcern
+
         skip_verify_authorized
 
         def production_states
@@ -56,7 +58,9 @@ module Api
           model_query_params["sorts"] = sorting_params(Model, model_query_params["sorts"])
 
           scope = Model.visible.active.includes(:manufacturer)
+          scope = with_cargo_grids(scope) if model_query_params.delete("with_cargo_grids")
           scope = scope.where(id: current_resource_owner.models.select(:id)) if model_query_params.delete("in_hangar") && current_resource_owner.present?
+          scope = container_fit(scope) if container_fit_params.present?
 
           @q = scope.ransack(model_query_params)
 
@@ -84,7 +88,7 @@ module Api
         private def model_query_params
           @model_query_params ||= params.permit(
             q: [
-              :name_cont, :name_eq, :slug_eq, :search_cont, :in_hangar, :s, :sorts,
+              :name_cont, :name_eq, :slug_eq, :search_cont, :in_hangar, :with_cargo_grids, :s, :sorts,
               name_in: [], slug_in: [], id_in: [], id_not_in: [],
               manufacturer_in: [], classification_in: [], focus_in: [],
               size_in: [], production_status_in: []

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -4,6 +4,7 @@ module Api
   module V1
     class ModelsController < ::Api::BaseController
       include ViteRails::TagHelpers
+      include ModelCargoFiltersConcern
 
       skip_verify_authorized
 
@@ -354,15 +355,7 @@ module Api
 
         scope = scope.with_dock if model_query_params.delete("with_dock")
         scope = scope.where(cargo: 0.1..) if model_query_params.delete("with_cargo")
-        if model_query_params.delete("with_cargo_grids")
-          scope = scope.where(
-            id: Model.joins(:cargo_holds_db).select(:id)
-          ).or(
-            scope.where(
-              id: Model.joins(:module_hardpoints).select(:id)
-            )
-          ).distinct
-        end
+        scope = with_cargo_grids(scope) if model_query_params.delete("with_cargo_grids")
         scope = scope.where(id: current_resource_owner.models.select(:id)) if model_query_params.delete("in_hangar") && current_resource_owner.present?
         scope = container_fit(scope) if container_fit_params.present?
         scope = will_it_fit?(scope) if model_query_params["will_it_fit"].present?
@@ -371,19 +364,6 @@ module Api
         model_query_params["sorts"] = sorting_params(Model, model_query_params["sorts"])
 
         scope.ransack(model_query_params)
-      end
-
-      private def container_fit_params
-        @container_fit_params ||= params.permit(container_fit: {})[:container_fit]
-      end
-
-      private def container_fit(scope)
-        return scope if container_fit_params.blank?
-
-        container_set = container_fit_params.to_h.transform_keys(&:to_i).transform_values(&:to_i).select { |_k, v| v > 0 }
-        return scope if container_set.empty?
-
-        scope.where(id: ScData::CargoFinderSql.find_fitting_models(container_set).select(:id))
       end
 
       private def find_model_by_slug!(*includes, joins: nil)

--- a/app/controllers/concerns/model_cargo_filters_concern.rb
+++ b/app/controllers/concerns/model_cargo_filters_concern.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module ModelCargoFiltersConcern
+  # A model has a cargo grid either because its own game files describe one or
+  # because a module it can carry brings one with it.
+  private def with_cargo_grids(scope)
+    scope.where(
+      id: Model.joins(:cargo_holds_db).select(:id)
+    ).or(
+      scope.where(
+        id: Model.joins(:module_hardpoints).select(:id)
+      )
+    ).distinct
+  end
+
+  private def container_fit_params
+    @container_fit_params ||= params.permit(container_fit: {})[:container_fit]
+  end
+
+  private def container_fit(scope)
+    return scope if container_fit_params.blank?
+
+    container_set = container_fit_params.to_h.transform_keys(&:to_i).transform_values(&:to_i).select { |_k, v| v > 0 }
+    return scope if container_set.empty?
+
+    scope.where(id: ScData::CargoFinderSql.find_fitting_models(container_set).select(:id))
+  end
+end

--- a/app/frontend/frontend/components/CargoGridViewer/index.vue
+++ b/app/frontend/frontend/components/CargoGridViewer/index.vue
@@ -1278,7 +1278,14 @@ const onDragEnd = (_shipIndex: number) => {
             :position="getShipPosition(shipResult)"
           >
             <!-- Ship label (Html from cientos) -->
-            <Html :position="[0, shipResult.boundingHeight + 1, 0]" center>
+            <!-- Capped well below the modal layer: cientos defaults the range to
+                 16777271, which floats the label over dialogs and overlays. It
+                 only ever has to clear the canvas it labels. -->
+            <Html
+              :position="[0, shipResult.boundingHeight + 1, 0]"
+              :z-index-range="[100, 0]"
+              center
+            >
               <span
                 class="cargo-grid-viewer__ship-label"
                 :style="{ color: shipResult.color }"

--- a/app/frontend/frontend/components/CargoGrids/Models/PickerModal/index.vue
+++ b/app/frontend/frontend/components/CargoGrids/Models/PickerModal/index.vue
@@ -1,0 +1,66 @@
+<script lang="ts">
+export default {
+  name: "CargoGridsModelsPickerModal",
+};
+</script>
+
+<script lang="ts" setup>
+import PickerModal from "@/frontend/components/Models/PickerModal/index.vue";
+import { type ModelPickerSelection } from "@/frontend/components/Models/PickerModal/types";
+import {
+  ModelProductionStatusEnum,
+  type ContainerFitQuery,
+} from "@/services/fyApi";
+import { useComlink } from "@/shared/composables/useComlink";
+import { useI18n } from "@/shared/composables/useI18n";
+
+type Props = {
+  // The grid already holds these; the picker shows them, marked, unpickable.
+  taken: string[];
+  max: number;
+  // The load the picker's container filter starts on. The page keeps its own
+  // counts either way - what happens here only decides which ships are offered.
+  containerFit?: ContainerFitQuery;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  containerFit: undefined,
+});
+
+const { t } = useI18n();
+
+const comlink = useComlink();
+
+// Only flight-ready ships, and only ones with a grid to draw: the tool has
+// nothing to show for a concept, and nothing at all for a hold the game files do
+// not describe.
+const query = {
+  withCargoGrids: true,
+  productionStatusIn: [ModelProductionStatusEnum.FLIGHT_READY],
+};
+
+const submit = (selection: ModelPickerSelection[]) => {
+  comlink.emit(
+    "cargo-grids-models-picked",
+    selection.map(({ option }) => option.slug),
+  );
+
+  comlink.emit("close-modal");
+};
+</script>
+
+<template>
+  <PickerModal
+    :title="t('modelPicker.cargoGridsTitle')"
+    :submit-label="t('actions.cargoGrids.addShips')"
+    :max="props.max - props.taken.length"
+    :max-hint="t('labels.cargoGridViewer.enoughShips')"
+    :taken-slugs="props.taken"
+    :taken-note="t('modelPicker.badges.onCargoGrid')"
+    :query="query"
+    :container-fit="props.containerFit"
+    container-filter
+    hangar-filter
+    @submit="submit"
+  />
+</template>

--- a/app/frontend/frontend/components/Models/PickerModal/index.vue
+++ b/app/frontend/frontend/components/Models/PickerModal/index.vue
@@ -9,6 +9,10 @@ import Modal from "@/shared/components/AppModal/Inner/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import Chip from "@/shared/components/base/Chip/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
+import {
+  InputAlignmentsEnum,
+  InputTypesEnum,
+} from "@/shared/components/base/FormInput/types";
 import Empty from "@/shared/components/Empty/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
 import ManufacturerSelect from "@/frontend/components/base/ManufacturerSelect/index.vue";
@@ -20,10 +24,13 @@ import {
 } from "@/frontend/components/Models/PickerModal/types";
 import { EmptyVariantsEnum } from "@/shared/components/Empty/types";
 import {
+  ContainerSizeEnum,
+  type ContainerFitQuery,
   type ModelOption,
   type ModelQuery,
   useModelOptions,
 } from "@/services/fyApi";
+import { useSessionStore } from "@/frontend/stores/session";
 import { keepPreviousData } from "@tanstack/vue-query";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
@@ -45,6 +52,19 @@ type Props = {
   // Ships the caller's list already holds: shown, named by `takenNote`, unpickable.
   takenSlugs?: string[];
   takenNote?: string;
+  // What the caller's list can display at all - a cargo grid has nothing to draw
+  // for a ship without one. Narrows every query the picker makes, and the filters
+  // below only ever narrow it further.
+  query?: ModelQuery;
+  // Offers a load to carry as a filter: only ships every counted container fits
+  // into are shown.
+  containerFilter?: boolean;
+  // The load the filter starts on. Editing it here only narrows or widens what
+  // the picker offers - the list you opened it from keeps the load it had.
+  containerFit?: ContainerFitQuery;
+  // Offers the hangar as a filter. Signed-out visitors have no hangar to filter
+  // by, so they never see it.
+  hangarFilter?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -55,6 +75,10 @@ const props = withDefaults(defineProps<Props>(), {
   highlight: undefined,
   takenSlugs: () => [],
   takenNote: undefined,
+  query: undefined,
+  containerFilter: false,
+  containerFit: undefined,
+  hangarFilter: false,
 });
 
 const emit = defineEmits<{
@@ -65,17 +89,52 @@ const PER_PAGE = "24";
 
 const { t } = useI18n();
 
+const sessionStore = useSessionStore();
+
+const hangarOffered = computed(
+  () => props.hangarFilter && sessionStore.isAuthenticated,
+);
+
 const search = ref<string>("");
 const searchTerm = ref<string>("");
 const manufacturerIn = ref<string[]>([]);
 const classificationIn = ref<string[]>([]);
+const hangarOnly = ref(false);
+
+// The sizes the API knows, as the literal keys ContainerFitQuery declares - so
+// the counts below index it without a cast, and a size added on the Ruby side
+// reaches this filter without an edit.
+const CONTAINER_SIZES = Object.values(ContainerSizeEnum);
+
+// Left sparse rather than zero-filled: an empty counter reads as "none asked
+// for", where a row of zeroes hides which sizes actually carry a load.
+const containerCounts = ref<ContainerFitQuery>({ ...props.containerFit });
+
+const containerCount = (size: `${ContainerSizeEnum}`) =>
+  Number(containerCounts.value[size]) || 0;
+
+const containerFit = computed<ContainerFitQuery | undefined>(() => {
+  const fit: ContainerFitQuery = {};
+
+  for (const size of CONTAINER_SIZES) {
+    const quantity = containerCount(size);
+
+    if (quantity > 0) {
+      fit[size] = quantity;
+    }
+  }
+
+  // Undefined rather than an empty map: the endpoint reads any present
+  // containerFit as a load to check against, and an empty one fits nothing.
+  return Object.keys(fit).length ? fit : undefined;
+});
 
 const page = ref(1);
 const records = ref<ModelOption[]>([]);
 const selection = ref<ModelPickerSelection[]>([]);
 
 const queryParams = computed(() => {
-  const q: ModelQuery = {};
+  const q: ModelQuery = { ...props.query };
 
   // searchCont, not nameCont: it is aliased to name-or-slug-or-manufacturer, so
   // typing "anvil" finds the manufacturer's ships rather than nothing.
@@ -91,10 +150,15 @@ const queryParams = computed(() => {
     q.classificationIn = classificationIn.value;
   }
 
+  if (hangarOnly.value) {
+    q.inHangar = true;
+  }
+
   return {
     page: String(page.value),
     perPage: PER_PAGE,
     q,
+    containerFit: containerFit.value,
   };
 });
 
@@ -161,7 +225,7 @@ watch(search, (value) => {
   applySearch(value);
 });
 
-watch([manufacturerIn, classificationIn], () => {
+watch([manufacturerIn, classificationIn, hangarOnly, containerFit], () => {
   page.value = 1;
 });
 
@@ -169,7 +233,9 @@ const filtersActive = computed(
   () =>
     !!searchTerm.value ||
     !!manufacturerIn.value.length ||
-    !!classificationIn.value.length,
+    !!classificationIn.value.length ||
+    hangarOnly.value ||
+    !!containerFit.value,
 );
 
 const resetFilters = () => {
@@ -177,6 +243,8 @@ const resetFilters = () => {
   searchTerm.value = "";
   manufacturerIn.value = [];
   classificationIn.value = [];
+  hangarOnly.value = false;
+  containerCounts.value = {};
   page.value = 1;
 };
 
@@ -320,6 +388,37 @@ const save = () => {
             class="model-picker__filter"
             name="model-picker-classification"
           />
+
+          <Btn
+            v-if="hangarOffered"
+            class="model-picker__hangar"
+            :active="hangarOnly"
+            data-test="model-picker-hangar-only"
+            @click="hangarOnly = !hangarOnly"
+          >
+            {{ t("modelPicker.labels.hangarOnly") }}
+          </Btn>
+        </div>
+
+        <div v-if="containerFilter" class="model-picker__containers">
+          <span class="model-picker__containers-label">
+            {{ t("modelPicker.labels.containerFit") }}
+          </span>
+          <FormInput
+            v-for="size in CONTAINER_SIZES"
+            :key="size"
+            v-model.number="containerCounts[size]"
+            class="model-picker__container"
+            :class="{
+              'model-picker__container--set': containerCount(size) > 0,
+            }"
+            :name="`model-picker-container-${size}`"
+            :label="`${size} SCU`"
+            :type="InputTypesEnum.NUMBER"
+            :min="0"
+            :step="1"
+            :alignment="InputAlignmentsEnum.RIGHT"
+          />
         </div>
 
         <div class="model-picker__summary">
@@ -418,6 +517,7 @@ const save = () => {
           :loading="submitting"
           :disabled="!selection.length"
           :size="BtnSizesEnum.LG"
+          data-test="model-picker-submit"
           @click="save"
         >
           {{ submitLabel }}
@@ -459,6 +559,37 @@ const save = () => {
  */
 .model-picker__filter :deep(.base-select-items-wrapper) {
   background-color: var(--color-gray-darker, #272b30);
+}
+
+/* Matched to the fields it stands next to rather than sized by its own text, so
+   the toolbar reads as one row. */
+.model-picker__hangar {
+  @apply self-stretch;
+}
+
+/* ---------- container filter ----------
+   A row of narrow counters, one per size, that wraps rather than scrolls: the
+   modal is wide but a phone fits three of them across. */
+.model-picker__containers {
+  @apply flex flex-wrap items-end gap-2;
+  padding-top: 12px;
+}
+
+.model-picker__containers-label {
+  @apply text-muted text-[13px];
+  /* Level with the fields' labels, not with the inputs the flex row bottom-aligns. */
+  @apply self-center;
+}
+
+.model-picker__container {
+  @apply w-[4.5rem] shrink-0;
+}
+
+/* Which sizes are actually being asked for, readable without comparing seven
+   numbers: an empty counter is silent, a filled one is marked. */
+.model-picker__container--set :deep(input) {
+  @apply text-gold font-semibold;
+  border-color: var(--color-gold);
 }
 
 .model-picker__summary {

--- a/app/frontend/frontend/pages/tools/cargo-grids.scss
+++ b/app/frontend/frontend/pages/tools/cargo-grids.scss
@@ -20,6 +20,14 @@
   }
 }
 
+// Which sizes are actually being asked for, readable without comparing seven
+// numbers: an empty counter is silent, a filled one is marked.
+.container-field--set :deep(input) {
+  color: var(--color-gold);
+  font-weight: 600;
+  border-color: var(--color-gold);
+}
+
 .toolbar {
   align-items: flex-start;
   position: relative;

--- a/app/frontend/frontend/pages/tools/cargo-grids.vue
+++ b/app/frontend/frontend/pages/tools/cargo-grids.vue
@@ -5,7 +5,6 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { ComponentExposed } from "vue-component-type-helpers";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import CargoGridViewer from "@/frontend/components/CargoGridViewer/index.vue";
 import {
@@ -19,30 +18,18 @@ import FormInput from "@/shared/components/base/FormInput/index.vue";
 import Btn from "@/shared/components/base/Btn/index.vue";
 import ViewImage from "@/shared/components/ViewImage/index.vue";
 import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
-import BaseSelect, {
-  type BaseSelectParams,
-  type ValueType,
-} from "@/shared/components/base/Select/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
-import {
-  models as fetchModels,
-  ModelProductionStatusEnum,
-  ContainerSizeEnum,
-  type ContainerFitQuery,
-  type Model,
-  type ModelQuery,
-  type Models,
-} from "@/services/fyApi";
+import { ContainerSizeEnum, type ContainerFitQuery } from "@/services/fyApi";
 import {
   InputTypesEnum,
   InputAlignmentsEnum,
 } from "@/shared/components/base/FormInput/types";
 
-import { useSessionStore } from "@/frontend/stores/session";
 import FeatureGuard from "@/frontend/components/FeatureGuard.vue";
 import { FeatureFlagName } from "@/services/fyApi";
 import { useCargoGridShip } from "@/frontend/composables/useCargoGridShip";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useComlink } from "@/shared/composables/useComlink";
 import { useMobile } from "@/shared/composables/useMobile";
 
 const { t } = useI18n();
@@ -50,23 +37,20 @@ const { t } = useI18n();
 const route = useRoute();
 const router = useRouter();
 
-const sessionStore = useSessionStore();
 const { displayConfirm } = useAppNotifications();
 
+const comlink = useComlink();
+
 const mobile = useMobile();
-
-const hangarOnly = ref(false);
-
-const containerFilterActive = ref(false);
 
 // Derived from the schema rather than repeated: ContainerSizeEnum is generated
 // from CargoHoldContainerCapacity::CONTAINER_SIZES, so adding a size on the
 // Ruby side reaches this page without an edit.
-const CONTAINER_SIZES = Object.values(ContainerSizeEnum).map(Number);
+const CONTAINER_SIZE_KEYS = Object.values(ContainerSizeEnum);
+
+const CONTAINER_SIZES = CONTAINER_SIZE_KEYS.map(Number);
 
 const MAX_SHIPS = 4;
-
-const modelSelect = ref<ComponentExposed<typeof BaseSelect>>();
 
 // Parse initial slugs from URL (backward compat: ?ship= or new ?ships=)
 const parseInitialSlugs = (): string[] => {
@@ -148,84 +132,49 @@ const singleShipCargoHolds = computed(() => {
 
 // Container requests: how many of each size the user wants to load. A link may
 // arrive with a load already counted out - a ship inventory sends what it holds.
+//
+// Sparse rather than zero-filled: an empty counter reads as "none of these",
+// where a row of zeroes hides which sizes carry a load.
 const containerRequests = ref<Record<number, number>>({
-  ...Object.fromEntries(CONTAINER_SIZES.map((s) => [s, 0])),
   ...parseContainerCounts(route.query.containers),
 });
+
+const containerCount = (size: number) =>
+  Number(containerRequests.value[size]) || 0;
 
 const hasContainerRequests = computed(() =>
   Object.values(containerRequests.value).some((v) => Number(v) > 0),
 );
 
 const requestedContainers = computed<ContainerRequest[]>(() => {
-  return CONTAINER_SIZES.filter(
-    (s) => Number(containerRequests.value[s]) > 0,
-  ).map((s) => ({
+  return CONTAINER_SIZES.filter((s) => containerCount(s) > 0).map((s) => ({
     size: s,
-    quantity: Number(containerRequests.value[s]),
+    quantity: containerCount(s),
   }));
 });
 
 const clearContainers = () => {
-  containerFilterActive.value = false;
-  for (const size of CONTAINER_SIZES) {
-    containerRequests.value[size] = 0;
-  }
+  containerRequests.value = {};
 };
 
-// Model filter that only shows flight-ready ships with cargo grids
-const fetchCargoModels = async (params: BaseSelectParams<Model>) => {
-  const q: ModelQuery = {
-    withCargoGrids: true,
-    productionStatusIn: [ModelProductionStatusEnum.FLIGHT_READY],
-  };
+// The load typed into the form, in the shape the picker's query takes. Iterated
+// over the enum rather than CONTAINER_SIZES: its values are the literal keys
+// ContainerFitQuery declares, so this indexes without a cast.
+const containerFit = computed<ContainerFitQuery>(() => {
+  const fit: ContainerFitQuery = {};
 
-  if (params.search) {
-    q.nameCont = params.search;
-  }
+  for (const size of CONTAINER_SIZE_KEYS) {
+    const quantity = containerCount(Number(size));
 
-  if (params.missing && !params.search) {
-    q.slugEq = params.missing as string;
-  }
-
-  if (hangarOnly.value) {
-    q.inHangar = true;
-  }
-
-  const containerFit: ContainerFitQuery = {};
-  if (containerFilterActive.value && hasContainerRequests.value) {
-    // Over the enum rather than CONTAINER_SIZES: its values are the literal
-    // keys ContainerFitQuery declares, so this indexes without a cast.
-    for (const size of Object.values(ContainerSizeEnum)) {
-      const qty = Number(containerRequests.value[Number(size)]);
-      if (qty > 0) {
-        containerFit[size] = qty;
-      }
+    if (quantity > 0) {
+      fit[size] = quantity;
     }
   }
 
-  return fetchModels({
-    page: String(params.page || 1),
-    q,
-    containerFit,
-  });
-};
+  return fit;
+});
 
-const formatModels = (response: Models) => {
-  return response.items.map((model) => ({
-    label: model.name,
-    value: model.slug,
-    object: model,
-  }));
-};
-
-const containerFilterVersion = ref(0);
-
-const filterKey = computed(
-  () => `cargo-grid-model-${hangarOnly.value}-${containerFilterVersion.value}`,
-);
-
-const selectDisabled = computed(() => selectedSlugs.value.length >= MAX_SHIPS);
+const full = computed(() => selectedSlugs.value.length >= MAX_SHIPS);
 
 // URL sync
 const syncUrl = () => {
@@ -259,24 +208,50 @@ const syncUrl = () => {
 // the URL follows them instead of being rewritten only when a ship changes.
 watch(containerRequests, () => syncUrl(), { deep: true });
 
-// Ship management
-const handleShipSelect = (value: ValueType<Model> | undefined) => {
-  const slug = value as string;
-  if (!slug) return;
+/**
+ * Opens the shared ship picker, carrying the load typed into the form over as its
+ * container filter - the ships worth offering are the ones that can take it. The
+ * filter is editable in the modal, and widening it there leaves the page's counts
+ * alone.
+ */
+const openPicker = () => {
+  comlink.emit("open-modal", {
+    component: () =>
+      import("@/frontend/components/CargoGrids/Models/PickerModal/index.vue"),
+    props: {
+      taken: selectedSlugs.value,
+      max: MAX_SHIPS,
+      containerFit: containerFit.value,
+    },
+    wide: true,
+  });
+};
 
-  // Prevent duplicates and enforce max
-  if (
-    selectedSlugs.value.includes(slug) ||
-    selectedSlugs.value.length >= MAX_SHIPS
-  ) {
-    modelSelect.value?.clear();
-    return;
+// The picker sizes its own cap from what was free when it opened, so the ceiling
+// and the duplicates are checked again here - a link opened in the meantime, or a
+// ship removed behind the modal, moves both.
+const addShips = (slugs: string[]) => {
+  const next = [...selectedSlugs.value];
+
+  for (const slug of slugs) {
+    if (next.length >= MAX_SHIPS || next.includes(slug)) continue;
+
+    next.push(slug);
   }
 
-  selectedSlugs.value = [...selectedSlugs.value, slug];
-  modelSelect.value?.clear();
+  selectedSlugs.value = next;
   syncUrl();
 };
+
+const offModelsPicked = ref<() => void>();
+
+onMounted(() => {
+  offModelsPicked.value = comlink.on("cargo-grids-models-picked", addShips);
+});
+
+onUnmounted(() => {
+  offModelsPicked.value?.();
+});
 
 const removeShip = (index: number) => {
   const next = [...selectedSlugs.value];
@@ -292,28 +267,18 @@ const handleToggleModule = (slotIndex: number, moduleSlug: string) => {
 
 const handleFillGreedy = (slotIndex: number) => {
   const counts = shipSlots[slotIndex].getGreedyFillCounts();
+  const next: Record<number, number> = {};
+
   for (const size of CONTAINER_SIZES) {
-    containerRequests.value[size] = counts[size] || 0;
+    if (counts[size] > 0) {
+      next[size] = counts[size];
+    }
   }
-};
 
-const applyContainerFilter = () => {
-  containerFilterActive.value = true;
-  containerFilterVersion.value++;
-  selectedSlugs.value = [];
-  syncUrl();
-};
-
-const toggleHangarOnly = () => {
-  hangarOnly.value = !hangarOnly.value;
-  containerFilterVersion.value++;
-  selectedSlugs.value = [];
-  syncUrl();
+  containerRequests.value = next;
 };
 
 const doResetFilters = () => {
-  hangarOnly.value = false;
-  containerFilterActive.value = false;
   clearContainers();
   selectedSlugs.value = [];
   syncUrl();
@@ -335,22 +300,23 @@ const resetFilters = () => {
       <div class="row toolbar">
         <div class="col-12 col-lg-8">
           <div class="ship-selector-row" data-test="ship-entries">
-            <BaseSelect
-              ref="modelSelect"
-              :key="filterKey"
-              :label="t('labels.selectModel')"
-              :search-label="t('labels.findModel')"
-              :query-fn="fetchCargoModels"
-              :query-response-formatter="formatModels"
-              name="cargo-grid-model"
-              :paginated="true"
-              :searchable="true"
-              :multiple="false"
-              :disabled="selectDisabled"
-              no-label
-              inline
-              @update:model-value="handleShipSelect"
-            />
+            <!-- The tooltip hangs on the wrapper, not the button: a disabled
+                 button dispatches no pointer events, so the one case that has
+                 something to say could never say it. -->
+            <div
+              v-tooltip="
+                full ? t('labels.cargoGridViewer.enoughShips') : undefined
+              "
+            >
+              <Btn
+                :disabled="full"
+                data-test="cargo-grid-add-ships"
+                @click="openPicker()"
+              >
+                <i class="fa-light fa-plus" />
+                {{ t("labels.cargoGridViewer.addShip") }}
+              </Btn>
+            </div>
             <Btn
               v-if="selectedSlugs.length > 0"
               v-tooltip="t('actions.reset')"
@@ -358,13 +324,6 @@ const resetFilters = () => {
               @click="resetFilters"
             >
               <i class="fa-light fa-undo" />
-            </Btn>
-            <Btn
-              v-if="sessionStore.isAuthenticated"
-              :active="hangarOnly"
-              @click="toggleHangarOnly"
-            >
-              {{ t("labels.cargoGridViewer.myHangar") }}
             </Btn>
           </div>
 
@@ -378,6 +337,9 @@ const resetFilters = () => {
             >
               <FormInput
                 v-model.number="containerRequests[size]"
+                :class="{
+                  'container-field--set': containerCount(size) > 0,
+                }"
                 :name="`container-${size}`"
                 :label="`${size} SCU`"
                 :type="InputTypesEnum.NUMBER"
@@ -387,9 +349,6 @@ const resetFilters = () => {
               />
             </div>
             <div class="container-fields__actions">
-              <Btn v-if="hasContainerRequests" @click="applyContainerFilter">
-                {{ t("labels.cargoGridViewer.filterShips") }}
-              </Btn>
               <Btn v-if="hasContainerRequests" @click="clearContainers">
                 {{ t("actions.clear") }}
               </Btn>

--- a/app/frontend/shared/composables/useComlink.ts
+++ b/app/frontend/shared/composables/useComlink.ts
@@ -42,6 +42,7 @@ type Events = {
   "fleet-event-updated": () => void | Promise<unknown>;
   "fleet-event-signup-changed": () => void | Promise<unknown>;
   "fleet-event-children-changed": () => void | Promise<unknown>;
+  "cargo-grids-models-picked": (slugs: string[]) => void | Promise<unknown>;
 };
 
 const AppComlink = createNanoEvents<Events>();

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -154,6 +154,9 @@
       "compare": {
         "ships": "Vergleichen"
       },
+      "cargoGrids": {
+        "addShips": "Schiffe hinzufügen"
+      },
       "hangar": {
         "editGroups": "Gruppen hinzufügen oder löschen",
         "editName": "Benenne dein Schiff",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1700,8 +1700,7 @@
         "totalCargo": "Gesamtfracht",
         "didNotFit": "Passte nicht",
         "openInTool": "Im Frachtraster-Tool öffnen",
-        "myHangar": "Nur meine Schiffe anzeigen",
-        "filterShips": "Schiffe nach Containergröße filtern",
+        "enoughShips": "Vier Schiffe füllen das Raster.",
         "addShip": "Schiff hinzufügen",
         "removeShip": "Entfernen",
         "autoFillShip": "Auto-Fill"

--- a/app/frontend/translations/de/modelPicker.json
+++ b/app/frontend/translations/de/modelPicker.json
@@ -3,9 +3,12 @@
     "modelPicker": {
       "hangarTitle": "Schiffe zum Hangar hinzufügen",
       "compareTitle": "Schiffe zum Vergleichen auswählen",
+      "cargoGridsTitle": "Schiffe für das Frachtraster auswählen",
       "wishlistTitle": "Schiffe zur Wunschliste hinzufügen",
       "labels": {
         "search": "Nach Name oder Hersteller suchen",
+        "hangarOnly": "Nur meine Schiffe",
+        "containerFit": "Zu transportierende Ladung",
         "results": "%{count} Schiffe",
         "selected": "%{count} ausgewählt"
       },
@@ -18,7 +21,8 @@
       "badges": {
         "inHangar": "Im Hangar",
         "onWishlist": "Auf der Wunschliste",
-        "comparing": "Im Vergleich"
+        "comparing": "Im Vergleich",
+        "onCargoGrid": "Im Raster"
       }
     }
   }

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -154,6 +154,9 @@
       "compare": {
         "ships": "Compare"
       },
+      "cargoGrids": {
+        "addShips": "Add Ships"
+      },
       "hangar": {
         "editGroups": "Add or remove Groups",
         "editName": "Name your Ship",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1691,8 +1691,7 @@
         "totalCargo": "Total Cargo",
         "didNotFit": "Did not fit",
         "openInTool": "Open in Cargo Grid Tool",
-        "myHangar": "Show only my Ships",
-        "filterShips": "Filter Ships by Container Size",
+        "enoughShips": "Four ships fill the grid.",
         "addShip": "Add Ship",
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"

--- a/app/frontend/translations/en/modelPicker.json
+++ b/app/frontend/translations/en/modelPicker.json
@@ -3,9 +3,12 @@
     "modelPicker": {
       "hangarTitle": "Add Ships to your Hangar",
       "compareTitle": "Select Ships to Compare",
+      "cargoGridsTitle": "Select Ships for the Cargo Grid",
       "wishlistTitle": "Add Ships to your Wishlist",
       "labels": {
         "search": "Search by name or manufacturer",
+        "hangarOnly": "Only my Ships",
+        "containerFit": "Load to carry",
         "results": "%{count} Ships",
         "selected": "%{count} Selected"
       },
@@ -18,7 +21,8 @@
       "badges": {
         "inHangar": "In Hangar",
         "onWishlist": "On Wishlist",
-        "comparing": "Comparing"
+        "comparing": "Comparing",
+        "onCargoGrid": "On the Grid"
       }
     }
   }

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -154,6 +154,9 @@
       "compare": {
         "ships": "Comparar"
       },
+      "cargoGrids": {
+        "addShips": "Añadir naves"
+      },
       "hangar": {
         "editGroups": "Añadir o eliminar grupos",
         "editName": "Nombrar tu nave",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1700,9 +1700,8 @@
         "totalCargo": "Carga total",
         "didNotFit": "No cabe",
         "openInTool": "Abrir en la herramienta de grilla de carga",
-        "myHangar": "Mostrar solo mis naves",
-        "filterShips": "Filtrar naves por tamaño de contenedor",
-        "addShip": "Add Ship",
+        "enoughShips": "Cuatro naves llenan la grilla.",
+        "addShip": "Añadir nave",
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },

--- a/app/frontend/translations/es/modelPicker.json
+++ b/app/frontend/translations/es/modelPicker.json
@@ -3,9 +3,12 @@
     "modelPicker": {
       "hangarTitle": "Añadir naves a tu hangar",
       "compareTitle": "Seleccionar naves para comparar",
+      "cargoGridsTitle": "Seleccionar naves para la grilla de carga",
       "wishlistTitle": "Añadir naves a tu lista de deseos",
       "labels": {
         "search": "Buscar por nombre o fabricante",
+        "hangarOnly": "Solo mis naves",
+        "containerFit": "Carga a transportar",
         "results": "%{count} naves",
         "selected": "%{count} seleccionadas"
       },
@@ -18,7 +21,8 @@
       "badges": {
         "inHangar": "En el hangar",
         "onWishlist": "En la lista de deseos",
-        "comparing": "En comparación"
+        "comparing": "En comparación",
+        "onCargoGrid": "En la grilla"
       }
     }
   }

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -154,6 +154,9 @@
       "compare": {
         "ships": "Comparer"
       },
+      "cargoGrids": {
+        "addShips": "Ajouter des vaisseaux"
+      },
       "hangar": {
         "editGroups": "Ajouter ou supprimer des groupes",
         "editName": "Nommez votre vaisseau",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1700,9 +1700,8 @@
         "totalCargo": "Cargaison totale",
         "didNotFit": "Ne rentre pas",
         "openInTool": "Ouvrir dans l'outil de grille de cargaison",
-        "myHangar": "Afficher uniquement mes vaisseaux",
-        "filterShips": "Filtrer les vaisseaux par taille de conteneur",
-        "addShip": "Add Ship",
+        "enoughShips": "Quatre vaisseaux remplissent la grille.",
+        "addShip": "Ajouter un vaisseau",
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },

--- a/app/frontend/translations/fr/modelPicker.json
+++ b/app/frontend/translations/fr/modelPicker.json
@@ -3,9 +3,12 @@
     "modelPicker": {
       "hangarTitle": "Ajouter des vaisseaux à votre hangar",
       "compareTitle": "Sélectionner des vaisseaux à comparer",
+      "cargoGridsTitle": "Sélectionner des vaisseaux pour la grille de cargaison",
       "wishlistTitle": "Ajouter des vaisseaux à votre liste de souhaits",
       "labels": {
         "search": "Rechercher par nom ou constructeur",
+        "hangarOnly": "Uniquement mes vaisseaux",
+        "containerFit": "Cargaison à transporter",
         "results": "%{count} vaisseaux",
         "selected": "%{count} sélectionnés"
       },
@@ -18,7 +21,8 @@
       "badges": {
         "inHangar": "Dans le hangar",
         "onWishlist": "Dans la liste de souhaits",
-        "comparing": "En comparaison"
+        "comparing": "En comparaison",
+        "onCargoGrid": "Sur la grille"
       }
     }
   }

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -154,6 +154,9 @@
       "compare": {
         "ships": "Compara"
       },
+      "cargoGrids": {
+        "addShips": "Aggiungi navi"
+      },
       "hangar": {
         "editGroups": "Aggiungi o rimuovi gruppo",
         "editName": "Rinomina la nave",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1700,9 +1700,8 @@
         "totalCargo": "Carico totale",
         "didNotFit": "Non entra",
         "openInTool": "Apri nello strumento griglia di carico",
-        "myHangar": "Mostra solo le mie navi",
-        "filterShips": "Filtra navi per dimensione container",
-        "addShip": "Add Ship",
+        "enoughShips": "Quattro navi riempiono la griglia.",
+        "addShip": "Aggiungi nave",
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },

--- a/app/frontend/translations/it/modelPicker.json
+++ b/app/frontend/translations/it/modelPicker.json
@@ -3,9 +3,12 @@
     "modelPicker": {
       "hangarTitle": "Aggiungi navi al tuo hangar",
       "compareTitle": "Seleziona navi da confrontare",
+      "cargoGridsTitle": "Seleziona navi per la griglia di carico",
       "wishlistTitle": "Aggiungi navi alla tua lista dei desideri",
       "labels": {
         "search": "Cerca per nome o produttore",
+        "hangarOnly": "Solo le mie navi",
+        "containerFit": "Carico da trasportare",
         "results": "%{count} navi",
         "selected": "%{count} selezionate"
       },
@@ -18,7 +21,8 @@
       "badges": {
         "inHangar": "Nell'hangar",
         "onWishlist": "Nella lista dei desideri",
-        "comparing": "Nel confronto"
+        "comparing": "Nel confronto",
+        "onCargoGrid": "Nella griglia"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -154,6 +154,9 @@
       "compare": {
         "ships": "对比"
       },
+      "cargoGrids": {
+        "addShips": "添加飞船"
+      },
       "hangar": {
         "editGroups": "Add or remove Groups",
         "editName": "Name your Ship",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1696,9 +1696,8 @@
         "totalCargo": "总货物",
         "didNotFit": "放不下",
         "openInTool": "在货物网格工具中打开",
-        "myHangar": "仅显示我的飞船",
-        "filterShips": "按集装箱大小筛选飞船",
-        "addShip": "Add Ship",
+        "enoughShips": "四艘飞船已填满网格。",
+        "addShip": "添加飞船",
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },

--- a/app/frontend/translations/zh-CN/modelPicker.json
+++ b/app/frontend/translations/zh-CN/modelPicker.json
@@ -3,9 +3,12 @@
     "modelPicker": {
       "hangarTitle": "将舰船添加到你的机库",
       "compareTitle": "选择要比较的飞船",
+      "cargoGridsTitle": "选择用于货物网格的飞船",
       "wishlistTitle": "将舰船添加到你的愿望清单",
       "labels": {
         "search": "按名称或制造商搜索",
+        "hangarOnly": "仅我的飞船",
+        "containerFit": "要运载的货物",
         "results": "%{count} 艘舰船",
         "selected": "已选择 %{count} 艘"
       },
@@ -18,7 +21,8 @@
       "badges": {
         "inHangar": "已在机库",
         "onWishlist": "已在愿望清单",
-        "comparing": "比较中"
+        "comparing": "比较中",
+        "onCargoGrid": "已在网格"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -154,6 +154,9 @@
       "compare": {
         "ships": "對比"
       },
+      "cargoGrids": {
+        "addShips": "新增飛船"
+      },
       "hangar": {
         "editGroups": "Add or remove Groups",
         "editName": "Name your Ship",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1696,9 +1696,8 @@
         "totalCargo": "總貨物",
         "didNotFit": "放不下",
         "openInTool": "在貨物網格工具中開啟",
-        "myHangar": "僅顯示我的飛船",
-        "filterShips": "按貨櫃大小篩選飛船",
-        "addShip": "Add Ship",
+        "enoughShips": "四艘飛船已填滿網格。",
+        "addShip": "新增飛船",
         "removeShip": "Remove",
         "autoFillShip": "Auto-fill"
       },

--- a/app/frontend/translations/zh-TW/modelPicker.json
+++ b/app/frontend/translations/zh-TW/modelPicker.json
@@ -3,9 +3,12 @@
     "modelPicker": {
       "hangarTitle": "將艦船加入你的機庫",
       "compareTitle": "選擇要比較的飛船",
+      "cargoGridsTitle": "選擇用於貨物網格的飛船",
       "wishlistTitle": "將艦船加入你的願望清單",
       "labels": {
         "search": "依名稱或製造商搜尋",
+        "hangarOnly": "僅我的飛船",
+        "containerFit": "要運載的貨物",
         "results": "%{count} 艘艦船",
         "selected": "已選擇 %{count} 艘"
       },
@@ -18,7 +21,8 @@
       "badges": {
         "inHangar": "已在機庫",
         "onWishlist": "已在願望清單",
-        "comparing": "比較中"
+        "comparing": "比較中",
+        "onCargoGrid": "已在網格"
       }
     }
   }

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -364,6 +364,13 @@ paths:
         style: deepObject
         explode: true
         required: false
+      - name: containerFit
+        in: query
+        schema:
+          "$ref": "#/components/schemas/ContainerFitQuery"
+        style: deepObject
+        explode: true
+        required: false
       responses:
         '200':
           description: successful

--- a/test/integration/api/v1/filters_models_options_test.rb
+++ b/test/integration/api/v1/filters_models_options_test.rb
@@ -20,6 +20,11 @@ class Api::V1::FiltersModelsOptionsTest < ActionDispatch::IntegrationTest
         style: :deepObject,
         explode: true,
         required: false
+      parameter name: "containerFit", in: :query,
+        schema: ::V1::Schemas::Queries::ContainerFitQuery,
+        style: :deepObject,
+        explode: true,
+        required: false
 
       response(200, "successful") do
         schema ::V1::Schemas::Models::Options::ModelOptions
@@ -74,6 +79,51 @@ class Api::V1::FiltersModelsOptionsTest < ActionDispatch::IntegrationTest
       assert_equal ["combat"], items.map { |item| item["classification"] }.uniq
       assert_equal ["Combat"], items.map { |item| item["classificationLabel"] }.uniq
     end
+  end
+
+  test "GET /filters/models/options filters by withCargoGrids" do
+    with_grid = create(:model, :with_store_image)
+    with_grid.update!(cargo_holds: [cargo_hold_attributes])
+    without_grid = create(:model, :with_store_image)
+
+    assert_api_response :get, 200, params: {q: {"withCargoGrids" => true}} do
+      ids = parsed_body["items"].map { |item| item["id"] }
+
+      assert_includes ids, with_grid.id
+      refute_includes ids, without_grid.id
+    end
+  end
+
+  test "GET /filters/models/options filters by containerFit" do
+    roomy = create(:model, :with_store_image)
+    roomy.update!(cargo_holds: [cargo_hold_attributes])
+    cramped = create(:model, :with_store_image)
+    cramped.update!(cargo_holds: [cargo_hold_attributes(capacity: 1, size: 1)])
+
+    assert_api_response :get, 200, params: {containerFit: {"8" => 1}} do
+      ids = parsed_body["items"].map { |item| item["id"] }
+
+      assert_includes ids, roomy.id
+      refute_includes ids, cramped.id
+    end
+  end
+
+  # One hold big enough for `size` SCU containers, in the shape the game files
+  # describe them - the before_save hook turns this into the CargoHold rows and
+  # container capacities both filters query.
+  private def cargo_hold_attributes(capacity: 8, size: 8)
+    dimensions = {"x" => 2.0, "y" => 2.0, "z" => 2.0}
+
+    {
+      "name" => "cargo_#{size}",
+      "capacity" => capacity,
+      "dimensions" => {"x" => 5.0, "y" => 2.5, "z" => 2.5},
+      "max_container_size" => {"size" => size, "dimensions" => dimensions},
+      "limits" => {
+        "min" => {"dimensions" => {"x" => 1.0, "y" => 1.0, "z" => 1.0}, "capacity" => 1},
+        "max" => {"dimensions" => dimensions, "capacity" => capacity}
+      }
+    }
   end
 
   test "GET /filters/models/options marks models the signed in user owns or wants" do

--- a/test/playwright/e2e/CargoGrids.spec.ts
+++ b/test/playwright/e2e/CargoGrids.spec.ts
@@ -1,5 +1,6 @@
 import { app, appScenario } from "../support/on-rails";
 import { test, expect } from "../support/commands";
+import type { Page } from "@playwright/test";
 
 test.describe("Cargo Grids", () => {
   test.beforeEach(async ({ page }) => {
@@ -8,9 +9,21 @@ test.describe("Cargo Grids", () => {
 
     await page.goto("/tools/cargo-grids/");
 
-    // Wait for the filter component to be interactive
-    await page.getByTestId("base-select-cargo-grid-model").waitFor();
+    // Wait for the picker's trigger to be interactive
+    await page.getByTestId("cargo-grid-add-ships").waitFor();
   });
+
+  const pickShips = async (page: Page, ...slugs: string[]) => {
+    await page.getByTestId("cargo-grid-add-ships").click();
+    await page.getByTestId("modal").waitFor({ state: "visible" });
+
+    for (const slug of slugs) {
+      await page.getByTestId(`model-picker-card-${slug}`).click();
+    }
+
+    await page.getByTestId("model-picker-submit").click();
+    await page.getByTestId("modal").waitFor({ state: "hidden" });
+  };
 
   test("Loads the page", async ({ page }) => {
     await expect(page).toHaveURL(/\/tools\/cargo-grids/);
@@ -29,14 +42,7 @@ test.describe("Cargo Grids", () => {
   test("Selects a model and displays the cargo grid viewer", async ({
     page,
   }) => {
-    // Open the model filter dropdown and search for Caterpillar
-    const baseSelect = page.getByTestId("base-select-cargo-grid-model");
-    await baseSelect.getByTestId("base-select-title").click();
-    await baseSelect.locator("input").first().fill("Caterpillar");
-
-    // Wait for search results and select
-    const option = page.getByText("Caterpillar").first();
-    await option.click();
+    await pickShips(page, "drak-caterpillar");
 
     await expect(page).toHaveURL(/ship=drak-caterpillar/);
 
@@ -66,11 +72,11 @@ test.describe("Cargo Grids", () => {
     await expect(clearBtn).toBeVisible();
     await clearBtn.click();
 
-    // All inputs should be 0
+    // Every counter empties out
     const sizes = [1, 2, 4, 8, 16, 24, 32];
     for (const size of sizes) {
       const field = page.locator(`input[name="container-${size}"]`);
-      await expect(field).toHaveValue("0");
+      await expect(field).toHaveValue("");
     }
   });
 
@@ -99,7 +105,7 @@ test.describe("Cargo Grids", () => {
     await page.getByTestId("confirm-ok").click();
 
     // Container inputs should be cleared
-    await expect(page.locator('input[name="container-8"]')).toHaveValue("0");
+    await expect(page.locator('input[name="container-8"]')).toHaveValue("");
 
     // Ship should be removed — viewer gone
     await expect(page.getByTestId("cargo-grid-viewer")).not.toBeVisible();
@@ -112,32 +118,73 @@ test.describe("Cargo Grids", () => {
     await page.locator('input[name="container-8"]').fill("2");
     await page.locator('input[name="container-4"]').fill("3");
 
-    // Click the filter ships button to apply
-    const filterBtn = page.getByText("Filter Ships by Container Size");
-    await expect(filterBtn).toBeVisible();
+    // The viewer draws the load on its own, with no ship to pack it into
+    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
   });
 
-  test("Adds multiple ships by selecting from the same filter", async ({
-    page,
-  }) => {
-    // Select first ship
-    const baseSelect = page.getByTestId("base-select-cargo-grid-model");
-    await baseSelect.getByTestId("base-select-title").click();
-    await baseSelect.locator("input").first().fill("Caterpillar");
-    await page.getByText("Caterpillar").first().click();
+  test("Adds several ships in one visit to the picker", async ({ page }) => {
+    await pickShips(page, "drak-caterpillar", "misc-freelancer-max");
 
-    // First ship should appear in viewer
-    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
-
-    // Select second ship
-    await baseSelect.getByTestId("base-select-title").click();
-    await baseSelect.locator("input").first().fill("Freelancer");
-    await page.getByText("Freelancer MAX").first().click();
-
-    // Multi-ship stats should appear
     await expect(
       page.getByTestId("cargo-grid-viewer-multi-stats"),
     ).toBeVisible();
+  });
+
+  test("Adds a second ship in a later visit to the picker", async ({
+    page,
+  }) => {
+    await pickShips(page, "drak-caterpillar");
+
+    await expect(page.getByTestId("cargo-grid-viewer")).toBeVisible();
+
+    await pickShips(page, "misc-freelancer-max");
+
+    await expect(
+      page.getByTestId("cargo-grid-viewer-multi-stats"),
+    ).toBeVisible();
+  });
+
+  test("Marks a ship already on the grid as unpickable", async ({ page }) => {
+    await pickShips(page, "drak-caterpillar");
+
+    await page.getByTestId("cargo-grid-add-ships").click();
+    await page.getByTestId("modal").waitFor({ state: "visible" });
+
+    await expect(
+      page.getByTestId("model-picker-card-drak-caterpillar"),
+    ).toHaveClass(/model-card--disabled/);
+  });
+
+  test("Offers only ships the typed load fits into", async ({ page }) => {
+    // 3x 32 SCU is more than the Caterpillar's holds take, and more than the
+    // Freelancer MAX has room for at all.
+    await page.locator('input[name="container-32"]').fill("3");
+
+    await page.getByTestId("cargo-grid-add-ships").click();
+    await page.getByTestId("modal").waitFor({ state: "visible" });
+
+    // The filter arrives filled in, and it is the picker's own count that shows
+    // what is being asked for.
+    await expect(
+      page.locator('input[name="model-picker-container-32"]'),
+    ).toHaveValue("3");
+
+    await expect(
+      page.getByTestId("model-picker-card-drak-caterpillar"),
+    ).toHaveCount(0);
+
+    // Widening the filter in the modal brings them back without touching the
+    // load the page is holding.
+    await page.locator('input[name="model-picker-container-32"]').fill("");
+
+    await expect(
+      page.getByTestId("model-picker-card-drak-caterpillar"),
+    ).toBeVisible();
+
+    await page.locator(".modal-header a.close").click();
+    await page.getByTestId("modal").waitFor({ state: "hidden" });
+
+    await expect(page.locator('input[name="container-32"]')).toHaveValue("3");
   });
 
   test("Loads multiple ships via URL and shows unified viewer with multi-ship stats", async ({


### PR DESCRIPTION
The cargo grids tool now picks ships through the same modal as compare, instead of a single-value dropdown that had to be reopened once per ship.

## What changed

**The picker replaces the dropdown.** One "Add Ship" button opens the shared `Models/PickerModal` — a grid of ship cards with search, manufacturer and classification filters, a selection tray, and up to four ships in one visit. Ships already on the grid are shown, marked, and unpickable.

**The two filters that sat beside the dropdown moved or went away.** The hangar toggle now lives inside the picker, next to the manufacturer and classification filters it belongs with (and is hidden from signed-out visitors, who have no hangar to filter by). The load typed into the container counters is carried over as the picker's container filter, editable there — widening it in the modal leaves the page's load alone. That left "Filter Ships by Container Size" doing exactly what the add button does, so it is gone; the counters keep their Clear.

**The counters no longer pre-fill with zero.** A row of seven zeroes hid which sizes were actually being asked for. An empty counter is now silent, a filled one is marked — in the picker and on the page alike.

**API.** The picker's options endpoint (`/filters/models/options`) had no way to be told which ships the caller can display. It now accepts `q[withCargoGrids]` and a `containerFit` map, both of which already existed on the models index; the two scopes moved to a concern so the endpoints answer the same question the same way. New integration tests cover both.

**Also fixed:** cientos defaults an `Html` overlay's z-index range to 16777271, so the 3D viewer's ship labels floated over everything — a modal opened from this tool had ship names printed across it. Capped to clear only the canvas they label.

## Verified

- `test/integration/api/v1/filters_models_options_test.rb` — 8 tests green, including the two new filters
- `standardrb`, `vue-tsc`, `tsc`, `eslint`, `prettier` all clean
- Every `t()` key introduced resolves in all seven locales

`test/playwright/e2e/CargoGrids.spec.ts` is rewritten for the modal flow but **was not run to completion locally** — `page.goto` times out against the local e2e server regardless of these changes (the two-thread test server stalls on the page's module fan-out), so CI is the first full run of it. Worth a look at the e2e job.

🤖
