### PR TITLE
feat(fleet-events): record when an event changed state

### DIFF
--- a/app/models/fleet_event.rb
+++ b/app/models/fleet_event.rb
@@ -5,12 +5,15 @@
 # Table name: fleet_events
 #
 #  id                        :uuid             not null, primary key
+#  active_at                 :datetime
 #  archived_at               :datetime
 #  auto_lock_enabled         :boolean          default(TRUE), not null
 #  auto_lock_minutes_before  :integer          default(60), not null
 #  briefing                  :text
+#  cancelled_at              :datetime
 #  cancelled_reason          :text
 #  category                  :integer          default(0), not null
+#  completed_at              :datetime
 #  cover_image_preset        :string
 #  description               :text
 #  discord_synced_at         :datetime
@@ -18,8 +21,11 @@
 #  excluded_dates            :date             default([]), not null, is an Array
 #  external_uid              :uuid             not null
 #  location                  :string
+#  locked_at                 :datetime
 #  max_attendees             :integer
 #  meetup_location           :string
+#  open_at                   :datetime
+#  published_at              :datetime
 #  recurrence_count          :integer
 #  recurrence_interval       :string
 #  recurrence_until          :date
@@ -105,6 +111,7 @@ class FleetEvent < ApplicationRecord
   before_validation :ensure_id, on: :create
   before_validation :default_cover_image_preset
   before_save :update_slug
+  before_save :stamp_published_at, if: :will_save_change_to_status?
 
   scope :upcoming, -> { where("starts_at >= ?", Time.current).order(:starts_at) }
   scope :past, -> { where("starts_at < ?", Time.current).order(starts_at: :desc) }
@@ -397,6 +404,15 @@ class FleetEvent < ApplicationRecord
   private def recurrence_count_or_until
     return unless recurrence_count.present? && recurrence_until.present?
     errors.add(:base, :recurrence_count_xor_until)
+  end
+
+  # `open_at` is written by aasm on every transition into `open`, so unlocking
+  # signups moves it. This one is set on the first publish and never again,
+  # which is what a lead time has to measure against.
+  private def stamp_published_at
+    return unless status == "open"
+
+    self.published_at ||= Time.current
   end
 
   private def set_external_uid

--- a/db/migrate/20260903120000_add_status_timestamps_to_fleet_events.rb
+++ b/db/migrate/20260903120000_add_status_timestamps_to_fleet_events.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AddStatusTimestampsToFleetEvents < ActiveRecord::Migration[8.1]
+  def change
+    # The AASM block on FleetEvent has always declared `timestamps: true`, but
+    # aasm only writes `#{state}_at` where a setter exists -- it checks
+    # `respond_to?` and skips silently otherwise -- so every transition the
+    # event went through went unrecorded. FleetMembership and Import, the two
+    # other state machines here, both carry a column per target state.
+    add_column :fleet_events, :open_at, :datetime
+    add_column :fleet_events, :locked_at, :datetime
+    add_column :fleet_events, :active_at, :datetime
+    add_column :fleet_events, :completed_at, :datetime
+    add_column :fleet_events, :cancelled_at, :datetime
+
+    # `open_at` moves every time signups are unlocked, which is the right
+    # meaning for "open since" and the wrong one for "when was this announced".
+    # Lead time needs a stamp that only ever gets set once.
+    add_column :fleet_events, :published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_31_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -530,12 +530,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_200000) do
   end
 
   create_table "fleet_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "active_at"
     t.datetime "archived_at"
     t.boolean "auto_lock_enabled", default: true, null: false
     t.integer "auto_lock_minutes_before", default: 60, null: false
     t.text "briefing"
+    t.datetime "cancelled_at"
     t.text "cancelled_reason"
     t.integer "category", default: 0, null: false
+    t.datetime "completed_at"
     t.string "cover_image_preset"
     t.datetime "created_at", null: false
     t.uuid "created_by_id", null: false
@@ -548,9 +551,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_31_200000) do
     t.uuid "external_uid", null: false
     t.uuid "fleet_id", null: false
     t.string "location"
+    t.datetime "locked_at"
     t.integer "max_attendees"
     t.string "meetup_location"
     t.uuid "mission_id"
+    t.datetime "open_at"
+    t.datetime "published_at"
     t.integer "recurrence_count"
     t.string "recurrence_interval"
     t.date "recurrence_until"

--- a/test/factories/fleet_events.rb
+++ b/test/factories/fleet_events.rb
@@ -5,12 +5,15 @@
 # Table name: fleet_events
 #
 #  id                        :uuid             not null, primary key
+#  active_at                 :datetime
 #  archived_at               :datetime
 #  auto_lock_enabled         :boolean          default(TRUE), not null
 #  auto_lock_minutes_before  :integer          default(60), not null
 #  briefing                  :text
+#  cancelled_at              :datetime
 #  cancelled_reason          :text
 #  category                  :integer          default(0), not null
+#  completed_at              :datetime
 #  cover_image_preset        :string
 #  description               :text
 #  discord_synced_at         :datetime
@@ -18,8 +21,11 @@
 #  excluded_dates            :date             default([]), not null, is an Array
 #  external_uid              :uuid             not null
 #  location                  :string
+#  locked_at                 :datetime
 #  max_attendees             :integer
 #  meetup_location           :string
+#  open_at                   :datetime
+#  published_at              :datetime
 #  recurrence_count          :integer
 #  recurrence_interval       :string
 #  recurrence_until          :date

--- a/test/models/fleet_event_test.rb
+++ b/test/models/fleet_event_test.rb
@@ -7,12 +7,15 @@ require "test_helper"
 # Table name: fleet_events
 #
 #  id                        :uuid             not null, primary key
+#  active_at                 :datetime
 #  archived_at               :datetime
 #  auto_lock_enabled         :boolean          default(TRUE), not null
 #  auto_lock_minutes_before  :integer          default(60), not null
 #  briefing                  :text
+#  cancelled_at              :datetime
 #  cancelled_reason          :text
 #  category                  :integer          default(0), not null
+#  completed_at              :datetime
 #  cover_image_preset        :string
 #  description               :text
 #  discord_synced_at         :datetime
@@ -20,8 +23,11 @@ require "test_helper"
 #  excluded_dates            :date             default([]), not null, is an Array
 #  external_uid              :uuid             not null
 #  location                  :string
+#  locked_at                 :datetime
 #  max_attendees             :integer
 #  meetup_location           :string
+#  open_at                   :datetime
+#  published_at              :datetime
 #  recurrence_count          :integer
 #  recurrence_interval       :string
 #  recurrence_until          :date
@@ -268,6 +274,64 @@ class FleetEventTest < ActiveSupport::TestCase
         recurrence_count: 4, recurrence_until: Date.tomorrow)
 
       refute event.valid?
+    end
+  end
+
+  class StatusTimestampsTest < FleetEventTest
+    test "records the moment of every transition" do
+      event = create(:fleet_event)
+
+      event.publish!
+      assert_not_nil event.open_at
+
+      event.lock_signups!
+      assert_not_nil event.locked_at
+
+      event.start!
+      assert_not_nil event.active_at
+
+      event.complete!
+      assert_not_nil event.completed_at
+    end
+
+    test "records a cancellation" do
+      event = create(:fleet_event)
+      event.publish!
+
+      event.cancel!
+
+      assert_not_nil event.cancelled_at
+    end
+
+    test "stamps published_at on the first publish" do
+      event = create(:fleet_event)
+
+      event.publish!
+
+      assert_not_nil event.published_at
+      assert_equal event.open_at.to_i, event.published_at.to_i
+    end
+
+    # aasm rewrites open_at on every transition into open, so an unlock moves
+    # it. published_at is what a lead time measures against and has to stay put.
+    test "keeps published_at when signups are unlocked again" do
+      event = travel_to(2.days.ago) { create(:fleet_event).tap(&:publish!) }
+      first_published_at = event.published_at
+
+      event.lock_signups!
+      event.unlock_signups!
+
+      assert_operator event.open_at, :>, first_published_at
+      assert_equal first_published_at.to_i, event.reload.published_at.to_i
+    end
+
+    test "leaves the timestamps alone on an unrelated update" do
+      event = create(:fleet_event)
+
+      event.update!(title: "Renamed")
+
+      assert_nil event.published_at
+      assert_nil event.open_at
     end
   end
 end


### PR DESCRIPTION
`FleetEvent` runs a state machine whose transition times were never written down.

## Why

The AASM block has always declared `timestamps: true`, but aasm only writes a `#{state}_at` column where the setter exists — `setup_timestamps` does `respond_to?(ts_setter) && send(ts_setter, Time.now)` and skips silently otherwise. `fleet_events` had none of those columns, so every `publish`, `lock_signups`, `start`, `complete` and `cancel` went unrecorded.

That makes a set of ordinary questions unanswerable: how far ahead events get published, how long before start signups actually lock, and completion rate over time. None of it can be reconstructed later, which is why this comes before the aggregation work that wants to read it — and before `fleet_mission_builder` opens for anyone.

`fleet_memberships` and `imports`, the two other state machines here, both carry a column per target state. `fleet_events` was the outlier.

## What changed

- One column per non-initial target state: `open_at`, `locked_at`, `active_at`, `completed_at`, `cancelled_at`. No `draft_at` — `draft` is initial and no transition points at it.
- No model code for those five. Aasm fills them as soon as the setters exist.
- `published_at` is stamped by hand, once, via `before_save`. `unlock_signups` transitions back into `open`, so aasm rewrites `open_at` on every unlock. That is the right reading for "open since" and the wrong one for "when was this announced" — a lead time measured against `open_at` would shrink every time an officer reopened signups.

## Verification

Five tests in `fleet_event_test.rb`. The factory traits set `status` directly and stamp nothing, so the tests go through the real transition methods. The one that carries the weight: after `lock_signups!` + `unlock_signups!`, `open_at` has moved and `published_at` has not.

`227 tests, 470 assertions, 0 failures, 0 errors, 0 skips` across every `fleet_event*` model, job and integration test, including `auto_lock_job_test` and `fleets_events_publish_test`. `standardrb` clean.

## Not in scope

- **The API payload.** The jbuilder views list fields one by one rather than dumping `attributes`, so nothing leaks and no schema regeneration is needed. The columns also stay out of `ransackable_attributes`. Both change when something actually reads them.
- **Per-occurrence timestamps.** Recurring events lock per occurrence — `AutoLockJob` writes `fleet_event_occurrence_states.locked_at` directly instead of going through aasm — and that table already carries `locked_at` and `cancelled_at`. Whether an occurrence needs its own `active_at`/`completed_at` is a product question for when the flag opens, so I did not add columns on spec.

🤖