### PR TITLE
fix(notifications): stand the placeholders in the frame the records land in

### DIFF
--- a/app/frontend/admin/components/Notifications/ListItem/index.vue
+++ b/app/frontend/admin/components/Notifications/ListItem/index.vue
@@ -220,9 +220,16 @@ defineExpose({ focus: () => select.value?.focus() });
 
 .notification-item__icon {
   flex-shrink: 0;
+  // A fixed footprint rather than the glyph's own. The icon comes from the
+  // notification type, its glyphs are not all the same width, and a column of
+  // titles that steps in and out by a few pixels a row reads as a list that
+  // cannot line itself up. 1.25em is the width a duotone glyph is drawn in, so
+  // nothing is clipped and the placeholders can reserve the same.
+  width: 1.25em;
   margin-top: 2px;
   color: $gray-lighter;
   font-size: 1.15em;
+  text-align: center;
 }
 
 .notification-item--unread .notification-item__icon {

--- a/app/frontend/admin/pages/notifications.vue
+++ b/app/frontend/admin/pages/notifications.vue
@@ -11,6 +11,7 @@ import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import Empty from "@/shared/components/Empty/index.vue";
 import ListSkeleton from "@/shared/components/ListSkeleton/index.vue";
 import { useReportListGeometry } from "@/shared/composables/useListGeometry";
 import BulkSelectionBar from "@/shared/components/BulkSelectionBar/index.vue";
@@ -136,6 +137,10 @@ const list = ref<ComponentPublicInstance>();
 // is as tall as its own two lines or the controls beside them, whichever wins,
 // and only the rendered row knows which.
 useReportListGeometry("row", list, {
+  // Named rather than injected: the geometry is provided by the FilteredList
+  // this page renders, and inject only looks upwards - so the measurements of
+  // a list drawn in that list's slot have to be filed under its name.
+  name: "admin-notifications",
   ready: () => !!records.value.length,
   pick: (host) => host.firstElementChild,
 });
@@ -332,13 +337,21 @@ const destroySelected = () =>
 <template>
   <Heading hero>
     {{ t("headlines.admin.notifications.index") }}
-    <HeadingSmall v-if="notifications">
-      {{
-        t("headlines.pagination.count", {
-          current: notifications?.items.length,
-          total: notifications?.meta.pagination?.totalCount,
-        })
-      }}
+    <!-- The line is reserved whether or not the count is known yet: rendered
+         only once the answer is in, the heading grows by its height the moment
+         the first page lands and takes the whole page down with it. -->
+    <HeadingSmall>
+      <template v-if="notifications">
+        {{
+          t("headlines.pagination.count", {
+            current: notifications?.items.length,
+            total: notifications?.meta.pagination?.totalCount,
+          })
+        }}
+      </template>
+      <!-- A non-breaking space, so the line is exactly as tall as the one it
+           stands in for. -->
+      <template v-else>&nbsp;</template>
     </HeadingSmall>
   </Heading>
 
@@ -365,11 +378,15 @@ const destroySelected = () =>
     </Btn>
   </Teleport>
 
+  <!-- `hide-empty`, because the page draws that state itself: the list's own
+       box stands in place of the whole default slot, which on this page is the
+       selection bar, the list and the reading pane together. -->
   <FilteredList
     name="admin-notifications"
     :records="records"
     :async-status="asyncStatus"
     :is-filter-selected="isFilterSelected"
+    hide-empty
   >
     <template #filter>
       <FilterForm />
@@ -415,13 +432,41 @@ const destroySelected = () =>
         }}
       </Btn>
     </template>
-    <template #skeleton>
-      <ListSkeleton />
-    </template>
-
-    <template #default="{ records: shown }">
+    <!-- The frame the records land in, not only the rows in it. From the
+         two-pane breakpoint up the reading pane takes the greater part of the
+         row, so a full-width column of placeholders would reflow to 38% of its
+         width the moment the first page arrived - and the selection bar above
+         them would push the whole list down by its height. Both are the real
+         ones in the state they are about to be in: nothing selected, nothing
+         open. The rows carry a checkbox for the same reason, since it takes the
+         row's left inset over from the title. -->
+    <template #skeleton="{ count }">
       <BulkSelectionBar
         class="admin-notifications__bulk"
+        :selected-count="0"
+        :matching-count="0"
+        :page-selected="false"
+        :page-partially-selected="false"
+        :can-select-all-matching="false"
+        :all-matching-selected="false"
+        disabled
+      />
+
+      <div class="admin-notifications">
+        <ListSkeleton
+          class="admin-notifications__list"
+          :count="count"
+          selectable
+        />
+
+        <Detail class="admin-notifications__detail" />
+      </div>
+    </template>
+
+    <template #default="{ records: shown, emptyVisible }">
+      <BulkSelectionBar
+        class="admin-notifications__bulk"
+        :disabled="!shown.length"
         :class="{ 'admin-notifications__bulk--hidden': !!selected }"
         :selected-count="selectedCount"
         :matching-count="matchingCount"
@@ -488,6 +533,7 @@ const destroySelected = () =>
         :class="{ 'admin-notifications--reading': !!selected }"
       >
         <TransitionGroup
+          v-if="!emptyVisible"
           tag="ul"
           name="fade-list"
           ref="list"
@@ -516,6 +562,14 @@ const destroySelected = () =>
             />
           </li>
         </TransitionGroup>
+
+        <!-- In the list's own column rather than in place of the page: an
+             empty inbox is still a two-pane page, and putting the box where
+             the list itself sits leaves the selection bar and the reading pane
+             where they were. -->
+        <div v-else class="admin-notifications__list">
+          <Empty variant="box" />
+        </div>
 
         <Detail
           class="admin-notifications__detail"

--- a/app/frontend/frontend/components/Notifications/ListItem/index.vue
+++ b/app/frontend/frontend/components/Notifications/ListItem/index.vue
@@ -211,9 +211,16 @@ defineExpose({ focus: () => select.value?.focus() });
 
 .notification-item__icon {
   flex-shrink: 0;
+  // A fixed footprint rather than the glyph's own. The icon comes from the
+  // notification type, its glyphs are not all the same width, and a column of
+  // titles that steps in and out by a few pixels a row reads as a list that
+  // cannot line itself up. 1.25em is the width a duotone glyph is drawn in, so
+  // nothing is clipped and the placeholders can reserve the same.
+  width: 1.25em;
   margin-top: 2px;
   color: $gray-lighter;
   font-size: 1.15em;
+  text-align: center;
 }
 
 .notification-item--unread .notification-item__icon {

--- a/app/frontend/frontend/pages/notifications.vue
+++ b/app/frontend/frontend/pages/notifications.vue
@@ -11,6 +11,7 @@ import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
+import Empty from "@/shared/components/Empty/index.vue";
 import ListSkeleton from "@/shared/components/ListSkeleton/index.vue";
 import { useReportListGeometry } from "@/shared/composables/useListGeometry";
 import BulkSelectionBar from "@/shared/components/BulkSelectionBar/index.vue";
@@ -134,6 +135,10 @@ const list = ref<ComponentPublicInstance>();
 // is as tall as its own two lines or the controls beside them, whichever wins,
 // and only the rendered row knows which.
 useReportListGeometry("row", list, {
+  // Named rather than injected: the geometry is provided by the FilteredList
+  // this page renders, and inject only looks upwards - so the measurements of
+  // a list drawn in that list's slot have to be filed under its name.
+  name: "notifications",
   ready: () => !!records.value.length,
   pick: (host) => host.firstElementChild,
 });
@@ -325,13 +330,21 @@ const destroySelected = () =>
 <template>
   <Heading hero>
     {{ t("headlines.notifications.index") }}
-    <HeadingSmall v-if="notifications">
-      {{
-        t("headlines.pagination.count", {
-          current: notifications?.items.length,
-          total: notifications?.meta.pagination?.totalCount,
-        })
-      }}
+    <!-- The line is reserved whether or not the count is known yet: rendered
+         only once the answer is in, the heading grows by its height the moment
+         the first page lands and takes the whole page down with it. -->
+    <HeadingSmall>
+      <template v-if="notifications">
+        {{
+          t("headlines.pagination.count", {
+            current: notifications?.items.length,
+            total: notifications?.meta.pagination?.totalCount,
+          })
+        }}
+      </template>
+      <!-- A non-breaking space, so the line is exactly as tall as the one it
+           stands in for. -->
+      <template v-else>&nbsp;</template>
     </HeadingSmall>
   </Heading>
 
@@ -367,11 +380,15 @@ const destroySelected = () =>
     </Btn>
   </Teleport>
 
+  <!-- `hide-empty`, because the page draws that state itself: the list's own
+       box stands in place of the whole default slot, which on this page is the
+       selection bar, the list and the reading pane together. -->
   <FilteredList
     name="notifications"
     :records="records"
     :async-status="asyncStatus"
     :is-filter-selected="isFilterSelected"
+    hide-empty
   >
     <template #filter>
       <FilterForm />
@@ -417,13 +434,37 @@ const destroySelected = () =>
         }}
       </Btn>
     </template>
-    <template #skeleton>
-      <ListSkeleton />
-    </template>
-
-    <template #default="{ records: shown }">
+    <!-- The frame the records land in, not only the rows in it. From the
+         two-pane breakpoint up the reading pane takes the greater part of the
+         row, so a full-width column of placeholders would reflow to 38% of its
+         width the moment the first page arrived - and the selection bar above
+         them would push the whole list down by its height. Both are the real
+         ones in the state they are about to be in: nothing selected, nothing
+         open. The rows carry a checkbox for the same reason, since it takes the
+         row's left inset over from the title. -->
+    <template #skeleton="{ count }">
       <BulkSelectionBar
         class="notifications__bulk"
+        :selected-count="0"
+        :matching-count="0"
+        :page-selected="false"
+        :page-partially-selected="false"
+        :can-select-all-matching="false"
+        :all-matching-selected="false"
+        disabled
+      />
+
+      <div class="notifications">
+        <ListSkeleton class="notifications__list" :count="count" selectable />
+
+        <Detail class="notifications__detail" />
+      </div>
+    </template>
+
+    <template #default="{ records: shown, emptyVisible }">
+      <BulkSelectionBar
+        class="notifications__bulk"
+        :disabled="!shown.length"
         :class="{ 'notifications__bulk--hidden': !!selected }"
         :selected-count="selectedCount"
         :matching-count="matchingCount"
@@ -490,6 +531,7 @@ const destroySelected = () =>
         :class="{ 'notifications--reading': !!selected }"
       >
         <TransitionGroup
+          v-if="!emptyVisible"
           tag="ul"
           name="fade-list"
           ref="list"
@@ -518,6 +560,14 @@ const destroySelected = () =>
             />
           </li>
         </TransitionGroup>
+
+        <!-- In the list's own column rather than in place of the page: an
+             empty inbox is still a two-pane page, and putting the box where
+             the list itself sits leaves the selection bar and the reading pane
+             where they were. -->
+        <div v-else class="notifications__list">
+          <Empty variant="box" />
+        </div>
 
         <Detail
           class="notifications__detail"

--- a/app/frontend/frontend/pages/visual-tests/lists.vue
+++ b/app/frontend/frontend/pages/visual-tests/lists.vue
@@ -76,6 +76,10 @@ const buildDocks = (): Dock[] => [
 
 const listGroupItems = ref(buildDocks());
 
+// Up by default: the placeholders are the state worth looking at, and the
+// toggle is there to watch them go.
+const listGroupLoading = ref(true);
+
 // ── InlineEditableList | full ────────────────────────────────────────
 
 type EditableListRef = {
@@ -183,6 +187,8 @@ const resetDocks = () => {
 
 const readOnlyDocks = ref(buildDocks());
 
+const editableListLoading = ref(true);
+
 // ── FilteredList ─────────────────────────────────────────────────────
 
 const filteredListLoading = ref(false);
@@ -230,8 +236,19 @@ const toggleFilteredListEmpty = () => {
   <Heading :level="HeadingLevelEnum.H2">ListGroup</Heading>
   <p>
     The plain list container behind the editable list — rows with a display and
-    an actions area, plus its own loading and empty states.
+    an actions area, plus its own loading and empty states. While it waits it
+    holds itself open with placeholder rows built to the recipe of the row each
+    one stands in for.
   </p>
+  <div class="vt-row">
+    <Btn
+      :active="listGroupLoading"
+      data-test="toggle-list-group-loading"
+      @click="listGroupLoading = !listGroupLoading"
+    >
+      Loading
+    </Btn>
+  </div>
   <div class="row">
     <div class="col-12 col-xl-6">
       <ListGroup :items="listGroupItems" empty-name="Docks">
@@ -249,7 +266,22 @@ const toggleFilteredListEmpty = () => {
       </ListGroup>
     </div>
     <div class="col-12 col-xl-6">
-      <ListGroup :items="[]" empty-name="Docks" loading />
+      <!-- Beside the list on the left, and reserving as many rows as that one
+           holds: the placeholders and the rows they stand in for are only
+           readable held against each other. The actions slot is passed for the
+           same reason - a row with buttons in it is as tall as those. -->
+      <ListGroup
+        :items="[]"
+        empty-name="Docks"
+        :loading="listGroupLoading"
+        :skeleton-rows="listGroupItems.length"
+      >
+        <template #actions>
+          <Btn>
+            <i class="fa-duotone fa-arrow-right" />
+          </Btn>
+        </template>
+      </ListGroup>
       <ListGroup :items="[]" empty-name="Docks" />
     </div>
   </div>
@@ -386,10 +418,28 @@ const toggleFilteredListEmpty = () => {
   <Heading :level="HeadingLevelEnum.H2">
     InlineEditableList | Loading & Empty
   </Heading>
-  <p>Both states are delegated to the underlying ListGroup.</p>
+  <p>
+    Both states are delegated to the underlying ListGroup. Every row of an
+    editable list carries the edit and destroy buttons, so its placeholders
+    reserve the control height rather than a line of text.
+  </p>
+  <div class="vt-row">
+    <Btn
+      :active="editableListLoading"
+      data-test="toggle-editable-list-loading"
+      @click="editableListLoading = !editableListLoading"
+    >
+      Loading
+    </Btn>
+  </div>
   <div class="row">
     <div class="col-12 col-xl-6">
-      <InlineEditableList :items="[]" empty-name="Docks" loading />
+      <InlineEditableList
+        :items="[]"
+        empty-name="Docks"
+        :loading="editableListLoading"
+        :skeleton-rows="4"
+      />
     </div>
     <div class="col-12 col-xl-6">
       <InlineEditableList :items="[]" empty-name="Docks" />

--- a/app/frontend/frontend/pages/visual-tests/notification-center.vue
+++ b/app/frontend/frontend/pages/visual-tests/notification-center.vue
@@ -11,6 +11,9 @@ import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import NotificationsListItem from "@/frontend/components/Notifications/ListItem/index.vue";
 import NotificationsDetail from "@/frontend/components/Notifications/Detail/index.vue";
 import ListSkeleton from "@/shared/components/ListSkeleton/index.vue";
+import BulkSelectionBar from "@/shared/components/BulkSelectionBar/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import { NotificationTypeEnum, type Notification } from "@/services/fyApi";
 
 /*
@@ -120,6 +123,15 @@ const selected = computed(() =>
   listed.find((item) => item.id === selectedId.value),
 );
 
+// The bar's three states, which the checkbox does a different thing in each of.
+type BulkState = "none" | "some" | "page";
+
+const bulkState = ref<BulkState>("some");
+
+const bulkCounts: Record<BulkState, number> = { none: 0, some: 3, page: 25 };
+
+const bulkSelectedCount = computed(() => bulkCounts[bulkState.value]);
+
 const log = ref<string[]>([]);
 
 const record = (entry: string) => {
@@ -173,19 +185,114 @@ const record = (entry: string) => {
   <p>
     What the list puts up while its first page is on its way, beside the rows it
     stands in for. The two are the check on each other: same surface, same
-    spacing, same height, so nothing moves when the records land.
+    spacing, same height, so nothing moves when the records land. The rows of
+    both notification pages are selectable, and the checkbox takes the row's
+    left inset over from the title — so a placeholder without one stands the
+    icon and both lines 35px left of where they land.
   </p>
   <div class="row">
     <div class="col-12 col-lg-6">
       <ul class="vt-notifications" data-test="waiting-rows">
         <li v-for="item in listed" :key="item.id">
+          <NotificationsListItem :notification="item" selectable />
+        </li>
+      </ul>
+    </div>
+    <div class="col-12 col-lg-6">
+      <ListSkeleton :count="listed.length" selectable />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2"
+    >ListItem | Waiting | No selection</Heading
+  >
+  <p>
+    The same pair for a list whose rows carry no checkbox, which is what
+    ListSkeleton draws by default.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <ul class="vt-notifications" data-test="waiting-rows-plain">
+        <li v-for="item in listed.slice(0, 2)" :key="item.id">
           <NotificationsListItem :notification="item" />
         </li>
       </ul>
     </div>
     <div class="col-12 col-lg-6">
-      <ListSkeleton :count="listed.length" />
+      <ListSkeleton :count="2" />
     </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">BulkSelectionBar</Heading>
+  <p>
+    The header over the list. It keeps its height while nothing is ticked, so
+    ticking a row does not push the list out from under the pointer — the count
+    and the actions are hidden rather than absent. The checkbox does a different
+    thing in each of the three states, and its tooltip says which: an empty box
+    ticks the page, a full one unticks it, and a minus box clears the rows the
+    reader picked one by one rather than growing them to the whole page.
+  </p>
+  <div class="vt-row">
+    <Btn
+      v-for="state in ['none', 'some', 'page'] as BulkState[]"
+      :key="state"
+      :active="bulkState === state"
+      :data-test="`bulk-state-${state}`"
+      @click="bulkState = state"
+    >
+      {{ state }}
+    </Btn>
+  </div>
+  <div class="vt-stack" data-test="bulk-bars">
+    <BulkSelectionBar
+      :selected-count="bulkSelectedCount"
+      :matching-count="30"
+      :page-selected="bulkState === 'page'"
+      :page-partially-selected="bulkState === 'some'"
+      :can-select-all-matching="bulkState === 'page'"
+      :all-matching-selected="false"
+      @toggle-page="bulkState = $event ? 'page' : 'none'"
+      @select-all-matching="record('select-all-matching')"
+      @clear="bulkState = 'none'"
+    >
+      <Btn><i class="fa-duotone fa-envelope-open" /></Btn>
+      <Btn><i class="fa-duotone fa-envelope-dot" /></Btn>
+      <Btn><i class="fa-duotone fa-box-archive" /></Btn>
+      <Btn :tone="BtnTonesEnum.DANGER"><i class="fa-duotone fa-trash" /></Btn>
+    </BulkSelectionBar>
+
+    <!-- A phone's column, where the bar wraps: the checkbox stays on the
+         count's line instead of centring itself against a two-line bar. -->
+    <div class="vt-narrow" data-test="bulk-bar-narrow">
+      <BulkSelectionBar
+        :selected-count="bulkSelectedCount"
+        :matching-count="30"
+        :page-selected="bulkState === 'page'"
+        :page-partially-selected="bulkState === 'some'"
+        :can-select-all-matching="false"
+        :all-matching-selected="false"
+        @toggle-page="bulkState = $event ? 'page' : 'none'"
+        @clear="bulkState = 'none'"
+      >
+        <Btn><i class="fa-duotone fa-envelope-open" /></Btn>
+        <Btn><i class="fa-duotone fa-envelope-dot" /></Btn>
+        <Btn><i class="fa-duotone fa-box-archive" /></Btn>
+        <Btn :tone="BtnTonesEnum.DANGER"><i class="fa-duotone fa-trash" /></Btn>
+      </BulkSelectionBar>
+    </div>
+
+    <!-- Nothing to tick: the list came back empty, and the box says so rather
+         than offering an action that would do nothing. -->
+    <BulkSelectionBar
+      data-test="bulk-bar-disabled"
+      :selected-count="0"
+      :matching-count="0"
+      :page-selected="false"
+      :page-partially-selected="false"
+      :can-select-all-matching="false"
+      :all-matching-selected="false"
+      disabled
+    />
   </div>
 
   <Heading :level="HeadingLevelEnum.H2">Detail | With a notification</Heading>
@@ -285,5 +392,12 @@ const record = (entry: string) => {
   margin: 0;
   padding: 0;
   list-style: none;
+}
+
+// A phone's column, held at that width on a desktop: the bar wraps here, and
+// the wrap is the state worth looking at.
+.vt-narrow {
+  width: 320px;
+  outline: 1px dashed rgba(#fff, 0.15);
 }
 </style>

--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -154,6 +154,17 @@ const updatePerPage = (value: number | string) => {
     </div>
   </div>
 
+  <Heading :level="HeadingLevelEnum.H3">Empty | In a narrow column</Heading>
+  <p>
+    The box is not always as wide as the page: the notification pages stand it
+    in the list's own column, beside the reading pane. Its 600px is a ceiling
+    rather than a width, and the headline wraps inside the box rather than
+    running over whatever sits next to it.
+  </p>
+  <div class="vt-narrow-column" data-test="empty-narrow">
+    <Empty :variant="EmptyVariantsEnum.BOX" hide-actions />
+  </div>
+
   <Heading :level="HeadingLevelEnum.H2">Loader</Heading>
   <p>
     The cube loader. <code>relative</code> and <code>inline</code> sit in the
@@ -339,3 +350,12 @@ const updatePerPage = (value: number | string) => {
     </div>
   </div>
 </template>
+
+<style lang="scss" scoped>
+// The width the notifications list column has on a desktop, which is where the
+// box was overflowing.
+.vt-narrow-column {
+  width: 361px;
+  outline: 1px dashed rgba(#fff, 0.15);
+}
+</style>

--- a/app/frontend/shared/components/Box/index.scss
+++ b/app/frontend/shared/components/Box/index.scss
@@ -3,13 +3,19 @@
 }
 
 @media (min-width: $tablet-breakpoint) {
+  // Ceilings rather than widths. A box is usually centred in a page and these
+  // are the widths it holds there, but it also stands inside a column of a
+  // page now - the notification pages put the empty box where the list itself
+  // sits, beside the reading pane - and a fixed 600px there ran the box and
+  // everything in it over whatever was next to it.
   .box {
-    width: 350px;
+    width: 100%;
+    max-width: 350px;
     margin: 0 auto 20px;
     margin-top: 6%;
 
     &.box-large {
-      width: 600px;
+      max-width: 600px;
     }
   }
 }

--- a/app/frontend/shared/components/BulkSelectionBar/index.scss
+++ b/app/frontend/shared/components/BulkSelectionBar/index.scss
@@ -6,7 +6,12 @@
   align-items: center;
   flex-wrap: wrap;
   gap: 10px;
-  min-height: 34px;
+  // As tall as a bar whose actions are buttons, whether or not it is holding
+  // any: the placeholders a loading list puts up draw this bar with an empty
+  // slot, and a bar that grows by 17px the moment the records land takes the
+  // whole list down with it. The token is the one the buttons are sized from,
+  // plus the bar's own insets.
+  min-height: calc(var(--field-h, 43px) + 8px);
   padding: 4px 8px 4px 10px;
 
   // The checkbox ships with a form field's bottom margin, which a toolbar row
@@ -16,21 +21,24 @@
   }
 }
 
+// The checkbox and the count, held together as one flex item. The bar wraps,
+// and the two are on the same line of it however narrow it gets - which is the
+// difference between a select-all that sits beside what it counts and one
+// centred against a two-line bar, level with the buttons at the far end.
+.bulk-selection-bar__lead {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
 // Kept in place rather than removed while nothing is ticked: the bar sits
 // directly above the list, and a row that grows the moment a checkbox is
 // clicked pushes the list out from under the pointer. `visibility` also takes
 // it off the tab order and out of the accessibility tree, so there is nothing
 // to reach while it is empty.
-.bulk-selection-bar__body {
-  display: flex;
-  align-items: center;
-  flex: 1;
-  flex-wrap: wrap;
-  gap: 10px;
-  min-width: 0;
-}
-
-.bulk-selection-bar__body--empty {
+.bulk-selection-bar__count--empty,
+.bulk-selection-bar__actions--empty {
   visibility: hidden;
 }
 

--- a/app/frontend/shared/components/BulkSelectionBar/index.vue
+++ b/app/frontend/shared/components/BulkSelectionBar/index.vue
@@ -37,33 +37,64 @@ const { t } = useI18n();
 
 const hasSelection = computed(() => props.selectedCount > 0);
 
-const pageLabel = computed(() =>
-  props.pageSelected
-    ? t("bulkSelection.actions.unselectPage")
-    : t("bulkSelection.actions.selectPage"),
-);
+// Three states, three things the box does - and the label has to say which,
+// since a minus box that clears is not what a minus box does everywhere. It
+// stays on the control as its accessible name while the box is disabled and
+// the tooltip does not, because there is nothing to hover about a list with no
+// rows to tick.
+const pageLabel = computed(() => {
+  if (props.pagePartiallySelected) {
+    return t("bulkSelection.actions.clear");
+  }
+
+  if (props.pageSelected) {
+    return t("bulkSelection.actions.unselectPage");
+  }
+
+  return t("bulkSelection.actions.selectPage");
+});
+
+// A minus box means the reader ticked some of the page row by row, and the way
+// out of that is to drop the selection rather than to grow it to all 25:
+// "select everything here" is not the undo for "I picked these three". Ticking
+// the whole page from a partial one is then two clicks - clear, then tick -
+// which is the rarer of the two moves.
+const onTogglePage = (value?: boolean) => {
+  if (props.pagePartiallySelected) {
+    emit("clear");
+
+    return;
+  }
+
+  emit("toggle-page", !!value);
+};
 </script>
 
 <template>
   <div class="bulk-selection-bar" data-test="bulk-selection-bar">
-    <FormCheckbox
-      :model-value="props.pageSelected"
-      :partial="props.pagePartiallySelected"
-      :disabled="props.disabled"
-      v-tooltip="pageLabel"
-      :aria-label="pageLabel"
-      name="bulk-selection-page"
-      data-test="bulk-select-page"
-      no-label
-      inline
-      @update:model-value="emit('toggle-page', $event)"
-    />
+    <!-- The checkbox and the count it belongs to are one line and stay one
+         line. The bar wraps on a phone, and with the count free to wrap on its
+         own the checkbox was centred against a two-line body - stranded
+         halfway down the bar beside the buttons, reading as one of them rather
+         than as the thing that ticks the page. -->
+    <div class="bulk-selection-bar__lead">
+      <FormCheckbox
+        :model-value="props.pageSelected"
+        :partial="props.pagePartiallySelected"
+        :disabled="props.disabled"
+        v-tooltip="props.disabled ? '' : pageLabel"
+        :aria-label="pageLabel"
+        name="bulk-selection-page"
+        data-test="bulk-select-page"
+        no-label
+        inline
+        @update:model-value="onTogglePage"
+      />
 
-    <div
-      class="bulk-selection-bar__body"
-      :class="{ 'bulk-selection-bar__body--empty': !hasSelection }"
-    >
-      <span class="bulk-selection-bar__count">
+      <span
+        class="bulk-selection-bar__count"
+        :class="{ 'bulk-selection-bar__count--empty': !hasSelection }"
+      >
         <span data-test="bulk-selection-count">
           {{
             props.allMatchingSelected
@@ -88,21 +119,14 @@ const pageLabel = computed(() =>
             })
           }}
         </Btn>
-        <Btn
-          v-tooltip="t('bulkSelection.actions.clear')"
-          :aria-label="t('bulkSelection.actions.clear')"
-          :size="BtnSizesEnum.SM"
-          :variant="BtnVariantsEnum.BARE"
-          data-test="bulk-selection-clear"
-          @click="emit('clear')"
-        >
-          <i class="fa-duotone fa-xmark" />
-        </Btn>
       </span>
+    </div>
 
-      <div class="bulk-selection-bar__actions">
-        <slot />
-      </div>
+    <div
+      class="bulk-selection-bar__actions"
+      :class="{ 'bulk-selection-bar__actions--empty': !hasSelection }"
+    >
+      <slot />
     </div>
   </div>
 </template>

--- a/app/frontend/shared/components/Empty/index.scss
+++ b/app/frontend/shared/components/Empty/index.scss
@@ -1,5 +1,9 @@
 .empty-list {
   width: 600px;
+  // A ceiling as well as a width: the box stands inside a list's own column on
+  // some pages - the notification pages put it where the list sits, beside the
+  // reading pane - and 600px overflows any column narrower than that.
+  max-width: 100%;
 }
 
 .empty-list-inline {

--- a/app/frontend/shared/components/Empty/index.vue
+++ b/app/frontend/shared/components/Empty/index.vue
@@ -34,11 +34,12 @@ const isPagePresent = computed(
   () => !!route.query.page && Number(route.query.page) > 1,
 );
 
+// The filters live under `q`, and only they decide whether this list came back
+// empty because of something the reader can undo. Any parameter at all used to
+// count, which made a tab, a sort or a highlighted record read as a filter -
+// so the notifications page offered to reset filters it never had.
 const isQueryPresent = computed(
-  () =>
-    Object.keys(route.query?.q || {}).length > 0 ||
-    Object.keys(route.query || {}).length > 0 ||
-    isPagePresent.value,
+  () => Object.keys(route.query?.q || {}).length > 0 || isPagePresent.value,
 );
 
 const cssClasses = computed(() => {

--- a/app/frontend/shared/components/InlineEditableList/index.spec.ts
+++ b/app/frontend/shared/components/InlineEditableList/index.spec.ts
@@ -1,0 +1,55 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import Component from "./index.vue";
+
+type Item = { id: string; name: string };
+
+// InlineEditableList is a generic SFC, which is not a plain constructor type;
+// this names the props and slots the tests use without reaching for `any`.
+const ListComponent = Component as unknown as new (...args: unknown[]) => {
+  $props: {
+    items: Item[];
+    loading?: boolean;
+    skeletonRows?: number;
+  };
+  $slots: Record<string, unknown>;
+};
+
+const mount = (props: {
+  items: Item[];
+  loading?: boolean;
+  skeletonRows?: number;
+}) =>
+  mountWithDefaults<typeof ListComponent>(ListComponent, {
+    props,
+    slots: { display: "<span>dock</span>" },
+  });
+
+const skeletonRows = (wrapper: Awaited<ReturnType<typeof mount>>) =>
+  wrapper.findAll('[data-test="list-group-skeleton-row"]');
+
+describe("InlineEditableList", () => {
+  // Every row of an editable list carries the edit and destroy buttons, so its
+  // placeholders stand as tall as those rather than as tall as a line of text.
+  it("holds the list open with placeholder rows on the first load", async () => {
+    const wrapper = await mount({ items: [], loading: true, skeletonRows: 4 });
+
+    expect(skeletonRows(wrapper)).toHaveLength(4);
+    expect(
+      skeletonRows(wrapper)[0]
+        .find(".list-group__actions .skeleton-bar--control")
+        .exists(),
+    ).toBe(true);
+  });
+
+  it("leaves the records in place while they are refetched", async () => {
+    const wrapper = await mount({
+      items: [{ id: "dock-1", name: "Forward Bay" }],
+      loading: true,
+      skeletonRows: 4,
+    });
+
+    expect(skeletonRows(wrapper)).toHaveLength(0);
+    expect(wrapper.findAll('[data-test="list-group-item"]')).toHaveLength(1);
+  });
+});

--- a/app/frontend/shared/components/InlineEditableList/index.vue
+++ b/app/frontend/shared/components/InlineEditableList/index.vue
@@ -25,6 +25,10 @@ type Props = {
   hideDestroy?: boolean;
   hideEdit?: boolean;
   selectable?: boolean;
+  // Passed straight down: the placeholder rows a list waiting for its first
+  // records is held open with, which the ListGroup below draws to the recipe of
+  // the row it stands in for.
+  skeletonRows?: number;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -34,6 +38,7 @@ const props = withDefaults(defineProps<Props>(), {
   hideDestroy: false,
   hideEdit: false,
   selectable: false,
+  skeletonRows: undefined,
 });
 
 const { displayConfirm } = useAppNotifications();
@@ -195,6 +200,7 @@ defineExpose({
     :empty-name="emptyName"
     :hide-empty="creating"
     :expanded-id="editingId"
+    :skeleton-rows="skeletonRows"
   >
     <template #prepend>
       <div v-if="creating" key="__create__" class="list-group__item">

--- a/app/frontend/shared/components/ListGroup/index.scss
+++ b/app/frontend/shared/components/ListGroup/index.scss
@@ -1,3 +1,5 @@
+@import "@/shared/components/skeleton";
+
 .list-group {
   gap: 8px;
   display: flex;
@@ -12,6 +14,12 @@
 
     &:hover {
       background: rgba(#fff, 0.1);
+    }
+
+    // A row that is not there yet is nothing to point at: no hover lift, and
+    // no cursor over the bars standing in for its content.
+    &--skeleton {
+      pointer-events: none;
     }
   }
 
@@ -50,5 +58,41 @@
     display: flex;
     gap: 4px;
     padding: 0;
+  }
+
+  // Widths and type only - the bars themselves are the shared primitive, and
+  // the type is what gives them their height.
+  .skeleton-bar {
+    // The pill these rows open with - a dock type, a price type, a feature's
+    // state - built to BasePill's own recipe: 15px type on a single line, its
+    // insets and the hairline it carries. A bar of body text is 5px shorter,
+    // which is 5px a row the list grows by when the records land.
+    &--pill {
+      flex: none;
+      width: 78px;
+      padding: 6px 10px;
+      font-size: 15px;
+      line-height: 1;
+      border: 1px solid transparent;
+      border-radius: 4px;
+    }
+
+    &--label {
+      width: 34%;
+    }
+
+    // Square, like the icon buttons a row's actions are made of - a bar the
+    // width of the text beside them would read as a second label.
+    //
+    // This is also what makes a row that carries buttons as tall as those
+    // rather than as tall as the line of text beside them: the token is the one
+    // the controls themselves are sized from, and the row's own insets are
+    // added to it the same way they are added to a real button.
+    &--control {
+      flex: none;
+      width: var(--field-h, 43px);
+      height: var(--field-h, 43px);
+      border-radius: $border-radius-base;
+    }
   }
 }

--- a/app/frontend/shared/components/ListGroup/index.spec.ts
+++ b/app/frontend/shared/components/ListGroup/index.spec.ts
@@ -1,0 +1,141 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
+import { MINIMUM_WAIT_MS } from "@/shared/composables/useMinimumDuration";
+import Component from "./index.vue";
+
+type Item = { id: string };
+
+// ListGroup is a generic SFC, which is not a plain constructor type; this names
+// the props and slots the tests use without reaching for `any`.
+const ListComponent = Component as unknown as new (...args: unknown[]) => {
+  $props: {
+    items: Item[];
+    loading?: boolean;
+    skeletonRows?: number;
+  };
+  $slots: Record<string, unknown>;
+};
+
+const mount = (
+  props: { items: Item[]; loading?: boolean; skeletonRows?: number },
+  slots?: Record<string, string>,
+) => mountWithDefaults<typeof ListComponent>(ListComponent, { props, slots });
+
+const skeletonRows = (wrapper: Awaited<ReturnType<typeof mount>>) =>
+  wrapper.findAll('[data-test="list-group-skeleton-row"]');
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ListGroup", () => {
+  it("holds the list open with placeholder rows on the first load", async () => {
+    const wrapper = await mount({
+      items: [],
+      loading: true,
+      skeletonRows: 4,
+    });
+
+    expect(skeletonRows(wrapper)).toHaveLength(4);
+  });
+
+  // A refetch keeps the records it already has on screen, and they hold the
+  // list open better than placeholders would.
+  it("leaves the records in place while they are refetched", async () => {
+    const wrapper = await mount({
+      items: [{ id: "dock-1" }],
+      loading: true,
+      skeletonRows: 4,
+    });
+
+    expect(skeletonRows(wrapper)).toHaveLength(0);
+    expect(wrapper.findAll('[data-test="list-group-item"]')).toHaveLength(1);
+  });
+
+  // These lists are short and carry no page size to read a bound off, so a
+  // full page of placeholders would claim a screenful of nothing.
+  it("reserves a short list where nothing is known yet", async () => {
+    const wrapper = await mount({ items: [], loading: true });
+
+    expect(skeletonRows(wrapper)).toHaveLength(3);
+  });
+
+  // A count of zero is an answer rather than a missing one: a list known to be
+  // empty should reserve nothing.
+  it("reserves nothing for a list known to be empty", async () => {
+    const wrapper = await mount({ items: [], loading: true, skeletonRows: 0 });
+
+    expect(skeletonRows(wrapper)).toHaveLength(0);
+  });
+
+  // The actions area of a row holds buttons, and those set the row's height
+  // rather than the text beside them - so the placeholder reserves a block of
+  // the control's own size there. A list whose rows carry no buttons gets none,
+  // or it would stand half a control taller than the rows it waits for.
+  it("reserves a control for a list that carries actions", async () => {
+    const withActions = await mount(
+      { items: [], loading: true },
+      {
+        actions: "<button>edit</button>",
+      },
+    );
+
+    const row = withActions.get('[data-test="list-group-skeleton-row"]');
+
+    expect(
+      row.find(".list-group__actions .skeleton-bar--control").exists(),
+    ).toBe(true);
+
+    const plain = await mount({ items: [], loading: true });
+    const plainRow = plain.get('[data-test="list-group-skeleton-row"]');
+
+    expect(plainRow.find(".skeleton-bar--control").exists()).toBe(false);
+  });
+
+  it("keeps the placeholders out of the reading order", async () => {
+    const wrapper = await mount({ items: [], loading: true });
+
+    expect(
+      wrapper
+        .get('[data-test="list-group-skeleton-row"]')
+        .attributes("aria-hidden"),
+    ).toBe("true");
+  });
+
+  // The empty box is what the answer turned out to be, and putting it up under
+  // the placeholders would say the list is empty while it is still loading.
+  it("holds the empty state back while it waits", async () => {
+    const wrapper = await mount({ items: [], loading: true });
+
+    expect(wrapper.find(".empty-list").exists()).toBe(false);
+  });
+
+  // A list on its own is handed a query's own flag, and a cached page answers
+  // inside a frame or two - placeholders that come and go that fast read as a
+  // glitch rather than as a load.
+  it("holds the placeholders up long enough to read", async () => {
+    const wrapper = await mount({ items: [], loading: true, skeletonRows: 2 });
+
+    vi.useFakeTimers();
+
+    await wrapper.setProps({ loading: false });
+
+    expect(skeletonRows(wrapper)).toHaveLength(2);
+    expect(wrapper.find(".empty-list").exists()).toBe(false);
+
+    vi.advanceTimersByTime(MINIMUM_WAIT_MS + 100);
+    await nextTick();
+
+    expect(skeletonRows(wrapper)).toHaveLength(0);
+    expect(wrapper.find(".empty-list").exists()).toBe(true);
+  });
+
+  it("keeps the spinner while nothing else is showing one", async () => {
+    const wrapper = await mount({ items: [], loading: true });
+
+    expect(wrapper.findComponent({ name: "LoaderComponent" }).props()).toEqual(
+      expect.objectContaining({ loading: true }),
+    );
+  });
+});

--- a/app/frontend/shared/components/ListGroup/index.vue
+++ b/app/frontend/shared/components/ListGroup/index.vue
@@ -7,6 +7,11 @@ export default {
 <script lang="ts" setup generic="T extends { id: string }">
 import Empty from "@/shared/components/Empty/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
+import {
+  useListGeometry,
+  useReportListGeometry,
+} from "@/shared/composables/useListGeometry";
+import { useMinimumDuration } from "@/shared/composables/useMinimumDuration";
 
 type Props = {
   items: T[];
@@ -16,18 +21,95 @@ type Props = {
   // The row whose content slot holds a tall panel rather than a single line.
   // Its actions align to the bottom instead of floating in the middle of it.
   expandedId?: string | null;
+  // Placeholder rows to hold the list open with while it waits for its first
+  // records. A list framed by a FilteredList takes the count from the frame
+  // instead, so this is only for one standing on its own.
+  skeletonRows?: number;
 };
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   loading: false,
   emptyName: "entries",
   hideEmpty: false,
   expandedId: undefined,
+  skeletonRows: undefined,
+});
+
+// A frame - FilteredList - offers this list its page size and what one of its
+// rows measured last time. A list standing on its own has neither.
+const geometry = useListGeometry();
+
+// A list on its own is handed a query's own flag, and a cached page answers
+// inside a frame or two: placeholders that go up and come down that fast read
+// as the page glitching rather than as the page loading. A framed list needs no
+// hold of its own, because the frame has already held the flag before deciding
+// to render this list, and holding it twice only stacks a second wait on the
+// first. See useMinimumDuration.
+const loading = geometry
+  ? computed(() => props.loading)
+  : useMinimumDuration(() => props.loading);
+
+// `??`, not `||`: a remembered zero means this list has been seen empty, and
+// reserving nothing for it is the right answer rather than a missing one.
+//
+// Three where nothing is known at all. These lists are short - a ship's docks,
+// an item's prices - and carry no page size to read a bound off, so a full page
+// of placeholders would claim a screenful of nothing to stand in for four rows.
+const skeletonRowCount = computed(
+  () => props.skeletonRows ?? geometry?.count.value ?? 3,
+);
+
+// Only for the first load. A refetch keeps the records it already has on
+// screen, and they hold the list open better than placeholders would.
+const skeletonVisible = computed(
+  () => !!skeletonRowCount.value && loading.value && !props.items.length,
+);
+
+// Held back only where the frame around this list is already showing one over
+// the placeholder rows. A list loading on its own keeps it.
+const loaderVisible = computed(() => {
+  if (!loading.value) {
+    return false;
+  }
+
+  return !(skeletonVisible.value && !!geometry?.spinnerVisible.value);
+});
+
+// What a row of this list measured, which only a frame is in a position to
+// remember - a list on its own has nowhere to keep it. Worth having where it is
+// there: a display slot that wraps to two lines is taller than anything the
+// stylesheet can build ahead of time.
+//
+// Unmeasured, the placeholder is built to the recipe these rows are made of and
+// comes out right without it: 47px against 47px for a row holding a pill and a
+// name, 61px against 61px once it carries buttons.
+const skeletonRowHeight = computed(() => {
+  const remembered = geometry?.heightFor("row");
+
+  return remembered ? `${remembered}px` : undefined;
+});
+
+const inner = ref<HTMLElement>();
+
+// The row rather than the item: an item wraps the expanded slot too, and a
+// placeholder stands in for the row alone. An open row is skipped for the same
+// reason - it is as tall as the edit panel inside it, which is no reading of
+// how tall a row of this list is.
+useReportListGeometry("row", inner, {
+  ready: () => !!props.items.length,
+  pick: (host) =>
+    Array.from(
+      host.querySelectorAll<HTMLElement>(
+        "[data-test='list-group-item'] > .list-group__row",
+      ),
+    ).find(
+      (candidate) => !candidate.classList.contains("list-group__row--expanded"),
+    ),
 });
 </script>
 
 <template>
-  <div class="list-group">
+  <div ref="inner" class="list-group">
     <TransitionGroup name="list">
       <slot name="prepend" />
 
@@ -52,7 +134,38 @@ withDefaults(defineProps<Props>(), {
       </div>
     </TransitionGroup>
 
-    <Loader :loading="loading" />
+    <!-- Built to the row's own recipe rather than to a height written by hand:
+         the same frame, the same insets and the same type, so the height falls
+         out of the same arithmetic the row's does.
+         Outside the transition group on purpose. A leaving row of that group
+         keeps its place in the column for the half second it fades, so
+         placeholders inside it would stand under the records that just landed
+         and hold the list at twice its height until they went - the jump the
+         placeholders are here to prevent. Records enter in place, so dropping
+         the placeholders in the same frame costs the list no height. -->
+    <template v-if="skeletonVisible">
+      <div
+        v-for="row in skeletonRowCount"
+        :key="`list-group__skeleton-${row}`"
+        class="list-group__item list-group__item--skeleton"
+        aria-hidden="true"
+        data-test="list-group-skeleton-row"
+      >
+        <div class="list-group__row" :style="{ height: skeletonRowHeight }">
+          <div class="list-group__content">
+            <span class="skeleton-bar skeleton-bar--pill" />
+            <span class="skeleton-bar skeleton-bar--label" />
+          </div>
+          <!-- Only where the rows of this list carry buttons, since it is the
+               block that makes the placeholder as tall as one of them. -->
+          <div v-if="$slots.actions" class="list-group__actions">
+            <span class="skeleton-bar skeleton-bar--control" />
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <Loader :loading="loaderVisible" />
 
     <Empty
       v-if="!items.length && !loading && !hideEmpty"

--- a/app/frontend/shared/components/ListSkeleton/index.scss
+++ b/app/frontend/shared/components/ListSkeleton/index.scss
@@ -1,11 +1,11 @@
 @import "@/shared/components/skeleton";
 
-// Built to the recipe of the row it stands in for - a framed panel in a gapped
-// column, see NotificationsListItem and the two notification pages - rather
-// than to a height written by hand: the same surface, the same insets, and the
-// same type on each of the two lines. The height then falls out of the same
-// arithmetic the row's does, so the first load reserves the right space without
-// having measured anything yet.
+// Built to the recipe of the row it stands in for - see NotificationsListItem -
+// rather than to a height written by hand, and to the same two boxes it splits
+// its insets between: the row, and the button filling it. The height then falls
+// out of the same arithmetic the row's does, so the first load reserves the
+// right space without having measured anything yet, and every offset across the
+// row lands where the record's own will.
 .list-skeleton {
   display: flex;
   flex-direction: column;
@@ -17,29 +17,70 @@
   &__item {
     display: flex;
     align-items: flex-start;
-    gap: 12px;
-    // The row splits the same insets between itself and the button it wraps -
-    // 4px and 8px vertically, 14px to the icon. A placeholder has no button, so
-    // it carries the total, less the 1px its border already contributes.
-    padding: 12px 12px 12px 14px;
+    // The row's own gap and insets. It keeps almost nothing on the left, since
+    // the button it wraps carries that side.
+    gap: 5px;
+    padding: 4px 8px 4px 0;
     overflow: hidden;
     background: $panel-bg;
     border: 1px solid rgba(#fff, 0.1);
     border-radius: 6px;
   }
 
-  // A round glyph the size of the row's icon, which sits 2px below the top of
-  // the first line rather than on it. The bar's fill rather than a well's: at
-  // 18px across, the well's sweep is a bright sliver crossing the dot every
-  // second and a half, which is exactly the flicker the placeholders are here
-  // to avoid.
-  &__icon {
+  // The button the row wraps, which carries the rest of the insets.
+  &__select {
+    display: flex;
+    flex: 1 1 auto;
+    align-items: flex-start;
+    gap: 12px;
+    min-width: 0;
+    padding: 8px 4px 8px 14px;
+  }
+
+  // The control's own box at the offsets the row's checkbox carries: 10px in
+  // from the edge, 30px of footprint for a 24px box - a checkbox's label is
+  // wider than the box drawn at its left - and 10px down, which is what lines
+  // it up with the first line of the title rather than the middle of the row.
+  &__checkbox {
     flex: none;
-    width: 18px;
-    height: 18px;
-    margin-top: 3px;
+    width: 24px;
+    height: 24px;
+    margin: 10px 6px 0 10px;
     background: rgba($gray-light, 0.18);
-    border-radius: 50%;
+    border-radius: var(--radius-control-bare, 6px);
+  }
+
+  // The checkbox has taken the left inset over, exactly as it does in the row.
+  &__item--selectable &__select {
+    padding-left: 4px;
+  }
+
+  // The footprint the row's icon keeps whatever glyph it draws - 1.25em of its
+  // own 1.15em type - so both lines beside it start where the record's will,
+  // and 2px down, since the icon sits just below the top of the first line
+  // rather than on it.
+  &__icon {
+    position: relative;
+    flex: none;
+    width: 1.4375em;
+    height: 18px;
+    margin-top: 2px;
+
+    // A round glyph the size of the row's icon, centred in that footprint. The
+    // bar's fill rather than a well's: at 18px across, the well's sweep is a
+    // bright sliver crossing the dot every second and a half, which is exactly
+    // the flicker the placeholders are here to avoid.
+    &::before {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 50%;
+      width: 18px;
+      height: 18px;
+      background: rgba($gray-light, 0.18);
+      border-radius: 50%;
+      transform: translateX(-50%);
+    }
   }
 
   &__lines {

--- a/app/frontend/shared/components/ListSkeleton/index.spec.ts
+++ b/app/frontend/shared/components/ListSkeleton/index.spec.ts
@@ -2,7 +2,7 @@ import { mountWithDefaults } from "@/shared/utils/TestUtils";
 import { describe, expect, it } from "vitest";
 import Component from "./index.vue";
 
-const mount = (props?: { count?: number }) =>
+const mount = (props?: { count?: number; selectable?: boolean }) =>
   mountWithDefaults<typeof Component>(Component, { props });
 
 const items = (wrapper: Awaited<ReturnType<typeof mount>>) =>
@@ -27,6 +27,31 @@ describe("ListSkeleton", () => {
     const wrapper = await mount();
 
     expect(items(wrapper)).toHaveLength(10);
+  });
+
+  // The checkbox takes the row's left inset over from the title, so a
+  // placeholder without one stands the icon and both lines 35px left of where
+  // they land - the whole row sliding sideways as the records arrive.
+  it("carries a checkbox where the rows it waits for do", async () => {
+    const wrapper = await mount({ count: 3, selectable: true });
+
+    expect(
+      wrapper.findAll('[data-test="list-skeleton-checkbox"]'),
+    ).toHaveLength(3);
+    expect(items(wrapper)[0].classes()).toContain(
+      "list-skeleton__item--selectable",
+    );
+  });
+
+  it("leaves it out for a list whose rows have none", async () => {
+    const wrapper = await mount({ count: 3 });
+
+    expect(
+      wrapper.findAll('[data-test="list-skeleton-checkbox"]'),
+    ).toHaveLength(0);
+    expect(items(wrapper)[0].classes()).not.toContain(
+      "list-skeleton__item--selectable",
+    );
   });
 
   it("keeps the placeholders out of the reading order", async () => {

--- a/app/frontend/shared/components/ListSkeleton/index.vue
+++ b/app/frontend/shared/components/ListSkeleton/index.vue
@@ -10,10 +10,16 @@ import { useListGeometry } from "@/shared/composables/useListGeometry";
 type Props = {
   // Comes from the list this stands in for when it is inside one.
   count?: number;
+  // Whether the rows this waits for carry a selection checkbox. The checkbox
+  // takes the row's left inset over from the title, so a placeholder without
+  // one stands the icon and both lines 35px left of where they land - which is
+  // the whole row sliding sideways as the records arrive.
+  selectable?: boolean;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   count: undefined,
+  selectable: false,
 });
 
 const geometry = useListGeometry();
@@ -39,14 +45,22 @@ const itemHeight = computed(() => {
       v-for="item in count"
       :key="`list-skeleton-${item}`"
       class="list-skeleton__item"
+      :class="{ 'list-skeleton__item--selectable': props.selectable }"
       :style="{ height: itemHeight }"
     >
-      <span class="list-skeleton__icon" />
-      <span class="list-skeleton__lines">
-        <span class="skeleton-bar skeleton-bar--title" />
-        <span class="list-skeleton__meta">
-          <span class="skeleton-bar skeleton-bar--type" />
-          <span class="skeleton-bar skeleton-bar--time" />
+      <span
+        v-if="props.selectable"
+        class="list-skeleton__checkbox"
+        data-test="list-skeleton-checkbox"
+      />
+      <span class="list-skeleton__select">
+        <span class="list-skeleton__icon" />
+        <span class="list-skeleton__lines">
+          <span class="skeleton-bar skeleton-bar--title" />
+          <span class="list-skeleton__meta">
+            <span class="skeleton-bar skeleton-bar--type" />
+            <span class="skeleton-bar skeleton-bar--time" />
+          </span>
         </span>
       </span>
     </li>

--- a/app/frontend/shared/composables/useListGeometry.spec.ts
+++ b/app/frontend/shared/composables/useListGeometry.spec.ts
@@ -4,7 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, ref, type Component } from "vue";
 import BaseTable from "@/shared/components/base/Table/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
-import { provideListGeometry } from "./useListGeometry";
+import ListGroup from "@/shared/components/ListGroup/index.vue";
+import { provideListGeometry, useReportListGeometry } from "./useListGeometry";
 import { useListGeometryStore } from "@/shared/stores/listGeometry";
 import type { BaseTableCol } from "@/shared/components/base/Table/types";
 
@@ -71,6 +72,55 @@ const gridHost = (records: Row[]) =>
           <div class="card">{{ record.name }}</div>
         </template>
       </Grid>
+    `,
+  });
+
+// Stands in for FilteredList around a list of rows rather than a table.
+const listGroupHost = (records: Row[], frameSpinner = true) =>
+  defineComponent({
+    components: { ListGroup: ListGroup as unknown as Component },
+    setup() {
+      provideListGeometry("docks", ref(4), ref(frameSpinner));
+
+      return {
+        items: records.map((entry) => ({ id: entry.slug, name: entry.name })),
+        loading: !records.length,
+        // The first row is the one being edited, which is as tall as the panel
+        // inside it.
+        expandedId: records[0]?.slug,
+      };
+    },
+    template: `
+      <ListGroup :items="items" :loading="loading" :expanded-id="expandedId">
+        <template #display="{ item }">
+          <span>{{ item.name }}</span>
+        </template>
+      </ListGroup>
+    `,
+  });
+
+// Stands in for a page that draws its list inside a FilteredList's slot: the
+// provide happens in a child of it, so there is nothing to inject and the list
+// is named instead.
+const namedHost = (records: Row[]) =>
+  defineComponent({
+    setup() {
+      const list = ref<HTMLElement>();
+
+      useReportListGeometry("row", list, {
+        name: "ships",
+        ready: () => !!records.length,
+        pick: (host) => host.firstElementChild,
+      });
+
+      return { list, records };
+    },
+    template: `
+      <ul ref="list">
+        <li v-for="record in records" :key="record.slug" class="row">
+          {{ record.name }}
+        </li>
+      </ul>
     `,
   });
 
@@ -179,6 +229,99 @@ describe("useListGeometry", () => {
     const alone = await render(listHost([], false));
 
     expect(alone.find(".base-table__loader").exists()).toBe(true);
+  });
+
+  it("hands a list of rows the row count of the frame around it", async () => {
+    const wrapper = await render(listGroupHost([]));
+
+    expect(
+      wrapper.findAll('[data-test="list-group-skeleton-row"]'),
+    ).toHaveLength(4);
+  });
+
+  // An item wraps the expanded slot as well, and a placeholder stands in for
+  // the row alone - so measuring the item would reserve an edit panel too. The
+  // open row is skipped for the same reason: it is as tall as the panel inside
+  // it, which says nothing about how tall a row of this list is.
+  it("measures a closed row rather than the item around it", async () => {
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: Element) {
+        if (!this.classList.contains("list-group__row")) {
+          return { height: 220 } as DOMRect;
+        }
+
+        return {
+          height: this.classList.contains("list-group__row--expanded")
+            ? 180
+            : 59,
+        } as DOMRect;
+      },
+    );
+
+    await render(listGroupHost([record, { slug: "hornet", name: "Hornet" }]));
+
+    expect(heights()).toEqual([59]);
+  });
+
+  it("reserves a remembered row's height for a list's placeholders", async () => {
+    stubHeight(59);
+    await render(listGroupHost([record, { slug: "hornet", name: "Hornet" }]));
+    vi.restoreAllMocks();
+
+    const wrapper = await render(listGroupHost([]));
+
+    expect(
+      wrapper
+        .get('[data-test="list-group-skeleton-row"]')
+        .get(".list-group__row")
+        .attributes("style"),
+    ).toContain("height: 59px");
+  });
+
+  it("holds back a list's spinner while the frame shows one", async () => {
+    const framed = await render(listGroupHost([]));
+
+    expect(framed.find('[data-test="loader"]').exists()).toBe(false);
+
+    const alone = await render(listGroupHost([], false));
+
+    expect(alone.find('[data-test="loader"]').exists()).toBe(true);
+  });
+
+  // A page renders the FilteredList that provides the geometry, and inject only
+  // ever looks upwards - so without a name its measurements went nowhere and
+  // every load reserved the height of a row nobody had ever measured.
+  it("files a named list's measurement without anything to inject", async () => {
+    stubHeight(93);
+
+    await render(namedHost([record]));
+
+    expect(heights()).toEqual([93]);
+    expect(
+      Object.keys(useListGeometryStore().heights)[0].startsWith("ships:row:"),
+    ).toBe(true);
+  });
+
+  it("has nothing to file for a list that is neither framed nor named", async () => {
+    stubHeight(93);
+
+    await render(
+      defineComponent({
+        setup() {
+          const list = ref<HTMLElement>();
+
+          useReportListGeometry("row", list, {
+            ready: () => true,
+            pick: (host) => host.firstElementChild,
+          });
+
+          return { list };
+        },
+        template: `<ul ref="list"><li class="row">Avenger</li></ul>`,
+      }),
+    );
+
+    expect(heights()).toEqual([]);
   });
 
   it("stays out of the way of a table with no list around it", async () => {

--- a/app/frontend/shared/composables/useListGeometry.ts
+++ b/app/frontend/shared/composables/useListGeometry.ts
@@ -29,6 +29,12 @@ export type ListGeometry = {
 
 const listGeometryKey = Symbol("listGeometry") as InjectionKey<ListGeometry>;
 
+// One list can be drawn as a card grid or as a table, and a row that wraps on a
+// phone is not the row it is on a desktop: each shape is remembered apart, and
+// each viewport class apart again.
+const keyFor = (name: string, kind: ListGeometryKindType, mobile: boolean) =>
+  `${name}:${kind}:${mobile ? "mobile" : "desktop"}`;
+
 // Offered by whatever frames a list - FilteredList - and picked up by the list
 // that renders inside it, so a table or a grid needs to be told neither how
 // many placeholders to draw nor how tall.
@@ -40,15 +46,15 @@ export const provideListGeometry = (
   const store = useListGeometryStore();
   const mobile = useMobile();
 
-  const keyFor = (kind: ListGeometryKindType) =>
-    `${toValue(name)}:${kind}:${mobile.value ? "mobile" : "desktop"}`;
+  const ownKeyFor = (kind: ListGeometryKindType) =>
+    keyFor(toValue(name), kind, mobile.value);
 
   const geometry: ListGeometry = {
     count,
     spinnerVisible,
-    heightFor: (kind) => store.findByKey(keyFor(kind)),
+    heightFor: (kind) => store.findByKey(ownKeyFor(kind)),
     report: (kind, measured) => {
-      const key = keyFor(kind);
+      const key = ownKeyFor(kind);
 
       if (measured > 0 && measured !== store.findByKey(key)) {
         store.setByKey(key, measured);
@@ -66,19 +72,47 @@ export const useListGeometry = () => inject(listGeometryKey, undefined);
 // The reporting half, for whatever actually drew the records: a table, a grid,
 // or a page with a list of its own. `pick` names the element to measure, since
 // only the caller knows which of its children stands for one record.
+//
+// `name` is for a page that draws its list inside a frame's slot. The provide
+// then happens in a child of that page - FilteredList is rendered by it - and
+// inject only ever looks upwards, so such a page has nothing to report to and
+// its measurements were going nowhere. Naming the list writes to the same key
+// the frame reads back, which is the list's own name.
 export const useReportListGeometry = (
   kind: ListGeometryKindType,
   root: Ref<HTMLElement | ComponentPublicInstance | undefined>,
   options: {
     ready: () => boolean;
     pick: (host: HTMLElement) => Element | null | undefined;
+    name?: MaybeRefOrGetter<string>;
   },
 ) => {
   const geometry = useListGeometry();
+  const store = useListGeometryStore();
   const mobile = useMobile();
 
+  const record = (measured: number) => {
+    if (geometry) {
+      geometry.report(kind, measured);
+
+      return;
+    }
+
+    const name = toValue(options.name);
+
+    if (!name) {
+      return;
+    }
+
+    const key = keyFor(name, kind, mobile.value);
+
+    if (measured > 0 && measured !== store.findByKey(key)) {
+      store.setByKey(key, measured);
+    }
+  };
+
   const report = async () => {
-    if (!geometry || !options.ready()) {
+    if ((!geometry && !toValue(options.name)) || !options.ready()) {
       return;
     }
 
@@ -93,10 +127,7 @@ export const useReportListGeometry = (
     const measured = host ? options.pick(host) : undefined;
 
     if (measured) {
-      geometry.report(
-        kind,
-        Math.round(measured.getBoundingClientRect().height),
-      );
+      record(Math.round(measured.getBoundingClientRect().height));
     }
   };
 


### PR DESCRIPTION
Placeholder rows now stand where the records land — on the notification pages, and in every list built on `ListGroup`.

## The notification jump

The waiting state and the loaded page disagreed on five measurements, so the list moved twice on arrival: once sideways, once down. Measured on the page at 1280px with the answer held back, before → after:

| | before | after |
|---|---|---|
| list column | full width → 361px | 361px both |
| reading pane | absent while waiting | 567×240 both |
| row icon (checkbox) | 365 → 400 | 365 both |
| row title (icon footprint) | 395 → 400 | 400 both |
| selection bar | 34px → 51px | 51px both |
| heading count line | 32px → 72px | 72px both |

The skeleton slot draws the frame now: the real selection bar (disabled, nothing to tick) and the real reading pane in the state it is about to be in, with the placeholders in the list's own column and a checkbox on every row. `ListSkeleton` is built to the row's two boxes rather than to their insets added together, so the checkbox, the icon and both lines sit where the record's own will.

An empty answer used to replace all of it — bar, list and pane together — with the empty box. The box goes in the list's own column instead, so an empty inbox is still a two-pane page.

## The measurement that never landed

A list's placeholders reserve what one of its rows measured last time, and this loop was never closing on these pages: `useReportListGeometry` reaches the geometry through inject, and the geometry is provided by the `FilteredList` the page renders — inject only looks upwards. Every load reserved a single-line row (72px) against rows that run to two (99px). Naming the list files the reading under the same key the frame reads back; second load now reserves 99px against a 99.375px row.

## Elsewhere

- **`ListGroup`** answered a load with a spinner over an empty box. It draws placeholder rows now, built to the row's own recipe: 47px against 47px for a pill-and-name row, 61px against 61px once it carries buttons. `InlineEditableList` passes the count through.
- **The selection bar on a phone**: once the bar wraps, the checkbox was centred against a two-line bar — 26.5px below the count and level with the buttons. It is held in one box with the count now.
- **The clear button is gone.** It only did something the checkbox could not in one state, and a minus box clears the selection in one click instead. Ticking the whole page from a partial selection is the two-click move now, which is the rarer one. Each of the three states says what a click will do; a disabled box says nothing.
- **The empty box** was 600px wide whatever it stood in, which ran it and its headline over the reading pane. Both box widths are ceilings now. It also offered to reset filters that were never applied — any query parameter counted as one, so the tab and the sort order read as filters.

## Checks

- New: 9 `ListGroup`, 2 `InlineEditableList`, 2 `ListSkeleton`, 6 `useListGeometry` tests. 189 shared-component and composable tests green, `lint:ts` clean.
- Verified against the running app rather than by eye: the numbers above come from measuring both states of the real page with the API held back, and the empty state from deleting every notification (bar and pane in place, box inside its column, no reset actions).
- New visual-test cases: lists → the loading list group beside the list it becomes; notification centre → selectable placeholders beside the rows they stand in for, and the selection bar in its three states plus a phone-width column; states → the empty box in a narrow column.

🤖
