### PR TITLE
feat(stats): show which ships people are actually looking at

### DIFF
--- a/app/controllers/api/v1/stats/base_controller.rb
+++ b/app/controllers/api/v1/stats/base_controller.rb
@@ -8,6 +8,10 @@ module Api
 
         include ChartHelper
 
+        # How far back a "trending" ship looks. Long enough that a quiet weekend
+        # does not empty the chart, short enough that it still reads as now.
+        TRENDING_WINDOW = 30.days
+
         before_action :authenticate_user!, only: []
 
         def quick_stats
@@ -36,6 +40,26 @@ module Api
             ship_of_the_month: ship_of_the_month_entry&.dimensions&.dig("name"),
             ship_of_the_month_count: ship_of_the_month_entry&.value&.to_i || 0
           }
+        end
+
+        def trending_ships
+          slug_views = Rollup
+            .where(name: MetricsJob::ROLLUP_SHIP_VIEWS, interval: "day")
+            .where(time: TRENDING_WINDOW.ago.beginning_of_day..)
+            .group(Arel.sql("dimensions->>'model_slug'"))
+            .sum(:value)
+
+          # The rollup stores whatever sat in `/ships/<here>/`, and two of those
+          # are routes rather than ships (`viewer`, `fleetchart`). Resolving each
+          # slug through Model drops them, and drops a ship that has since been
+          # hidden or retired along with them.
+          names = Model.visible.active.where(slug: slug_views.keys).pluck(:slug, :name).to_h
+
+          trending_ships = transform_for_bar_chart(
+            slug_views.filter_map { |slug, views| [names[slug], views.to_i] if names.key?(slug) }.to_h
+          ).take(10)
+
+          render json: trending_ships.to_json
         end
 
         def components_by_class

--- a/app/frontend/frontend/pages/stats.vue
+++ b/app/frontend/frontend/pages/stats.vue
@@ -29,6 +29,7 @@ import {
   useVehiclesByModel as useVehiclesByModelQuery,
   useVehiclesPerMonth as useVehiclesPerMonthQuery,
   useShipsOfTheMonth as useShipsOfTheMonthQuery,
+  useTrendingShips as useTrendingShipsQuery,
 } from "@/services/fyApi";
 
 const { t } = useI18n();
@@ -57,6 +58,9 @@ const { data: vehiclesPerMonthOptions, ...vehiclesPerMonthStatus } =
 
 const { data: shipsOfTheMonthOptions, ...shipsOfTheMonthStatus } =
   useShipsOfTheMonthQuery();
+
+const { data: trendingShipsOptions, ...trendingShipsStatus } =
+  useTrendingShipsQuery();
 
 const route = useRoute();
 
@@ -120,6 +124,11 @@ watch(
  * value in here.
  */
 const csvCharts = computed(() => ({
+  "trending-ships": {
+    name: "trending-ships",
+    title: t("labels.stats.trendingShips"),
+    points: trendingShipsOptions.value,
+  },
   "vehicles-by-model": {
     name: "vehicles-by-model",
     title: t("labels.stats.topVehiclesByModel"),
@@ -312,6 +321,33 @@ const csvMetrics = computed<StatsMetric[]>(() => [
         :value="shipOfTheMonthCount"
         :label="shipOfTheMonthLabel"
       />
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.stats.trendingShips") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['trending-ships']"
+            />
+          </template>
+        </PanelHeading>
+        <PanelBody>
+          <Chart
+            v-if="trendingShipsOptions"
+            key="trending-ships"
+            name="trending-ships"
+            :async-status="trendingShipsStatus"
+            :options="trendingShipsOptions"
+            tooltip-type="ship"
+            type="bar"
+          />
+        </PanelBody>
+      </Panel>
     </div>
   </div>
 

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -185,6 +185,7 @@
         "vehiclesPerMonth": "Hangar Schiffe pro Monat",
         "topVehiclesByModel": "Top 10 Hangar Schiffe",
         "shipsOfTheMonth": "Schiff des Monats",
+        "trendingShips": "Meistgesehene Schiffe (30 Tage)",
         "crewDeficit": "Crew Defizit",
         "crewSurplus": "Crew Überschuss",
         "membersByRole": "Mitglieder nach Rolle",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -185,6 +185,7 @@
         "vehiclesPerMonth": "Hangared Ships per Month",
         "topVehiclesByModel": "Top 10 Hangared Ships",
         "shipsOfTheMonth": "Ship of the Month",
+        "trendingShips": "Most Viewed Ships (30 Days)",
         "crewDeficit": "Crew Deficit",
         "crewSurplus": "Crew Surplus",
         "membersByRole": "Members by Role",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -185,6 +185,7 @@
         "vehiclesPerMonth": "Naves en hangar por mes",
         "topVehiclesByModel": "Top 10 naves en hangar",
         "shipsOfTheMonth": "Nave del mes",
+        "trendingShips": "Naves más vistas (30 días)",
         "crewDeficit": "Déficit de tripulación",
         "crewSurplus": "Excedente de tripulación",
         "membersByRole": "Miembros por rol",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -185,6 +185,7 @@
         "vehiclesPerMonth": "Vaisseaux en hangar par mois",
         "topVehiclesByModel": "Top 10 vaisseaux en hangar",
         "shipsOfTheMonth": "Vaisseau du mois",
+        "trendingShips": "Vaisseaux les plus consultés (30 jours)",
         "crewDeficit": "Déficit d'équipage",
         "crewSurplus": "Excédent d'équipage",
         "membersByRole": "Membres par rôle",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -185,6 +185,7 @@
         "vehiclesPerMonth": "Navi in hangar al mese",
         "topVehiclesByModel": "Top 10 navi in hangar",
         "shipsOfTheMonth": "Nave del mese",
+        "trendingShips": "Navi più viste (30 giorni)",
         "crewDeficit": "Deficit equipaggio",
         "crewSurplus": "Surplus equipaggio",
         "membersByRole": "Membri per ruolo",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -185,6 +185,7 @@
         "vehiclesPerMonth": "每月机库飞船",
         "topVehiclesByModel": "前 10 机库飞船",
         "shipsOfTheMonth": "月度飞船",
+        "trendingShips": "浏览最多的飞船（30 天）",
         "crewDeficit": "船员缺口",
         "crewSurplus": "船员盈余",
         "membersByRole": "按角色分组成员",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -185,6 +185,7 @@
         "vehiclesPerMonth": "每月機庫飛船",
         "topVehiclesByModel": "前 10 機庫飛船",
         "shipsOfTheMonth": "月度飛船",
+        "trendingShips": "瀏覽最多的飛船（30 天）",
         "crewDeficit": "船員缺口",
         "crewSurplus": "船員盈餘",
         "membersByRole": "按角色分組成員",

--- a/app/jobs/metrics_job.rb
+++ b/app/jobs/metrics_job.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class MetricsJob < ApplicationJob
+  # A `$view` event records the path it happened on, so the ship is the third
+  # segment of `/ships/<slug>/`. Sub-pages (`images/`, `videos/`) resolve to the
+  # same slug and count towards the ship, which is what interest in it looks
+  # like.
+  SHIP_VIEW_SLUG = Arel.sql("split_part(ahoy_events.properties->>'page', '/', 3)")
+
+  ROLLUP_SHIP_VIEWS = "Ship Views"
+
   def perform
     User.rollup("Registrations", interval: "month")
     User.rollup("Registrations", interval: "year")
@@ -16,11 +24,43 @@ class MetricsJob < ApplicationJob
     Vehicle.visible.wanted.where(loaner: false).rollup("Vehicle Wish", interval: "year")
     Vehicle.visible.wanted.where(loaner: false).rollup("Vehicle Wish", interval: "month")
 
+    track_ship_views
     track_ship_of_the_month
     track_api_usage
   end
 
   private
+
+  # Ahoy keeps visits for a month (`Cleanup::VisitsJob`) and rolls up nothing but
+  # a monthly total, so per-ship views are gone before anything can read them.
+  # The interval is deliberately `day`: the gem recomputes from the newest stored
+  # interval onward, so a monthly rollup would recompute a half-purged month down
+  # to a wrong number, while a day is always complete by the time it is purged.
+  def track_ship_views
+    scope = Ahoy::Event
+      .where(name: "$view")
+      .where("ahoy_events.properties->>'page' LIKE ?", "/ships/_%")
+
+    # `Ahoy.exclude_method` already refuses to record an objecting user, so this
+    # only covers rows written before they objected. `NOT IN` alone would drop
+    # every anonymous view along with them, since `NULL NOT IN (...)` is NULL.
+    blocked_user_ids = User.where(tracking: false).pluck(:id)
+    if blocked_user_ids.any?
+      scope = scope.where(
+        "ahoy_events.user_id IS NULL OR ahoy_events.user_id NOT IN (?)",
+        blocked_user_ids
+      )
+    end
+
+    scope.group(SHIP_VIEW_SLUG).rollup(
+      ROLLUP_SHIP_VIEWS,
+      interval: "day",
+      column: :time,
+      # The gem derives a dimension name from the grouped column and only accepts
+      # a bare word, which an expression is not.
+      dimension_names: ["model_slug"]
+    )
+  end
 
   # Rolls up every day still held in Redis, not just yesterday, so a failed run
   # does not drop a day of counters.

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -101,6 +101,7 @@ v1_api_routes = lambda do
     get "vehicles-by-model", to: "base#vehicles_by_model"
     get "vehicles-per-month", to: "base#vehicles_per_month"
     get "ships-of-the-month", to: "base#ships_of_the_month"
+    get "trending-ships", to: "base#trending_ships"
   end
 end
 

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -9510,6 +9510,19 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/BarChartStatsList"
+  "/stats/trending-ships":
+    get:
+      summary: Stats Trending Ships
+      tags:
+      - Stats
+      operationId: trendingShips
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BarChartStatsList"
   "/stats/vehicles-by-model":
     get:
       summary: Stats Vehicles by Model

--- a/test/integration/api/v1/stats_trending_ships_test.rb
+++ b/test/integration/api/v1/stats_trending_ships_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::StatsTrendingShipsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/stats/trending-ships" do
+    get("Stats Trending Ships") do
+      operationId "trendingShips"
+      tags "Stats"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Shared::V1::Schemas::BarChartStatsList
+      end
+    end
+  end
+
+  test "GET /stats/trending-ships returns chart data" do
+    assert_api_response :get, 200
+  end
+
+  test "GET /stats/trending-ships names the ship a slug belongs to" do
+    model = create(:model)
+    record_views(model.slug, 12)
+
+    assert_api_response :get, 200 do
+      assert_equal [model.name], parsed_body.map { |point| point["label"] }
+      assert_equal [12], parsed_body.map { |point| point["count"] }
+    end
+  end
+
+  # `/ships/viewer/` and `/ships/fleetchart/` are routes, so the rollup collects
+  # them alongside the real slugs and the endpoint has to drop them.
+  test "GET /stats/trending-ships drops a slug that is not a ship" do
+    record_views("viewer", 99)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /stats/trending-ships drops a ship that is no longer visible" do
+    hidden = create(:model, hidden: true)
+    record_views(hidden.slug, 40)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /stats/trending-ships ignores views older than the window" do
+    model = create(:model)
+    record_views(model.slug, 5, at: 2.days.ago)
+    record_views(model.slug, 7, at: 90.days.ago)
+
+    assert_api_response :get, 200 do
+      assert_equal [5], parsed_body.map { |point| point["count"] }
+    end
+  end
+
+  private def record_views(slug, views, at: 1.day.ago)
+    Rollup.create!(
+      name: MetricsJob::ROLLUP_SHIP_VIEWS,
+      interval: "day",
+      time: at.beginning_of_day,
+      value: views,
+      dimensions: {model_slug: slug}
+    )
+  end
+end

--- a/test/jobs/metrics_job_test.rb
+++ b/test/jobs/metrics_job_test.rb
@@ -57,4 +57,69 @@ class MetricsJobTest < ActiveJob::TestCase
 
     assert_not Rollup.exists?(name: ApiUsageTracker::ROLLUP_NAME)
   end
+
+  test "#perform rolls up ship page views per slug" do
+    track_ship_view("/ships/aurora-mr/")
+    track_ship_view("/ships/aurora-mr/")
+    track_ship_view("/ships/cutlass-black/")
+
+    MetricsJob.new.perform
+
+    assert_equal 2, ship_views("aurora-mr")
+    assert_equal 1, ship_views("cutlass-black")
+  end
+
+  test "#perform counts a ship's sub-pages towards the ship" do
+    track_ship_view("/ships/aurora-mr/")
+    track_ship_view("/ships/aurora-mr/images/")
+
+    MetricsJob.new.perform
+
+    assert_equal 2, ship_views("aurora-mr")
+  end
+
+  test "#perform ignores the ship index, which names no ship" do
+    track_ship_view("/ships/")
+
+    MetricsJob.new.perform
+
+    assert_equal 0, Rollup.where(name: MetricsJob::ROLLUP_SHIP_VIEWS).count
+  end
+
+  # Ahoy refuses to record an objecting user from the moment they object, so
+  # what is left to exclude here are the rows written before that.
+  test "#perform leaves out views by a user who objected to tracking" do
+    objector = create(:user, tracking: false)
+    track_ship_view("/ships/aurora-mr/", user: objector)
+    track_ship_view("/ships/aurora-mr/")
+
+    MetricsJob.new.perform
+
+    assert_equal 1, ship_views("aurora-mr")
+  end
+
+  private def track_ship_view(page, user: nil, at: 1.day.ago)
+    visit = Ahoy::Visit.create!(
+      visit_token: SecureRandom.hex,
+      visitor_token: SecureRandom.hex,
+      started_at: at,
+      user_id: user&.id
+    )
+
+    Ahoy::Event.create!(
+      visit: visit,
+      user_id: user&.id,
+      name: "$view",
+      properties: {"page" => page},
+      time: at
+    )
+  end
+
+  private def ship_views(slug)
+    Rollup.where(
+      name: MetricsJob::ROLLUP_SHIP_VIEWS,
+      interval: "day",
+      dimensions: {model_slug: slug}
+    ).sum(:value)
+  end
 end


### PR DESCRIPTION
Phase 1 of the stats plan (#4697): start keeping per-ship page views, and put them on `/stats`.

## Why

Ahoy records the path of every `$view`, so a ship page view has always carried its slug — `/ships/drak-cutlass-black/`. Nothing ever read it. `Cleanup::VisitsJob` deletes visits after a month and rolls up one monthly total; the only per-page view is an admin chart over raw paths for the last month. So every month of per-ship interest was being thrown away, and no later work can get it back.

That is what makes this the first phase rather than a nice-to-have: the chart could wait, the collection could not.

## What changed

**Collection.** A `Ship Views` rollup in `MetricsJob`, dimensioned by ship slug.

- The interval is `day`, deliberately. The rollups gem recomputes from the newest stored interval onward, so a *monthly* rollup would recompute a half-purged month down to a wrong number. A day is always complete by the time the purge reaches it.
- Sub-pages (`images/`, `videos/`) resolve to the same slug and count towards the ship — that is what interest in a ship looks like.
- Slugs that are really routes (`viewer`, `fleetchart`) get collected too. Dropping them here would mean a blocklist that drifts from the route table, so the read side drops them instead by resolving through `Model`.
- Views by a user who has objected to tracking are excluded. Mostly belt-and-braces: `Ahoy.exclude_method` already refuses to record them from the moment they object, so this only covers rows written before that. Written as `user_id IS NULL OR user_id NOT IN (...)` because `NOT IN` alone drops every anonymous view along with them — `NULL NOT IN (…)` is `NULL`.

**Presentation.** A `GET /stats/trending-ships` endpoint over the last 30 days, and a panel on `/stats`. The endpoint resolves each slug through `Model.visible.active`, which names the ship and drops the non-ships and anything since hidden or retired in one step. It reuses the existing `BarChartStatsList` component, so no new schema component.

The panel is registered in `csvCharts` under the same key the `Chart` gets, so its own export button and the page-level export cannot drift apart.

## Verification

- Four job tests against real rows, not mocks — the point is that the slug extraction and the dimension name actually work. They cover per-slug counting, a sub-page counting towards its ship, the ship index (which names no ship) being ignored, and an objecting user's historical view being left out.
- Five endpoint tests: the schema response, a slug resolving to its ship's name, a non-ship slug dropped, a hidden ship dropped, and views outside the window ignored.
- `24 tests, 52 assertions, 0 failures` across every `stats_*` integration test and the metrics job. `standardrb` clean, `pnpm lint:ts` exits 0.
- `trendingShips` label added in all seven locales, translated rather than left to fall back.

## Not verified

I did not open the page in a browser. The panel is structurally identical to the two bar-chart panels beside it and takes the same props, and TypeScript is clean, but that is an argument rather than a check.

## Note on the data

The rollup starts empty and fills from the next nightly `MetricsJob`, reading whatever Ahoy still holds — up to a month. So the chart is blank on deploy and meaningful within a day.

🤖