### PR TITLE
fix(admin): stop flashing access denied while the session loads

### DIFF
--- a/app/frontend/admin/App.vue
+++ b/app/frontend/admin/App.vue
@@ -131,7 +131,11 @@ onUnmounted(() => {
   }
 });
 
-const { data: user, refetch: refetchCurrentUser } = useMeQuery({
+const {
+  data: user,
+  isError: currentUserFailed,
+  refetch: refetchCurrentUser,
+} = useMeQuery({
   query: {
     enabled: isAuthenticated,
   },
@@ -144,6 +148,16 @@ watch(
       sessionStore.currentUser = user.value;
     }
   },
+);
+
+// A reload restores `authenticated` from storage but not the user it belongs to, so
+// the access check has no privileges to match against until `me` comes back. Denying
+// on that gap flashes "access denied" on every page whose route declares an `access`.
+const currentUserUnknown = computed(
+  () =>
+    isAuthenticated.value &&
+    !sessionStore.currentUser &&
+    !currentUserFailed.value,
 );
 
 const setNoScroll = () => {
@@ -182,8 +196,9 @@ const setNoScroll = () => {
 
           <router-view v-slot="{ Component, route: viewRoute }">
             <AccessCheck
-              :resource-access="user?.resourceAccess"
-              :super-admin="user?.superAdmin"
+              :resource-access="sessionStore.currentUser?.resourceAccess"
+              :super-admin="sessionStore.currentUser?.superAdmin"
+              :loading="currentUserUnknown"
             >
               <template #granted>
                 <transition name="fade" mode="out-in">

--- a/app/frontend/admin/components/AccessCheck.spec.ts
+++ b/app/frontend/admin/components/AccessCheck.spec.ts
@@ -1,0 +1,66 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import { defineComponent, h } from "vue";
+import { createRouter, createWebHashHistory } from "vue-router";
+import Component from "./AccessCheck.vue";
+
+const Page = defineComponent({ render: () => h("div") });
+
+const restrictedRouter = async () => {
+  const router = createRouter({
+    history: createWebHashHistory(),
+    routes: [
+      {
+        path: "/",
+        name: "admin-models",
+        component: Page,
+        meta: { access: ["models"] },
+      },
+      // NotAuthorized links back to it, so resolving the denied state needs it.
+      { path: "/home", name: "home", component: Page },
+    ],
+  });
+
+  await router.push("/");
+  await router.isReady();
+
+  return router;
+};
+
+const mount = async (props: InstanceType<typeof Component>["$props"]) =>
+  mountWithDefaults<typeof Component>(Component, {
+    props,
+    slots: { granted: () => [h("div", { class: "page" })] },
+    plugins: [await restrictedRouter()],
+  });
+
+describe("AdminAccessCheck", () => {
+  it("waits instead of denying while the current user is still unknown", async () => {
+    const wrapper = await mount({ loading: true });
+
+    expect(wrapper.findComponent({ name: "NotAuthorized" }).exists()).toBe(
+      false,
+    );
+    expect(wrapper.find(".page").exists()).toBe(false);
+  });
+
+  it("denies once the user is known to lack the privilege", async () => {
+    const wrapper = await mount({ resourceAccess: ["users"] });
+
+    expect(wrapper.findComponent({ name: "NotAuthorized" }).exists()).toBe(
+      true,
+    );
+  });
+
+  it("renders the page for a user holding the privilege", async () => {
+    const wrapper = await mount({ resourceAccess: ["models"] });
+
+    expect(wrapper.find(".page").exists()).toBe(true);
+  });
+
+  it("renders the page for a super admin", async () => {
+    const wrapper = await mount({ superAdmin: true });
+
+    expect(wrapper.find(".page").exists()).toBe(true);
+  });
+});

--- a/app/frontend/admin/components/AccessCheck.vue
+++ b/app/frontend/admin/components/AccessCheck.vue
@@ -6,14 +6,20 @@ export default {
 
 <script lang="ts" setup>
 import NotAuthorized from "@/shared/components/NotAuthorized/index.vue";
+import Loader from "@/shared/components/Loader/index.vue";
 import { checkAccess } from "@/shared/utils/Access";
 
 type Props = {
   resourceAccess?: string[];
   superAdmin?: boolean;
+  loading?: boolean;
 };
 
-const props = defineProps<Props>();
+const props = withDefaults(defineProps<Props>(), {
+  resourceAccess: undefined,
+  superAdmin: false,
+  loading: false,
+});
 
 const route = useRoute();
 
@@ -25,7 +31,10 @@ const accessDenied = computed(() => {
 </script>
 
 <template>
-  <slot v-if="accessDenied" name="denied">
+  <slot v-if="loading" name="loading">
+    <Loader :loading="true" />
+  </slot>
+  <slot v-else-if="accessDenied" name="denied">
     <NotAuthorized />
   </slot>
   <slot v-else name="granted"></slot>


### PR DESCRIPTION
Reloading an admin page showed **Access denied** for a moment before the page appeared.

## Why

`useSessionStore` persists only `authenticated`, not the user it belongs to. On a reload the router guard therefore lets the page straight through, but `AccessCheck` was reading `resourceAccess` off the in-flight `me` query. With nothing to match against, `checkAccess(undefined, ["models"])` answers `false` — so every admin route that declares an `access` rendered `NotAuthorized` until the request landed.

The dashboard declares no `access`, which is why it looked intermittent rather than universal.

## What changed

- `AccessCheck` gets a `loading` state that renders a `Loader` — the same thing `AsyncData` does while it waits. "Not known yet" is now a different answer from "known to lack the privilege", instead of collapsing into a denial.
- `App.vue` passes it `isAuthenticated && !currentUser && !meFailed`. Gating on the error matters at both ends: a 401 flips `authenticated` false through the axios interceptor, and a 500 stops the loader short of standing there forever.
- The access props now read from the session store, which `login()` fills synchronously. That covers the post-login redirect, where the query is also still fetching.

## Verification

Four tests in `AccessCheck.spec.ts`. The loading one fails against the old template and passes against the new one, so it pins the regression rather than just describing it. `vue-tsc`, `tsc`, eslint and prettier are clean.

## Not in scope

The nav reads the same store, so its items still fill in as `me` lands. That is ordinary loading rather than a false error, so I left it alone.

🤖