### PR TITLE
fix(lists): let the last six lists draw their own wait

### DIFF
--- a/app/frontend/frontend/pages/fleets/[slug]/logistics/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics/index.vue
@@ -203,6 +203,10 @@ const crumbs = computed<Crumb[]>(() => [
     name="inventories"
   />
 
+  <!-- `placeholders`, so both views draw their own wait. The two tables
+       take a loading flag already and hold themselves open with a header and
+       a page of placeholder rows; the log view was the one that never got
+       the chance, since only the stock view turns the frame's spinner off. -->
   <FilteredList
     v-if="inventoryList.length"
     name="all-inventory-items"
@@ -210,6 +214,7 @@ const crumbs = computed<Crumb[]>(() => [
     :async-status="logAsyncStatus"
     :hide-loading="activeTab === 'stock'"
     :hide-empty="true"
+    placeholders
     :is-filter-selected="isFilterSelected"
   >
     <template #filter>

--- a/app/frontend/frontend/pages/fleets/[slug]/logistics/inventories/[inventory].vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics/inventories/[inventory].vue
@@ -263,12 +263,17 @@ const crumbs = computed<Crumb[]>(() => [
           </Btn>
         </Teleport>
 
+        <!-- `placeholders`, so both views draw their own wait. The two tables
+             take a loading flag already and hold themselves open with a header and
+             a page of placeholder rows; the log view was the one that never got
+             the chance, since only the stock view turns the frame's spinner off. -->
         <FilteredList
           name="inventory-items"
           :records="activeRecords"
           :async-status="logAsyncStatus"
           :hide-loading="activeTab === 'stock'"
           :hide-empty="true"
+          placeholders
           :is-filter-selected="isFilterSelected"
         >
           <template #filter>

--- a/app/frontend/frontend/pages/hangar/[id]/cargo.vue
+++ b/app/frontend/frontend/pages/hangar/[id]/cargo.vue
@@ -286,12 +286,17 @@ onMounted(() => {
       </Btn>
     </Teleport>
 
+    <!-- `placeholders`, so both views draw their own wait. The two tables
+         take a loading flag already and hold themselves open with a header and
+         a page of placeholder rows; the log view was the one that never got
+         the chance, since only the stock view turns the frame's spinner off. -->
     <FilteredList
       name="vehicle-inventory-items"
       :records="activeRecords"
       :async-status="logAsyncStatus"
       :hide-loading="activeTab === 'stock'"
       :hide-empty="true"
+      placeholders
       :is-filter-selected="isFilterSelected"
     >
       <template #filter>

--- a/app/frontend/frontend/pages/hangar/inventories/[inventory].vue
+++ b/app/frontend/frontend/pages/hangar/inventories/[inventory].vue
@@ -225,12 +225,17 @@ const crumbs = computed<Crumb[]>(() => [
           </Btn>
         </Teleport>
 
+        <!-- `placeholders`, so both views draw their own wait. The two tables
+             take a loading flag already and hold themselves open with a header and
+             a page of placeholder rows; the log view was the one that never got
+             the chance, since only the stock view turns the frame's spinner off. -->
         <FilteredList
           name="hangar-inventory-items"
           :records="activeRecords"
           :async-status="logAsyncStatus"
           :hide-loading="activeTab === 'stock'"
           :hide-empty="true"
+          placeholders
           :is-filter-selected="isFilterSelected"
         >
           <template #filter>

--- a/app/frontend/frontend/pages/hangar/inventories/index.vue
+++ b/app/frontend/frontend/pages/hangar/inventories/index.vue
@@ -154,6 +154,10 @@ onMounted(() => {
     name="inventories"
   />
 
+  <!-- `placeholders`, so both views draw their own wait. The two tables
+       take a loading flag already and hold themselves open with a header and
+       a page of placeholder rows; the log view was the one that never got
+       the chance, since only the stock view turns the frame's spinner off. -->
   <FilteredList
     v-if="inventoryList.length"
     name="hangar-inventory-items"
@@ -161,6 +165,7 @@ onMounted(() => {
     :async-status="logAsyncStatus"
     :hide-loading="activeTab === 'stock'"
     :hide-empty="true"
+    placeholders
     :is-filter-selected="isFilterSelected"
   >
     <template #filter>

--- a/app/frontend/frontend/pages/tools/travel-times.vue
+++ b/app/frontend/frontend/pages/tools/travel-times.vue
@@ -474,15 +474,20 @@ const columns = computed<BaseTableCol<Component>[]>(() => {
           </span>
         </div>
 
+        <!-- `placeholders`, so the table itself draws the wait: a header and a
+             page of placeholder rows out of an empty record set is closer to
+             the answer on its way than a spinner in an empty box. -->
         <FilteredList
           key="quantumDrives"
           :records="visibleDrives"
           :name="route.name?.toString() || ''"
           :async-status="asyncStatus"
+          placeholders
         >
-          <template #default="{ records }">
+          <template #default="{ records, loading }">
             <BaseTable
               :records="records"
+              :loading="loading"
               :filter-visible="false"
               primary-key="slug"
               :columns="columns"


### PR DESCRIPTION
Follow-up to the placeholder work in #4695, and independent of it — both changes lean on `BaseTable`'s own placeholder rows, which are already on main.

An audit of every list in the app turned up six pages that still answered a load with a spinner in an empty box while their table was perfectly able to draw the wait itself. Both fixes are the same one: stop having the frame answer first.

## travel-times

The list went through `FilteredList`'s loading branch, so the tool showed a centred cube and then a full table of drives. `placeholders` hands the branch to the table instead — a header, the columns' own widths, and a page of placeholder rows out of an empty record set — and the loading flag that was already in the slot is passed on.

## The five stock and cargo pages

`hangar/[id]/cargo`, `hangar/inventories` (index and detail), `fleets/[slug]/logistics` (index and detail).

Each carries two views of the same records, and only one held itself open. The stock view turns the frame's spinner off, so its table renders while loading and reserves its own rows; the log view left it on, so the frame answered for it and the table never rendered at all. Both tables in `InventoryLedgerTables` already take a loading flag and an empty flag, so the pages only needed `placeholders`.

Nothing changes on the stock view: its `hide-loading` still skips the branch entirely.

## What the audit found already covered

Worth recording, since it is not obvious from the outside:

- **21 admin index tables** need nothing. They pass `hide-loading` *and* `hide-empty` and hand their table a loading flag, so the table already renders itself with the count the frame provides.
- **12 card and grid pages** draw a `GridSkeleton` through the list's `skeleton` slot.
- **Three admin list-group lists** that pass no loading flag are correct as they are — they render items handed down as props, so they never sit empty waiting for an answer.

## Left alone deliberately

The inventory cards above the tabs on the two index pages still show a bare spinner. They are a `Grid` of compact `InventoryPanel`s outside any list frame, so `GridSkeleton`'s card — a 286px photo well — would be a loud wrong guess, and there is no frame to take a count or a remembered height from. That one wants its own placeholder rather than a prop.

🤖
