### PR TITLE
fix(lists): put the picture floor back under the summary placeholder

### DIFF
--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -200,9 +200,10 @@ const updatePerPage = (value: number | string) => {
   </Heading>
   <p>
     The <code>summary</code> variant, beside the cards it stands in for. These
-    carry no picture floor of their own — a heading over the top of the photo
-    and a strip of figures at the bottom of it — so the placeholder is built to
-    that shape instead of the ships card's.
+    stand on the same picture floor the ships card does, but carry a strip of
+    figures at the bottom of the photo as well as a heading at the top of it —
+    290px against 290px, which is the measurement the pair is here to keep
+    honest.
   </p>
   <div class="row">
     <div class="col-12 col-lg-6">

--- a/app/frontend/shared/components/GridSkeleton/index.scss
+++ b/app/frontend/shared/components/GridSkeleton/index.scss
@@ -37,16 +37,21 @@
     }
   }
 
-  // The inventory cards are the same photo card in another shape - see
-  // InventoryPanel: no floor of their own, a heading over the top of the
-  // picture and a strip of figures at the bottom of it, so the height is those
-  // two plus the body's own minimum rather than a picture's.
+  // The inventory cards - see InventoryPanel - stand on the same picture floor
+  // the ships card does, since both are a Panel carrying a bg-image, so the
+  // height is that floor and not the sum of what sits over it. What differs is
+  // what sits over it: a heading at the top of the picture and a strip of
+  // figures at the bottom, rather than a heading alone.
+  //
+  // Measured against the card on /visual-tests/states/: 290px against 290px.
+  // Dropping the floor here, on the reasoning that a card with a body must be
+  // as tall as its parts, came out 126px short - the body carries `flex: 1` and
+  // grows into the floor rather than setting the height.
   &__panel--summary {
     .grid-skeleton__media {
       display: flex;
       flex-direction: column;
       justify-content: space-between;
-      min-height: 0;
     }
 
     // The heading is PanelHeading's own type rather than the ships card's: a
@@ -70,9 +75,9 @@
   }
 
   // Mirrors PanelBody's own `4px 18px 18px` and the floor the inventory card's
-  // body carries, with the figure at the type its count is set in - the strip
-  // is the taller half of that card, and a bar of body text there would leave
-  // the placeholder a third short.
+  // body carries, with the figure at the type its count is set in: the count is
+  // the tall thing in that strip, and a bar of body text there would sit a
+  // third of a line low.
   &__counts {
     display: flex;
     align-items: baseline;


### PR DESCRIPTION
Follow-up to #4701, which went into the merge queue before I could measure it. The `summary` placeholder it added stands **126px short** of the card it stands in for.

| | height |
|---|---|
| real `InventoryPanel` | 290px |
| placeholder as merged | 164px |
| placeholder here | 290px |

## What was wrong

I built the placeholder from the card's parts — a card with a body must be as tall as its heading plus its body — and dropped the picture floor on that reasoning. But `InventoryPanel` stands on the same 286px floor the ships card does: both are a `Panel` carrying a `bg-image`, and `.panel--has-bg` sets `min-height: var(--panel-image-height, 286px)`. The card's body carries `flex: 1`, so it *grows into* that floor rather than setting the height — which is why reasoning from the parts came out at a little over half the card, the same jump #4701 set out to remove, pointing the other way.

One line (`min-height: 0`, deleted). The reasoning that was wrong is written into the stylesheet rather than just removed, since the next person to look at a card with a body under a picture will reason the same way.

## Checks

Measured against the real card on `/visual-tests/states/` — the demo #4701 added puts the two side by side, which is where the numbers above come from. The demo's copy is corrected here too: it claimed these cards carry no picture floor.

The general lesson, for what it is worth: every other placeholder in this series was checked against the thing it replaces before it shipped, and this one was not, because a worktree had no server. It was wrong.

🤖
