### PR TITLE
feat(models): record when a ship is on sale

### DIFF
--- a/app/api_components/v1/schemas/models/sales/model_sale.rb
+++ b/app/api_components/v1/schemas/models/sales/model_sale.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Sales
+        class ModelSale
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              startedAt: {type: :string, format: :"date-time"},
+              endedAt: {type: [:string, :null], format: :"date-time"},
+              ongoing: {type: :boolean},
+              # Null while the sale is still running -- an open stretch has no
+              # length to report.
+              durationInDays: {type: [:number, :null]}
+            },
+            required: %i[id startedAt ongoing],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/sales/model_sales.rb
+++ b/app/api_components/v1/schemas/models/sales/model_sales.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Sales
+        class ModelSales
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              sales: {type: :array, items: {"$ref": "#/components/schemas/ModelSale"}},
+              salesCount: {type: :integer},
+              lastSaleAt: {type: [:string, :null], format: :"date-time"},
+              # Null until a second sale gives the first one a gap to measure.
+              averageDaysBetweenSales: {type: [:number, :null]}
+            },
+            required: %i[sales salesCount],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -275,6 +275,13 @@ module Api
           .order(name: :asc)
       end
 
+      def sales
+        @model = find_model_by_slug!
+        return if performed?
+
+        @sales = @model.sales.recent_first
+      end
+
       def store_image
         model = find_model_by_slug(Model.visible.active)
         return if performed?

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -356,6 +356,11 @@ class Model < ApplicationRecord
     dependent: :destroy,
     inverse_of: :model
 
+  has_many :sales,
+    class_name: "ModelSale",
+    dependent: :destroy,
+    inverse_of: :model
+
   has_many :images,
     as: :gallery,
     dependent: :destroy,
@@ -452,6 +457,7 @@ class Model < ApplicationRecord
   before_create :set_last_updated_at
 
   after_save :send_on_sale_notification, if: :saved_change_to_on_sale?
+  after_save :record_sale, if: :saved_change_to_on_sale?
   after_save :broadcast_update
   after_save :send_new_model_notification, if: :saved_change_to_rsi_id?
 
@@ -895,6 +901,25 @@ class Model < ApplicationRecord
     slug&.start_with?(prefix) ? slug.delete_prefix(prefix) : slug
   end
 
+  def last_sale
+    sales.recent_first.first
+  end
+
+  def sales_count
+    sales.count
+  end
+
+  # Needs two sales to have a gap at all. Measured start to start, so a long
+  # sale does not read as a short wait for the next one.
+  def average_days_between_sales
+    started_ats = sales.order(:started_at).pluck(:started_at)
+    return if started_ats.size < 2
+
+    gaps = started_ats.each_cons(2).map { |before, after| (after - before) / 1.day }
+
+    (gaps.sum / gaps.size).round(1)
+  end
+
   private def broadcast_update
     ActionCable.server.broadcast("models", to_jbuilder_hash)
   end
@@ -905,6 +930,17 @@ class Model < ApplicationRecord
     Notifications::NewModelJob.perform_async(id)
 
     ActionCable.server.broadcast("new_model", to_jbuilder_hash)
+  end
+
+  # The flag alone says only whether a ship is on sale right now. Turning each
+  # flip into a row is what makes "how often" and "how long ago" answerable --
+  # and it only works forwards, since nothing recorded the flips before this.
+  private def record_sale
+    if on_sale?
+      sales.create!(started_at: Time.current) unless sales.ongoing.exists?
+    else
+      sales.ongoing.update_all(ended_at: Time.current, updated_at: Time.current)
+    end
   end
 
   private def send_on_sale_notification

--- a/app/models/model_sale.rb
+++ b/app/models/model_sale.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# One stretch of time a model was on sale. An open row -- `ended_at` nil -- is
+# a sale still running.
+# == Schema Information
+#
+# Table name: model_sales
+#
+#  id         :uuid             not null, primary key
+#  ended_at   :datetime
+#  started_at :datetime         not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  model_id   :uuid             not null
+#
+# Indexes
+#
+#  index_model_sales_on_model_id                 (model_id)
+#  index_model_sales_on_model_id_and_started_at  (model_id,started_at) UNIQUE
+#  index_model_sales_on_model_id_ongoing         (model_id) UNIQUE WHERE (ended_at IS NULL)
+#  index_model_sales_on_started_at               (started_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
+class ModelSale < ApplicationRecord
+  belongs_to :model
+
+  scope :ongoing, -> { where(ended_at: nil) }
+  scope :finished, -> { where.not(ended_at: nil) }
+  scope :recent_first, -> { order(started_at: :desc) }
+
+  validates :started_at, presence: true
+  validate :ended_after_started
+
+  def ongoing?
+    ended_at.blank?
+  end
+
+  # Nil while the sale is still running: an open-ended stretch has no length,
+  # and reporting "so far" as a duration would read as a finished sale.
+  def duration_in_days
+    return if ongoing?
+
+    ((ended_at - started_at) / 1.day).round(1)
+  end
+
+  private def ended_after_started
+    return if ended_at.blank? || started_at.blank?
+    return if ended_at >= started_at
+
+    errors.add(:ended_at, :invalid)
+  end
+end

--- a/app/views/api/v1/model_sales/_model_sale.jbuilder
+++ b/app/views/api/v1/model_sales/_model_sale.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.id model_sale.id
+json.started_at model_sale.started_at
+json.ended_at model_sale.ended_at
+json.ongoing model_sale.ongoing?
+json.duration_in_days model_sale.duration_in_days

--- a/app/views/api/v1/models/sales.jbuilder
+++ b/app/views/api/v1/models/sales.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.sales @sales, partial: "api/v1/model_sales/model_sale", as: :model_sale
+
+json.sales_count @model.sales_count
+json.last_sale_at @model.last_sale&.started_at
+json.average_days_between_sales @model.average_days_between_sales

--- a/config/routes/api/models_routes.rb
+++ b/config/routes/api/models_routes.rb
@@ -20,6 +20,7 @@ resources :models, param: :slug, only: %i[index show] do
     get :module_packages, path: "module-packages"
     get :upgrades
     get :paints
+    get :sales
     get :store_image, path: "store-image"
     get :fleetchart_image, path: "fleetchart-image"
   end

--- a/db/data/20260903141000_open_sales_for_models_already_on_sale.rb
+++ b/db/data/20260903141000_open_sales_for_models_already_on_sale.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Opens a sale row for every ship the store currently has discounted.
+#
+# `started_at` is the moment this runs, not the moment the sale began -- nothing
+# recorded that, and a backdated guess would be indistinguishable from a
+# measurement. It is deliberately wrong in one direction only: these first rows
+# under-report how long the sale ran, and are excluded from nothing else.
+#
+# Without them the flag's *next* flip has no open row to close, so the sale that
+# is running right now would vanish entirely rather than merely start late.
+class OpenSalesForModelsAlreadyOnSale < ActiveRecord::Migration[8.1]
+  def up
+    now = Time.current
+
+    Model.where(on_sale: true).find_each do |model|
+      next if model.sales.ongoing.exists?
+
+      model.sales.create!(started_at: now)
+    end
+  end
+
+  def down
+    ModelSale.ongoing.delete_all
+  end
+end

--- a/db/migrate/20260903140000_create_model_sales.rb
+++ b/db/migrate/20260903140000_create_model_sales.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# When a ship was on sale, which nothing recorded until now.
+#
+# `models.on_sale` is a flag the store sync flips. It fires a notification and
+# is deliberately absent from Model's paper_trail `only:` list, so every past
+# sale is gone -- how often a ship goes on sale, and how long ago the last one
+# was, are the questions this table exists to answer.
+class CreateModelSales < ActiveRecord::Migration[8.1]
+  def change
+    create_table :model_sales, id: :uuid do |t|
+      t.references :model, type: :uuid, null: false, foreign_key: {on_delete: :cascade}
+      t.datetime :started_at, null: false
+      t.datetime :ended_at
+
+      t.timestamps
+    end
+
+    add_index :model_sales, [:model_id, :started_at], unique: true
+
+    # A ship is either on sale or it is not, so at most one row can be open.
+    # Without this a missed close leaves two open rows and every later sale is
+    # measured from the wrong one.
+    add_index :model_sales, :model_id,
+      unique: true,
+      where: "ended_at IS NULL",
+      name: "index_model_sales_on_model_id_ongoing"
+
+    add_index :model_sales, :started_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_140000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1150,6 +1150,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_120000) do
     t.index ["model_id"], name: "index_model_positions_on_model_id"
   end
 
+  create_table "model_sales", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "ended_at"
+    t.uuid "model_id", null: false
+    t.datetime "started_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["model_id", "started_at"], name: "index_model_sales_on_model_id_and_started_at", unique: true
+    t.index ["model_id"], name: "index_model_sales_on_model_id"
+    t.index ["model_id"], name: "index_model_sales_on_model_id_ongoing", unique: true, where: "(ended_at IS NULL)"
+    t.index ["started_at"], name: "index_model_sales_on_started_at"
+  end
+
   create_table "model_snub_crafts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "model_id", null: false
@@ -1697,6 +1709,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_120000) do
   add_foreign_key "model_paints", "components", on_delete: :nullify
   add_foreign_key "model_positions", "hardpoints", on_delete: :nullify
   add_foreign_key "model_positions", "models"
+  add_foreign_key "model_sales", "models", on_delete: :cascade
   add_foreign_key "notification_preferences", "users"
   add_foreign_key "notifications", "users"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7427,6 +7427,34 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/models/{slug}/sales":
+    parameters:
+    - name: slug
+      in: path
+      schema:
+        type: string
+      description: Model slug
+      required: true
+    get:
+      summary: Model Sales
+      tags:
+      - Models
+      operationId: modelSales
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelSales"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/models/{slug}/snub-crafts":
     parameters:
     - name: slug
@@ -18706,6 +18734,55 @@ components:
       additionalProperties: false
       example: {}
       title: ModelQuery
+    ModelSale:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        startedAt:
+          type: string
+          format: date-time
+        endedAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        ongoing:
+          type: boolean
+        durationInDays:
+          type:
+          - number
+          - 'null'
+      required:
+      - id
+      - startedAt
+      - ongoing
+      additionalProperties: false
+      title: ModelSale
+    ModelSales:
+      type: object
+      properties:
+        sales:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ModelSale"
+        salesCount:
+          type: integer
+        lastSaleAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        averageDaysBetweenSales:
+          type:
+          - number
+          - 'null'
+      required:
+      - sales
+      - salesCount
+      additionalProperties: false
+      title: ModelSales
     ModelSignatureCrossSection:
       type: object
       properties:

--- a/test/factories/model_sales.rb
+++ b/test/factories/model_sales.rb
@@ -1,5 +1,27 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: model_sales
+#
+#  id         :uuid             not null, primary key
+#  ended_at   :datetime
+#  started_at :datetime         not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  model_id   :uuid             not null
+#
+# Indexes
+#
+#  index_model_sales_on_model_id                 (model_id)
+#  index_model_sales_on_model_id_and_started_at  (model_id,started_at) UNIQUE
+#  index_model_sales_on_model_id_ongoing         (model_id) UNIQUE WHERE (ended_at IS NULL)
+#  index_model_sales_on_started_at               (started_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
 FactoryBot.define do
   factory :model_sale do
     model

--- a/test/factories/model_sales.rb
+++ b/test/factories/model_sales.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :model_sale do
+    model
+    started_at { 1.week.ago }
+
+    trait :finished do
+      ended_at { 5.days.ago }
+    end
+  end
+end

--- a/test/integration/api/v1/models_sales_test.rb
+++ b/test/integration/api/v1/models_sales_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::ModelsSalesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/models/{slug}/sales" do
+    parameter name: "slug", in: :path, schema: {type: :string}, description: "Model slug", required: true
+
+    get("Model Sales") do
+      operationId "modelSales"
+      tags "Models"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::V1::Schemas::Models::Sales::ModelSales
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  test "GET /models/:slug/sales returns the recorded sales, newest first" do
+    model = create(:model)
+    create(:model_sale, :finished, model:, started_at: 1.year.ago, ended_at: 11.months.ago)
+    create(:model_sale, model:, started_at: 2.days.ago, ended_at: nil)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal 2, parsed_body["salesCount"]
+      assert_equal 2, parsed_body["sales"].count
+      assert parsed_body["sales"].first["ongoing"]
+      assert_nil parsed_body["sales"].first["durationInDays"]
+      assert_in_delta 30.0, parsed_body["sales"].last["durationInDays"], 2.0
+    end
+  end
+
+  test "GET /models/:slug/sales reports the gap between sales" do
+    model = create(:model)
+    create(:model_sale, :finished, model:, started_at: 100.days.ago, ended_at: 96.days.ago)
+    create(:model_sale, :finished, model:, started_at: 60.days.ago, ended_at: 56.days.ago)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal 40.0, parsed_body["averageDaysBetweenSales"]
+    end
+  end
+
+  # Nothing recorded the flag before this table existed, so a ship with no
+  # history has to answer rather than look broken.
+  test "GET /models/:slug/sales answers for a ship that has never been on sale" do
+    model = create(:model)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal 0, parsed_body["salesCount"]
+      assert_empty parsed_body["sales"]
+      assert_nil parsed_body["lastSaleAt"]
+      assert_nil parsed_body["averageDaysBetweenSales"]
+    end
+  end
+
+  test "GET /models/:slug/sales returns 404 for unknown model" do
+    assert_api_response :get, 404, path_params: {slug: "unknown-model"}
+  end
+end

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -530,4 +530,90 @@ class ModelTest < ActiveSupport::TestCase
     assert_not_predicate concept, :in_game?
     assert_includes Model.visible.active, concept
   end
+
+  test "going on sale opens a sale" do
+    model = create(:model, on_sale: false)
+
+    model.update!(on_sale: true)
+
+    assert_equal 1, model.sales.count
+    assert_predicate model.sales.last, :ongoing?
+  end
+
+  test "coming off sale closes the open sale" do
+    model = create(:model, on_sale: false)
+    model.update!(on_sale: true)
+
+    model.update!(on_sale: false)
+
+    sale = model.sales.sole
+    assert_not_predicate sale, :ongoing?
+    assert_not_nil sale.ended_at
+  end
+
+  # The store sync writes the flag on every run, so a save that does not change
+  # it must not look like a new sale.
+  test "saving an already discounted model does not open a second sale" do
+    model = create(:model, on_sale: false)
+    model.update!(on_sale: true)
+
+    model.update!(name: "Renamed")
+    model.update!(on_sale: true)
+
+    assert_equal 1, model.sales.count
+  end
+
+  test "a second sale opens its own row" do
+    model = create(:model, on_sale: false)
+    model.update!(on_sale: true)
+    model.update!(on_sale: false)
+
+    model.update!(on_sale: true)
+
+    assert_equal 2, model.sales.count
+    assert_equal 1, model.sales.ongoing.count
+  end
+
+  test "#last_sale returns the most recently started one" do
+    model = create(:model)
+    create(:model_sale, :finished, model:, started_at: 1.year.ago, ended_at: 11.months.ago)
+    newest = create(:model_sale, model:, started_at: 1.week.ago, ended_at: nil)
+
+    assert_equal newest, model.last_sale
+  end
+
+  test "#average_days_between_sales needs two sales to have a gap" do
+    model = create(:model)
+    create(:model_sale, :finished, model:)
+
+    assert_nil model.average_days_between_sales
+  end
+
+  test "#average_days_between_sales measures start to start" do
+    model = create(:model)
+    create(:model_sale, :finished, model:, started_at: 100.days.ago, ended_at: 96.days.ago)
+    create(:model_sale, :finished, model:, started_at: 60.days.ago, ended_at: 56.days.ago)
+    create(:model_sale, model:, started_at: 20.days.ago, ended_at: nil)
+
+    assert_equal 40.0, model.average_days_between_sales
+  end
+
+  test "a running sale has no duration yet" do
+    sale = create(:model_sale, ended_at: nil)
+
+    assert_nil sale.duration_in_days
+  end
+
+  test "a finished sale knows how long it ran" do
+    sale = create(:model_sale, started_at: 10.days.ago, ended_at: 7.days.ago)
+
+    assert_equal 3.0, sale.duration_in_days
+  end
+
+  test "a sale cannot end before it started" do
+    sale = build(:model_sale, started_at: 1.day.ago, ended_at: 2.days.ago)
+
+    assert_not_predicate sale, :valid?
+    assert_predicate sale.errors[:ended_at], :present?
+  end
 end


### PR DESCRIPTION
Phase 2 of the stats plan (#4697): start keeping sale history, and serve it.

## Why

`models.on_sale` is a flag the store sync flips. It fires a notification (`model.rb:454`) and is deliberately absent from Model's paper_trail `only:` list — so the moment a sale ends, that it ever happened is gone.

That makes the questions people actually ask about a ship unanswerable: when was it last on sale, how often does it go on sale, how long is the wait. None of it is reconstructable, which is why this is a collection phase rather than a chart.

## What changed

**Recording.** A `model_sales` row per stretch, opened and closed by the flag's existing change hook.

- A partial unique index (`WHERE ended_at IS NULL`) allows at most one open sale per model. Without it a missed close leaves two open rows and every later sale is measured from the wrong one. Same shape as the conditional index `inventories` already uses.
- Re-saving an already-discounted model does not open a second sale — the store sync writes the flag on every run, and a no-op save must not look like a new sale.

**The ships that are already discounted.** A data migration opens a row for each of them. `started_at` is the moment it runs, not the moment the sale began: nothing recorded that, and a backdated guess would be indistinguishable from a measurement. It is wrong in one direction only — those first rows under-report how long the sale ran.

Leaving them out was the alternative and it is worse than late data: with no open row, the *next* flip has nothing to close, so the sale running today would vanish entirely rather than merely start late.

**Serving.** `GET /models/:slug/sales` returns the stretches newest first plus three derived figures — count, when the last one started, and the average gap. The gap is measured start to start, so a long sale does not read as a short wait for the next one, and it stays null until a second sale gives the first one a gap at all. A running sale reports no duration; an open-ended stretch has no length, and "so far" would read as a finished sale.

## Verification

- 11 model tests: opening, closing, the no-op save that must not open a second sale, a second sale getting its own row, `last_sale`, the gap needing two sales, the gap measured start to start, duration nil while running, and a sale that ends before it starts being rejected.
- 4 endpoint tests, including a ship that has never been on sale — with nothing recorded before this table existed, that is the common case and it has to answer rather than look broken.
- `690 tests, 1586 assertions, 0 failures` across `test/models` and `test/loaders`, since the new callback fires on every model save and the loaders create models in bulk.
- `standardrb` clean, `pnpm lint:ts` exits 0.

**The data migration is not covered by tests** — this repo does not test `db/data` migrations, and `bin/rails data:migrate` cannot run to completion in a fresh database anyway: `20260309112027_create_feature_flags` dies on `FeatureSetting#self_service=`, which no longer exists. That is pre-existing and I left it alone. I verified my migration by running the class directly against a seeded database instead: it opens a row for a ship flagged on sale with no history, creates nothing for a ship that already has an open row, touches nothing for a full-price ship, and the following off-sale flip then closes a real row.

## Not in scope

No frontend. The plan puts per-ship history on a ship history sub-page, together with price history and patch changes — that is its own phase, and building the page around one of its four panels would mean redoing it twice.

🤖