### PR TITLE
feat(logistics): hold the inventory grid open with the cards it is about to hold

### DIFF
--- a/app/frontend/frontend/pages/fleets/[slug]/logistics/index.vue
+++ b/app/frontend/frontend/pages/fleets/[slug]/logistics/index.vue
@@ -13,6 +13,8 @@ import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
+import { useOwnListGeometry } from "@/shared/composables/useOwnListGeometry";
 import Empty from "@/shared/components/Empty/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
 import MemberName from "@/frontend/components/Fleets/MemberName/index.vue";
@@ -64,6 +66,14 @@ const {
 
 const inventoryList = computed<FleetInventory[]>(
   () => inventories.value?.items ?? [],
+);
+
+// This page is the grid's frame: nothing wraps it, so the count its
+// placeholders reserve and the height they take are the page's own to keep.
+const { count: inventoryCount } = useOwnListGeometry(
+  "fleet-inventories",
+  inventoryList,
+  inventoriesLoading,
 );
 
 const refetchAll = async () => {
@@ -195,6 +205,15 @@ const crumbs = computed<Crumb[]>(() => [
       />
     </template>
   </Grid>
+
+  <!-- The cards this grid is about to hold, as many of them as it held last
+       time: a grid that answers with a spinner in the space it will fill grows
+       the page under the reader the moment the answer lands. -->
+  <GridSkeleton
+    v-else-if="inventoriesLoading"
+    variant="summary"
+    :count="inventoryCount"
+  />
 
   <Empty
     v-if="!inventoriesLoading && !inventoryList.length"

--- a/app/frontend/frontend/pages/hangar/inventories/index.vue
+++ b/app/frontend/frontend/pages/hangar/inventories/index.vue
@@ -12,6 +12,8 @@ import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
 import BtnGroup from "@/shared/components/base/BtnGroup/index.vue";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
+import { useOwnListGeometry } from "@/shared/composables/useOwnListGeometry";
 import Empty from "@/shared/components/Empty/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
 import InventoryPanel from "@/frontend/components/Logistics/InventoryPanel/index.vue";
@@ -43,6 +45,14 @@ const {
 
 const inventoryList = computed<HangarInventory[]>(
   () => inventories.value?.items ?? [],
+);
+
+// This page is the grid's frame: nothing wraps it, so the count its
+// placeholders reserve and the height they take are the page's own to keep.
+const { count: inventoryCount } = useOwnListGeometry(
+  "hangar-inventories",
+  inventoryList,
+  inventoriesLoading,
 );
 
 const refetchAll = async () => {
@@ -146,6 +156,15 @@ onMounted(() => {
       />
     </template>
   </Grid>
+
+  <!-- The cards this grid is about to hold, as many of them as it held last
+       time: a grid that answers with a spinner in the space it will fill grows
+       the page under the reader the moment the answer lands. -->
+  <GridSkeleton
+    v-else-if="inventoriesLoading"
+    variant="summary"
+    :count="inventoryCount"
+  />
 
   <Empty
     v-if="!inventoriesLoading && !inventoryList.length"

--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -8,6 +8,8 @@ export default {
 import Btn from "@/shared/components/base/Btn/index.vue";
 import BaseText from "@/shared/components/base/Text/index.vue";
 import Empty from "@/shared/components/Empty/index.vue";
+import InventoryPanel from "@/frontend/components/Logistics/InventoryPanel/index.vue";
+import type { InventoryPanelRecord } from "@/frontend/types/logistics";
 import Grid from "@/shared/components/base/Grid/index.vue";
 import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
 import ModelPanel from "@/frontend/components/Models/Panel/index.vue";
@@ -101,6 +103,34 @@ const emptyList: BaseList = {
   },
 };
 
+// The card the `summary` placeholders stand in for. Two of them, since the
+// second line of a card - a ship's name against a written location - is where
+// the heights of two cards in one row can differ.
+const inventories: InventoryPanelRecord[] = [
+  {
+    id: "inventory-1",
+    name: "Port Olisar Locker",
+    slug: "port-olisar-locker",
+    location: "Port Olisar",
+    entriesCount: 24,
+    totalScu: 118,
+    totalUnits: 1420,
+  },
+  {
+    id: "inventory-2",
+    name: "Ironclad Hold",
+    slug: "ironclad-hold",
+    entriesCount: 8,
+    totalScu: 384,
+    totalUnits: 0,
+    vehicle: {
+      id: "vehicle-1",
+      name: "Grey Hauler",
+      model: { slug: "ironclad", cargo: 384, personalInventory: 0 },
+    },
+  },
+];
+
 const perPage = ref<number | string>(25);
 
 const updatePerPage = (value: number | string) => {
@@ -163,6 +193,30 @@ const updatePerPage = (value: number | string) => {
   </p>
   <div class="vt-narrow-column" data-test="empty-narrow">
     <Empty :variant="EmptyVariantsEnum.BOX" hide-actions />
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H3">
+    GridSkeleton | The inventory cards
+  </Heading>
+  <p>
+    The <code>summary</code> variant, beside the cards it stands in for. These
+    carry no picture floor of their own — a heading over the top of the photo
+    and a strip of figures at the bottom of it — so the placeholder is built to
+    that shape instead of the ships card's.
+  </p>
+  <div class="row">
+    <div class="col-12 col-lg-6">
+      <BaseText muted no-spacing>cards</BaseText>
+      <Grid :records="inventories" primary-key="id" grid-base="2">
+        <template #default="{ record }">
+          <InventoryPanel :inventory="record" :to="{ name: 'home' }" />
+        </template>
+      </Grid>
+    </div>
+    <div class="col-12 col-lg-6">
+      <BaseText muted no-spacing>placeholders</BaseText>
+      <GridSkeleton :count="2" variant="summary" grid-base="2" />
+    </div>
   </div>
 
   <Heading :level="HeadingLevelEnum.H2">Loader</Heading>

--- a/app/frontend/shared/components/GridSkeleton/index.scss
+++ b/app/frontend/shared/components/GridSkeleton/index.scss
@@ -37,6 +37,50 @@
     }
   }
 
+  // The inventory cards are the same photo card in another shape - see
+  // InventoryPanel: no floor of their own, a heading over the top of the
+  // picture and a strip of figures at the bottom of it, so the height is those
+  // two plus the body's own minimum rather than a picture's.
+  &__panel--summary {
+    .grid-skeleton__media {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      min-height: 0;
+    }
+
+    // The heading is PanelHeading's own type rather than the ships card's: a
+    // `2xl` title on a 2rem line, and HeadingSmall's 70% of that below it on a
+    // line of the same height. Both bars stand exactly as tall as the line
+    // each replaces, which is what the card's own height is made of.
+    .grid-skeleton__heading {
+      gap: 8px;
+    }
+
+    .skeleton-bar--title {
+      font-size: 1.5rem;
+      line-height: 2rem;
+    }
+
+    .skeleton-bar--subtitle {
+      width: 46%;
+      font-size: 1.05rem;
+      line-height: 2rem;
+    }
+  }
+
+  // Mirrors PanelBody's own `4px 18px 18px` and the floor the inventory card's
+  // body carries, with the figure at the type its count is set in - the strip
+  // is the taller half of that card, and a bar of body text there would leave
+  // the placeholder a third short.
+  &__counts {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-height: 60px;
+    padding: 4px 18px 18px;
+  }
+
   // A card on the ships grid passes no body, so its height is exactly the
   // image floor - which is the one measurement a placeholder has to match, and
   // the reason the bars inside it need no height of their own.
@@ -100,6 +144,19 @@
       display: block;
       width: 42%;
       font-size: 10px;
+    }
+
+    // The count and its label, at the type each is set in: `2em` on a single
+    // line is what makes the figure the tall thing in that strip.
+    &--figure {
+      width: 46px;
+      font-size: 2em;
+      line-height: 1;
+    }
+
+    &--figure-label {
+      width: 84px;
+      font-size: 0.8em;
     }
   }
 

--- a/app/frontend/shared/components/GridSkeleton/index.vue
+++ b/app/frontend/shared/components/GridSkeleton/index.vue
@@ -16,10 +16,12 @@ type Props = {
   filterVisible?: boolean;
   gridBase?: "2" | "3";
   // What the cells of this grid hold. `panel` is a card - a photo with a title
-  // over it and a frame around it. The other two are bare: `image` a gallery
-  // picture, which is as tall as its token whatever the column width, and
-  // `embed` a video, which is 16:9 of it.
-  variant?: "panel" | "image" | "embed";
+  // over it and a frame around it. `summary` is the same card in the shape the
+  // inventory grids use - see InventoryPanel - which carries no picture floor
+  // of its own and closes with a strip of figures over the bottom of the photo.
+  // The other two are bare: `image` a gallery picture, which is as tall as its
+  // token whatever the column width, and `embed` a video, which is 16:9 of it.
+  variant?: "panel" | "summary" | "image" | "embed";
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -72,7 +74,7 @@ const dimensionRows = 6;
     <!-- No frame and no title: a cell of the image grid holds the picture
          itself, and one of the video grid the embed. -->
     <span
-      v-if="props.variant !== 'panel'"
+      v-if="props.variant === 'image' || props.variant === 'embed'"
       class="grid-skeleton__bare skeleton-well"
       :class="`grid-skeleton__bare--${props.variant}`"
       :style="{ height: cardHeight }"
@@ -84,7 +86,10 @@ const dimensionRows = 6;
     <Panel
       v-else
       class="grid-skeleton__panel"
-      :class="{ 'grid-skeleton__panel--measured': !!cardHeight }"
+      :class="{
+        'grid-skeleton__panel--measured': !!cardHeight,
+        'grid-skeleton__panel--summary': props.variant === 'summary',
+      }"
       :style="{ height: cardHeight }"
     >
       <template #default>
@@ -95,6 +100,13 @@ const dimensionRows = 6;
           <div class="grid-skeleton__heading">
             <span class="skeleton-bar skeleton-bar--title" />
             <span class="skeleton-bar skeleton-bar--subtitle" />
+          </div>
+
+          <!-- The card's own body, which on these cards is a count and what it
+               counts, over the bottom of the picture rather than under it. -->
+          <div v-if="props.variant === 'summary'" class="grid-skeleton__counts">
+            <span class="skeleton-bar skeleton-bar--figure" />
+            <span class="skeleton-bar skeleton-bar--figure-label" />
           </div>
         </div>
       </template>

--- a/app/frontend/shared/composables/useOwnListGeometry.spec.ts
+++ b/app/frontend/shared/composables/useOwnListGeometry.spec.ts
@@ -1,0 +1,87 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
+import { defineComponent, ref, type Component } from "vue";
+import GridSkeleton from "@/shared/components/GridSkeleton/index.vue";
+import { useOwnListGeometry } from "./useOwnListGeometry";
+import { useListGeometryStore } from "@/shared/stores/listGeometry";
+
+// A real store rather than the testing one: what is under test is the round
+// trip through it, and the testing pinia stubs the action that writes.
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+type Record = { id: string };
+
+// Stands in for a page with a grid of its own: no FilteredList anywhere, so the
+// page is the only thing that can frame it.
+const host = (records: Record[], loading: boolean) =>
+  defineComponent({
+    components: { GridSkeleton: GridSkeleton as unknown as Component },
+    setup() {
+      const { count } = useOwnListGeometry(
+        "inventories",
+        ref(records),
+        ref(loading),
+      );
+
+      return { count, loading };
+    },
+    template: `
+      <GridSkeleton v-if="loading" variant="summary" />
+      <span class="count">{{ count }}</span>
+    `,
+  });
+
+const render = async (component: Component) => {
+  const wrapper = mount(component, {
+    global: { directives: { Tooltip: {} } },
+  });
+
+  await flushPromises();
+
+  return wrapper;
+};
+
+describe("useOwnListGeometry", () => {
+  it("reserves a short list until this one has been seen", async () => {
+    const wrapper = await render(host([], true));
+
+    expect(wrapper.get(".count").text()).toBe("3");
+    expect(wrapper.findAll(".grid-skeleton__panel")).toHaveLength(3);
+  });
+
+  it("remembers what the answer held and reserves that next time", async () => {
+    await render(
+      host([{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }], false),
+    );
+
+    expect(useListGeometryStore().countByKey("inventories")).toBe(4);
+
+    const next = await render(host([], true));
+
+    expect(next.get(".count").text()).toBe("4");
+    expect(next.findAll(".grid-skeleton__panel")).toHaveLength(4);
+  });
+
+  // A list read mid-load is empty for a reason that says nothing about its size.
+  it("takes no reading while the answer is still on its way", async () => {
+    await render(host([], true));
+
+    expect(useListGeometryStore().countByKey("inventories")).toBeUndefined();
+  });
+
+  // Zero is a reading like any other: a reader with no inventories should have
+  // nothing reserved for them.
+  it("keeps a list known to be empty at nothing", async () => {
+    await render(host([], false));
+
+    expect(useListGeometryStore().countByKey("inventories")).toBe(0);
+
+    const next = await render(host([], true));
+
+    expect(next.get(".count").text()).toBe("0");
+    expect(next.findAll(".grid-skeleton__panel")).toHaveLength(0);
+  });
+});

--- a/app/frontend/shared/composables/useOwnListGeometry.ts
+++ b/app/frontend/shared/composables/useOwnListGeometry.ts
@@ -1,0 +1,48 @@
+import { provideListGeometry } from "@/shared/composables/useListGeometry";
+import { useListGeometryStore } from "@/shared/stores/listGeometry";
+import type { ComputedRef, MaybeRefOrGetter } from "vue";
+
+// For a page that draws a list of its own with no FilteredList around it. It
+// becomes that list's frame, so the placeholders it puts up can read the same
+// two things a framed list's read: how many records the answer is expected to
+// hold, and what one of them measured last time.
+//
+// The count is this list's own high-water mark, because there is no page size
+// to read a bound off - an unpaginated grid holds what it holds, and what it
+// held last time is the only honest reading of that. The height comes back
+// through the geometry, which whatever drew the records reports into: Grid and
+// BaseTable both do it already.
+export const useOwnListGeometry = (
+  name: string,
+  records: MaybeRefOrGetter<unknown[]>,
+  loading: MaybeRefOrGetter<boolean>,
+  // Where nothing is known yet. Small on purpose: a page of placeholders
+  // reserved for a reader who keeps two of something is a screenful of nothing.
+  fallback = 3,
+): { count: ComputedRef<number> } => {
+  const store = useListGeometryStore();
+
+  // Once the answer is in, whatever it held - including nothing. A list read
+  // mid-load is empty for a reason that says nothing about how much it holds.
+  watch(
+    [() => toValue(records).length, () => toValue(loading)],
+    ([count, busy]) => {
+      if (!busy) {
+        store.recordCount(name, count);
+      }
+    },
+    { immediate: true },
+  );
+
+  const count = computed(() => store.countByKey(name) ?? fallback);
+
+  // The page is showing a spinner of its own over these placeholders, so a list
+  // rendered inside them knows not to put up a second.
+  provideListGeometry(
+    name,
+    count,
+    computed(() => toValue(loading)),
+  );
+
+  return { count };
+};


### PR DESCRIPTION
The one thing #4699 left alone: the inventory cards above the tabs on the two logistics pages, which answered their first load with a spinner in the space the cards were about to fill. On a page whose grid is the top half of it, that is the whole layout moving when the answer lands.

Rebased onto main now that #4695 and #4699 have landed, so this stands on its own.

## Why not the card GridSkeleton already had

`GridSkeleton` knew one card: the ships card, whose height *is* the image floor it stands on (286px). An `InventoryPanel` is the same photo card in another shape — no floor of its own, a heading over the top of the picture and a strip of figures at the bottom of it — so the existing placeholder would have stood nearly twice too tall, which is the same jump pointing the other way.

`summary` is that shape: the heading at `PanelHeading`'s own type rather than the ships card's (a `2xl` title on a 2rem line, `HeadingSmall`'s 70% of it below), a figure bar at the `2em` the count is set in, `PanelBody`'s own insets and the 60px floor the card's body carries, and the picture region taking whatever those leave.

## Why the page needs a frame

A framed list gets two readings for free — how many records to expect, and what one of them measured — and this grid has no frame. `useOwnListGeometry` makes the page the frame: it keeps the high-water count of what the answer held (an unpaginated grid has no page size to read a bound off, so what it held last time is the only honest reading) and provides it alongside the card height `Grid` already reports back. Three cards where nothing is known yet.

- A reading is only taken once the answer is in, so an empty mid-load list never counts as a short one.
- Zero is a reading like any other: a reader with no inventories has nothing reserved for them.

## Checks

- 4 new tests for the composable — the fallback, the round trip through the store into the placeholder count, no reading while loading, and a list known to be empty. `GridSkeleton`'s own 4 still pass, `lint:ts` clean.
- A new visual-test case at **states → GridSkeleton | The inventory cards**, which puts two real cards beside two placeholders, since a placeholder of a different height is the whole thing this is here to prevent.

**One caveat, stated plainly:** the placeholder's height is built from the card's recipe, not measured against it — I could not boot a server for this worktree without a 1Password unlock. From the second load on it uses the height a real card measured, so the recipe only carries the first load after a browser is opened. The visual-test case above is where the two can be held against each other if you want to check that first load by eye.

🤖
