### PR TITLE
feat(stats): show which ships people started wanting

### DIFF
--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -282,6 +282,31 @@ module Api
         @sales = @model.sales.recent_first
       end
 
+      # Additions per month, not the standing total: the rollup counts when a
+      # wishlist entry was created, so a steadily wanted ship draws a flat line.
+      def wishlist_history
+        model = find_model_by_slug!
+        return if performed?
+
+        wishlist_history = Rollup
+          .where(
+            name: MetricsJob::ROLLUP_WISHLIST_BY_MODEL,
+            interval: "month",
+            dimensions: {model_id: model.id}
+          )
+          .where("time > ?", 1.year.ago)
+          .order(:time)
+          .map do |entry|
+            {
+              label: I18n.l(entry.time.to_date, format: :month_year_short),
+              count: entry.value.to_i,
+              tooltip: I18n.l(entry.time.to_date, format: :month_year)
+            }
+          end
+
+        render json: wishlist_history.to_json
+      end
+
       def store_image
         model = find_model_by_slug(Model.visible.active)
         return if performed?

--- a/app/controllers/api/v1/stats/base_controller.rb
+++ b/app/controllers/api/v1/stats/base_controller.rb
@@ -62,6 +62,22 @@ module Api
           render json: trending_ships.to_json
         end
 
+        def most_wishlisted
+          model_additions = Rollup
+            .where(name: MetricsJob::ROLLUP_WISHLIST_BY_MODEL, interval: "month")
+            .where(time: Time.current.beginning_of_month)
+            .group(Arel.sql("dimensions->>'model_id'"))
+            .sum(:value)
+
+          names = Model.visible.active.where(id: model_additions.keys).pluck(:id, :name).to_h
+
+          most_wishlisted = transform_for_bar_chart(
+            model_additions.filter_map { |id, additions| [names[id], additions.to_i] if names.key?(id) }.to_h
+          ).take(10)
+
+          render json: most_wishlisted.to_json
+        end
+
         def components_by_class
           components_by_class = transform_for_pie_chart(
             Component.group(:component_class).count

--- a/app/frontend/frontend/pages/stats.vue
+++ b/app/frontend/frontend/pages/stats.vue
@@ -30,6 +30,7 @@ import {
   useVehiclesPerMonth as useVehiclesPerMonthQuery,
   useShipsOfTheMonth as useShipsOfTheMonthQuery,
   useTrendingShips as useTrendingShipsQuery,
+  useMostWishlisted as useMostWishlistedQuery,
 } from "@/services/fyApi";
 
 const { t } = useI18n();
@@ -61,6 +62,9 @@ const { data: shipsOfTheMonthOptions, ...shipsOfTheMonthStatus } =
 
 const { data: trendingShipsOptions, ...trendingShipsStatus } =
   useTrendingShipsQuery();
+
+const { data: mostWishlistedOptions, ...mostWishlistedStatus } =
+  useMostWishlistedQuery();
 
 const route = useRoute();
 
@@ -128,6 +132,11 @@ const csvCharts = computed(() => ({
     name: "trending-ships",
     title: t("labels.stats.trendingShips"),
     points: trendingShipsOptions.value,
+  },
+  "most-wishlisted": {
+    name: "most-wishlisted",
+    title: t("labels.stats.mostWishlisted"),
+    points: mostWishlistedOptions.value,
   },
   "vehicles-by-model": {
     name: "vehicles-by-model",
@@ -343,6 +352,33 @@ const csvMetrics = computed<StatsMetric[]>(() => [
             name="trending-ships"
             :async-status="trendingShipsStatus"
             :options="trendingShipsOptions"
+            tooltip-type="ship"
+            type="bar"
+          />
+        </PanelBody>
+      </Panel>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.stats.mostWishlisted") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['most-wishlisted']"
+            />
+          </template>
+        </PanelHeading>
+        <PanelBody>
+          <Chart
+            v-if="mostWishlistedOptions"
+            key="most-wishlisted"
+            name="most-wishlisted"
+            :async-status="mostWishlistedStatus"
+            :options="mostWishlistedOptions"
             tooltip-type="ship"
             type="bar"
           />

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -186,6 +186,7 @@
         "topVehiclesByModel": "Top 10 Hangar Schiffe",
         "shipsOfTheMonth": "Schiff des Monats",
         "trendingShips": "Meistgesehene Schiffe (30 Tage)",
+        "mostWishlisted": "Meistgewünschte Schiffe diesen Monat",
         "crewDeficit": "Crew Defizit",
         "crewSurplus": "Crew Überschuss",
         "membersByRole": "Mitglieder nach Rolle",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -186,6 +186,7 @@
         "topVehiclesByModel": "Top 10 Hangared Ships",
         "shipsOfTheMonth": "Ship of the Month",
         "trendingShips": "Most Viewed Ships (30 Days)",
+        "mostWishlisted": "Most Wishlisted This Month",
         "crewDeficit": "Crew Deficit",
         "crewSurplus": "Crew Surplus",
         "membersByRole": "Members by Role",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -186,6 +186,7 @@
         "topVehiclesByModel": "Top 10 naves en hangar",
         "shipsOfTheMonth": "Nave del mes",
         "trendingShips": "Naves más vistas (30 días)",
+        "mostWishlisted": "Naves más deseadas este mes",
         "crewDeficit": "Déficit de tripulación",
         "crewSurplus": "Excedente de tripulación",
         "membersByRole": "Miembros por rol",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -186,6 +186,7 @@
         "topVehiclesByModel": "Top 10 vaisseaux en hangar",
         "shipsOfTheMonth": "Vaisseau du mois",
         "trendingShips": "Vaisseaux les plus consultés (30 jours)",
+        "mostWishlisted": "Vaisseaux les plus souhaités ce mois-ci",
         "crewDeficit": "Déficit d'équipage",
         "crewSurplus": "Excédent d'équipage",
         "membersByRole": "Membres par rôle",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -186,6 +186,7 @@
         "topVehiclesByModel": "Top 10 navi in hangar",
         "shipsOfTheMonth": "Nave del mese",
         "trendingShips": "Navi più viste (30 giorni)",
+        "mostWishlisted": "Navi più desiderate questo mese",
         "crewDeficit": "Deficit equipaggio",
         "crewSurplus": "Surplus equipaggio",
         "membersByRole": "Membri per ruolo",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -186,6 +186,7 @@
         "topVehiclesByModel": "前 10 机库飞船",
         "shipsOfTheMonth": "月度飞船",
         "trendingShips": "浏览最多的飞船（30 天）",
+        "mostWishlisted": "本月最受期待的飞船",
         "crewDeficit": "船员缺口",
         "crewSurplus": "船员盈余",
         "membersByRole": "按角色分组成员",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -186,6 +186,7 @@
         "topVehiclesByModel": "前 10 機庫飛船",
         "shipsOfTheMonth": "月度飛船",
         "trendingShips": "瀏覽最多的飛船（30 天）",
+        "mostWishlisted": "本月最受期待的飛船",
         "crewDeficit": "船員缺口",
         "crewSurplus": "船員盈餘",
         "membersByRole": "按角色分組成員",

--- a/app/jobs/metrics_job.rb
+++ b/app/jobs/metrics_job.rb
@@ -9,6 +9,11 @@ class MetricsJob < ApplicationJob
 
   ROLLUP_SHIP_VIEWS = "Ship Views"
 
+  # Its own name rather than a dimension on `Vehicle Wish`: the same name and
+  # interval would then hold both a total row and one row per model, and reading
+  # the plain series back would have to know to ask for the empty dimensions.
+  ROLLUP_WISHLIST_BY_MODEL = "Vehicle Wish by Model"
+
   def perform
     User.rollup("Registrations", interval: "month")
     User.rollup("Registrations", interval: "year")
@@ -25,6 +30,7 @@ class MetricsJob < ApplicationJob
     Vehicle.visible.wanted.where(loaner: false).rollup("Vehicle Wish", interval: "month")
 
     track_ship_views
+    track_wishlist_by_model
     track_ship_of_the_month
     track_api_usage
   end
@@ -60,6 +66,18 @@ class MetricsJob < ApplicationJob
       # a bare word, which an expression is not.
       dimension_names: ["model_slug"]
     )
+  end
+
+  # Which ship the wishlist grew by, which the dimensionless `Vehicle Wish`
+  # rollup beside it cannot say.
+  #
+  # This counts `created_at`, so it measures wishlist *additions* in a month
+  # rather than how many people want the ship in total. A ship whose demand is
+  # steady and high shows a flat line, not a rising one.
+  def track_wishlist_by_model
+    Vehicle.visible.wanted.where(loaner: false)
+      .group(:model_id)
+      .rollup(ROLLUP_WISHLIST_BY_MODEL, interval: "month")
   end
 
   # Rolls up every day still held in Redis, not just yesterday, so a failed run

--- a/config/routes/api/models_routes.rb
+++ b/config/routes/api/models_routes.rb
@@ -21,6 +21,7 @@ resources :models, param: :slug, only: %i[index show] do
     get :upgrades
     get :paints
     get :sales
+    get :wishlist_history, path: "wishlist-history"
     get :store_image, path: "store-image"
     get :fleetchart_image, path: "fleetchart-image"
   end

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -102,6 +102,7 @@ v1_api_routes = lambda do
     get "vehicles-per-month", to: "base#vehicles_per_month"
     get "ships-of-the-month", to: "base#ships_of_the_month"
     get "trending-ships", to: "base#trending_ships"
+    get "most-wishlisted", to: "base#most_wishlisted"
   end
 end
 

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7602,6 +7602,34 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/models/{slug}/wishlist-history":
+    parameters:
+    - name: slug
+      in: path
+      schema:
+        type: string
+      description: Model slug
+      required: true
+    get:
+      summary: Model Wishlist History
+      tags:
+      - Models
+      operationId: modelWishlistHistory
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BarChartStatsList"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/notification-preferences":
     get:
       summary: List notification preferences
@@ -9505,6 +9533,19 @@ paths:
       tags:
       - Stats
       operationId: modelsPerMonth
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BarChartStatsList"
+  "/stats/most-wishlisted":
+    get:
+      summary: Stats Most Wishlisted
+      tags:
+      - Stats
+      operationId: mostWishlisted
       responses:
         '200':
           description: successful

--- a/test/integration/api/v1/models_wishlist_history_test.rb
+++ b/test/integration/api/v1/models_wishlist_history_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::ModelsWishlistHistoryTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/models/{slug}/wishlist-history" do
+    parameter name: "slug", in: :path, schema: {type: :string}, description: "Model slug", required: true
+
+    get("Model Wishlist History") do
+      operationId "modelWishlistHistory"
+      tags "Models"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Shared::V1::Schemas::BarChartStatsList
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  test "GET /models/:slug/wishlist-history returns the months oldest first" do
+    model = create(:model)
+    record_additions(model, 3, at: 3.months.ago)
+    record_additions(model, 8, at: 1.month.ago)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal [3, 8], parsed_body.map { |point| point["count"] }
+    end
+  end
+
+  test "GET /models/:slug/wishlist-history leaves out other ships" do
+    model = create(:model)
+    other = create(:model)
+    record_additions(model, 5, at: 1.month.ago)
+    record_additions(other, 40, at: 1.month.ago)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal [5], parsed_body.map { |point| point["count"] }
+    end
+  end
+
+  test "GET /models/:slug/wishlist-history answers for a ship nobody has wishlisted" do
+    model = create(:model)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /models/:slug/wishlist-history returns 404 for unknown model" do
+    assert_api_response :get, 404, path_params: {slug: "unknown-model"}
+  end
+
+  private def record_additions(model, additions, at:)
+    Rollup.create!(
+      name: MetricsJob::ROLLUP_WISHLIST_BY_MODEL,
+      interval: "month",
+      time: at.beginning_of_month,
+      value: additions,
+      dimensions: {model_id: model.id}
+    )
+  end
+end

--- a/test/integration/api/v1/stats_most_wishlisted_test.rb
+++ b/test/integration/api/v1/stats_most_wishlisted_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::StatsMostWishlistedTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/stats/most-wishlisted" do
+    get("Stats Most Wishlisted") do
+      operationId "mostWishlisted"
+      tags "Stats"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Shared::V1::Schemas::BarChartStatsList
+      end
+    end
+  end
+
+  test "GET /stats/most-wishlisted returns chart data" do
+    assert_api_response :get, 200
+  end
+
+  test "GET /stats/most-wishlisted ranks ships by this month's additions" do
+    popular = create(:model)
+    quiet = create(:model)
+    record_additions(popular, 30)
+    record_additions(quiet, 4)
+
+    assert_api_response :get, 200 do
+      assert_equal [popular.name, quiet.name], parsed_body.map { |point| point["label"] }
+      assert_equal [30, 4], parsed_body.map { |point| point["count"] }
+    end
+  end
+
+  test "GET /stats/most-wishlisted drops a ship that is no longer visible" do
+    hidden = create(:model, hidden: true)
+    record_additions(hidden, 50)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /stats/most-wishlisted ignores earlier months" do
+    model = create(:model)
+    record_additions(model, 9, at: 3.months.ago)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  private def record_additions(model, additions, at: Time.current)
+    Rollup.create!(
+      name: MetricsJob::ROLLUP_WISHLIST_BY_MODEL,
+      interval: "month",
+      time: at.beginning_of_month,
+      value: additions,
+      dimensions: {model_id: model.id}
+    )
+  end
+end

--- a/test/jobs/metrics_job_test.rb
+++ b/test/jobs/metrics_job_test.rb
@@ -122,4 +122,45 @@ class MetricsJobTest < ActiveJob::TestCase
       dimensions: {model_slug: slug}
     ).sum(:value)
   end
+
+  test "#perform rolls up wishlist additions per model" do
+    wanted = create(:model)
+    other = create(:model)
+    create_list(:vehicle, 2, model: wanted, wanted: true, loaner: false)
+    create(:vehicle, model: other, wanted: true, loaner: false)
+
+    MetricsJob.new.perform
+
+    assert_equal 2, wishlist_additions(wanted)
+    assert_equal 1, wishlist_additions(other)
+  end
+
+  test "#perform leaves purchased ships out of the wishlist rollup" do
+    model = create(:model)
+    create(:vehicle, model:, wanted: true, loaner: false)
+    create(:vehicle, model:, wanted: false, loaner: false)
+
+    MetricsJob.new.perform
+
+    assert_equal 1, wishlist_additions(model)
+  end
+
+  # The dimensionless series is twelve years of history and nothing else writes
+  # it, so the per-model rollup has to sit beside it rather than replace it.
+  test "#perform keeps the plain wishlist series" do
+    model = create(:model)
+    create(:vehicle, model:, wanted: true, loaner: false)
+
+    MetricsJob.new.perform
+
+    assert_operator Rollup.where(name: "Vehicle Wish", interval: "month").count, :>, 0
+  end
+
+  private def wishlist_additions(model)
+    Rollup.where(
+      name: MetricsJob::ROLLUP_WISHLIST_BY_MODEL,
+      interval: "month",
+      dimensions: {model_id: model.id}
+    ).sum(:value)
+  end
 end


### PR DESCRIPTION
Phase 3 of the stats plan (#4697): give the wishlist rollup a ship, and read it two ways.

## Why

`Vehicle Wish` has been rolled up monthly for years, but without a dimension — it knows how many wishlist entries exist and cannot say which ship any of them is for. So the one question the wishlist can answer, *which ships are people starting to want*, was unanswerable, while 457k wishlist entries sat in the table.

## What changed

**Collection.** A per-model rollup of wishlist additions, monthly.

- It gets **its own name** (`Vehicle Wish by Model`) rather than a dimension on the existing rollup. Under one name and interval the table would hold both a total row and up to 243 per-model rows, and every reader of the plain series would have to know to ask for the empty dimensions. Two names, two unambiguous series.
- The dimensionless rollup keeps running beside it. Nothing currently reads it — the `wishlistsCount` tile does a live `Vehicle.where(wanted: true).count`, not a rollup lookup — but it is twelve years of history and nothing else writes it, so removing it is destructive and reversible by nobody.

**Reading.** `/stats/most-wishlisted` ranks this month's additions, with a panel on `/stats`. `/models/:slug/wishlist-history` gives one ship its last twelve months.

Both resolve the rollup's model ids through `Model.visible.active`, so a ship since hidden or retired drops out instead of charting a name nobody can click — the same resolution step the trending-ships endpoint does for slugs.

## What it measures, and what it does not

The rollup counts `created_at`, so it is **additions**, not standing demand. A ship that is steadily and heavily wanted draws a flat line, not a rising one. The label says "Most Wishlisted This Month" for that reason; anything implying a total would be wrong.

Like `Ship of the Month` next to it, the chart reads a partial current month, so it is thin on the 1st and fills through the month. That is the existing convention on this page rather than a new quirk.

## Verification

- 3 job tests: additions counted per model, purchased ships stayed out, and the plain series still written beside the new one.
- 8 endpoint tests across both endpoints — ranking, a hidden ship dropped, earlier months ignored, another ship's rows not leaking in, and a ship nobody has wishlisted answering rather than erroring.
- `35 tests, 83 assertions, 0 failures` across the metrics job and every `stats_*` integration test. `standardrb` clean, `pnpm lint:ts` exits 0, label added in all seven locales.

## Not verified / not in scope

- I did not open the page in a browser. The panel takes the same props as the two bar-chart panels beside it and TypeScript is clean, but that is an argument rather than a check.
- **`/models/:slug/wishlist-history` has no caller yet.** It is the data the ship history page is built on, and that page is its own phase — building it around one of its four panels would mean building it twice.
- The first `MetricsJob` run computes the new series from scratch over every wishlist entry ever created, which is one grouped pass and then only the current month each night. Worth an eye on the `rollups` row count after it: up to 243 models times the months they have existed.

🤖