### PR TITLE
feat(prices): keep the prices the UEX sync overwrites every morning

### DIFF
--- a/app/api_components/v1/schemas/commodities/commodity_price_point.rb
+++ b/app/api_components/v1/schemas/commodities/commodity_price_point.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Commodities
+      # One day of one commodity's prices, across every terminal that listed it.
+      #
+      # `sold` is the shop selling and `bought` the shop buying, the same
+      # perspective `soldAt` and `boughtAt` use on the commodity itself. A day
+      # nobody sold it has the `sold` figures null rather than zero.
+      class CommodityPricePoint
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            recordedOn: {type: :string, format: :date},
+            soldLowest: {type: [:number, :null]},
+            soldAverage: {type: [:number, :null]},
+            soldHighest: {type: [:number, :null]},
+            boughtLowest: {type: [:number, :null]},
+            boughtAverage: {type: [:number, :null]},
+            boughtHighest: {type: [:number, :null]}
+          },
+          required: %i[recordedOn],
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/commodities/commodity_price_points_list.rb
+++ b/app/api_components/v1/schemas/commodities/commodity_price_points_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Commodities
+      class CommodityPricePointsList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :array,
+          items: {"$ref": "#/components/schemas/CommodityPricePoint"}
+        })
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/commodities_controller.rb
+++ b/app/controllers/api/v1/commodities_controller.rb
@@ -3,9 +3,13 @@
 module Api
   module V1
     class CommoditiesController < ::Api::PublicBaseController
-      skip_verify_authorized only: %i[index]
+      skip_verify_authorized only: %i[index price_history]
 
       after_action -> { pagination_header(:commodities) }, only: [:index]
+
+      # How far back the chart reaches. Two years are retained, but a commodity
+      # chart people read to trade on is about the last few months.
+      PRICE_HISTORY_WINDOW = 90.days
 
       def index
         commodities_query_params["sorts"] = "name asc"
@@ -29,6 +33,44 @@ module Api
         @commodities = @q.result
           .page(params[:page])
           .per(per_page(Commodity))
+      end
+
+      def price_history
+        commodity = Commodity.find_by!(slug: params[:slug].to_s.downcase)
+
+        # One row per day and direction, folded into a row per day below. Doing
+        # the aggregation in Postgres keeps a 90-day window at a few hundred
+        # rows rather than every snapshot the commodity has.
+        per_day_and_direction = ItemPriceSnapshot
+          .where(item_type: "Commodity", item_id: commodity.id)
+          .recorded_since(PRICE_HISTORY_WINDOW.ago.to_date)
+          .group(:recorded_on, :price_type)
+          .pluck(
+            :recorded_on,
+            :price_type,
+            Arel.sql("MIN(price)"),
+            Arel.sql("AVG(price)"),
+            Arel.sql("MAX(price)")
+          )
+
+        @price_history = fold_price_history(per_day_and_direction)
+      end
+
+      # `sell` is the shop selling, which is where a player buys -- the same
+      # perspective `soldAt` and `boughtAt` already use on the item itself.
+      private def fold_price_history(rows)
+        days = Hash.new { |result, day| result[day] = {recorded_on: day} }
+
+        rows.each do |day, price_type, lowest, average, highest|
+          # `pluck` casts an enum back to its name, so this compares strings.
+          prefix = (price_type.to_s == "sell") ? :sold : :bought
+
+          days[day][:"#{prefix}_lowest"] = lowest
+          days[day][:"#{prefix}_average"] = average&.round(2)
+          days[day][:"#{prefix}_highest"] = highest
+        end
+
+        days.values.sort_by { |day| day[:recorded_on] }
       end
 
       # Taken out of the ransack params rather than left in them: it is a scope,

--- a/app/controllers/api/v1/stats/base_controller.rb
+++ b/app/controllers/api/v1/stats/base_controller.rb
@@ -78,6 +78,43 @@ module Api
           render json: most_wishlisted.to_json
         end
 
+        # How far back a price movement is measured over. A week is long enough
+        # to be a trend rather than a terminal restocking.
+        PRICE_MOVER_WINDOW = 7.days
+
+        def price_movers
+          latest_day = ItemPriceSnapshot.where(item_type: "Commodity").maximum(:recorded_on)
+          earlier_day = latest_day && ItemPriceSnapshot
+            .where(item_type: "Commodity", recorded_on: ..(latest_day - PRICE_MOVER_WINDOW))
+            .maximum(:recorded_on)
+
+          # Nothing to compare against until the second week of collecting.
+          return render(json: [].to_json) if earlier_day.blank?
+
+          now = average_sold_prices(latest_day)
+          before = average_sold_prices(earlier_day)
+
+          names = Commodity.where(id: now.keys & before.keys).pluck(:id, :name).to_h
+
+          price_movers = names.filter_map do |id, name|
+            change = (now[id] - before[id]).round
+            next if change.zero?
+
+            {label: name, count: change, tooltip: name}
+          end
+
+          # By size of the move rather than by value, so the steepest drop ranks
+          # beside the steepest rise instead of falling off the end.
+          render json: price_movers.sort_by { |mover| -mover[:count].abs }.take(10).to_json
+        end
+
+        private def average_sold_prices(day)
+          ItemPriceSnapshot
+            .where(item_type: "Commodity", recorded_on: day, price_type: "sell")
+            .group(:item_id)
+            .average(:price)
+        end
+
         def components_by_class
           components_by_class = transform_for_pie_chart(
             Component.group(:component_class).count

--- a/app/frontend/frontend/pages/stats.vue
+++ b/app/frontend/frontend/pages/stats.vue
@@ -31,6 +31,7 @@ import {
   useShipsOfTheMonth as useShipsOfTheMonthQuery,
   useTrendingShips as useTrendingShipsQuery,
   useMostWishlisted as useMostWishlistedQuery,
+  usePriceMovers as usePriceMoversQuery,
 } from "@/services/fyApi";
 
 const { t } = useI18n();
@@ -65,6 +66,8 @@ const { data: trendingShipsOptions, ...trendingShipsStatus } =
 
 const { data: mostWishlistedOptions, ...mostWishlistedStatus } =
   useMostWishlistedQuery();
+const { data: priceMoversOptions, ...priceMoversStatus } =
+  usePriceMoversQuery();
 
 const route = useRoute();
 
@@ -137,6 +140,11 @@ const csvCharts = computed(() => ({
     name: "most-wishlisted",
     title: t("labels.stats.mostWishlisted"),
     points: mostWishlistedOptions.value,
+  },
+  "price-movers": {
+    name: "price-movers",
+    title: t("labels.stats.priceMovers"),
+    points: priceMoversOptions.value,
   },
   "vehicles-by-model": {
     name: "vehicles-by-model",
@@ -353,6 +361,32 @@ const csvMetrics = computed<StatsMetric[]>(() => [
             :async-status="trendingShipsStatus"
             :options="trendingShipsOptions"
             tooltip-type="ship"
+            type="bar"
+          />
+        </PanelBody>
+      </Panel>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.stats.priceMovers") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['price-movers']"
+            />
+          </template>
+        </PanelHeading>
+        <PanelBody>
+          <Chart
+            v-if="priceMoversOptions"
+            key="price-movers"
+            name="price-movers"
+            :async-status="priceMoversStatus"
+            :options="priceMoversOptions"
             type="bar"
           />
         </PanelBody>

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -187,6 +187,7 @@
         "shipsOfTheMonth": "Schiff des Monats",
         "trendingShips": "Meistgesehene Schiffe (30 Tage)",
         "mostWishlisted": "Meistgewünschte Schiffe diesen Monat",
+        "priceMovers": "Größte Preisbewegungen (7 Tage)",
         "crewDeficit": "Crew Defizit",
         "crewSurplus": "Crew Überschuss",
         "membersByRole": "Mitglieder nach Rolle",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -187,6 +187,7 @@
         "shipsOfTheMonth": "Ship of the Month",
         "trendingShips": "Most Viewed Ships (30 Days)",
         "mostWishlisted": "Most Wishlisted This Month",
+        "priceMovers": "Biggest Price Movers (7 Days)",
         "crewDeficit": "Crew Deficit",
         "crewSurplus": "Crew Surplus",
         "membersByRole": "Members by Role",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -187,6 +187,7 @@
         "shipsOfTheMonth": "Nave del mes",
         "trendingShips": "Naves más vistas (30 días)",
         "mostWishlisted": "Naves más deseadas este mes",
+        "priceMovers": "Mayores variaciones de precio (7 días)",
         "crewDeficit": "Déficit de tripulación",
         "crewSurplus": "Excedente de tripulación",
         "membersByRole": "Miembros por rol",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -187,6 +187,7 @@
         "shipsOfTheMonth": "Vaisseau du mois",
         "trendingShips": "Vaisseaux les plus consultés (30 jours)",
         "mostWishlisted": "Vaisseaux les plus souhaités ce mois-ci",
+        "priceMovers": "Plus fortes variations de prix (7 jours)",
         "crewDeficit": "Déficit d'équipage",
         "crewSurplus": "Excédent d'équipage",
         "membersByRole": "Membres par rôle",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -187,6 +187,7 @@
         "shipsOfTheMonth": "Nave del mese",
         "trendingShips": "Navi più viste (30 giorni)",
         "mostWishlisted": "Navi più desiderate questo mese",
+        "priceMovers": "Maggiori variazioni di prezzo (7 giorni)",
         "crewDeficit": "Deficit equipaggio",
         "crewSurplus": "Surplus equipaggio",
         "membersByRole": "Membri per ruolo",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -187,6 +187,7 @@
         "shipsOfTheMonth": "月度飞船",
         "trendingShips": "浏览最多的飞船（30 天）",
         "mostWishlisted": "本月最受期待的飞船",
+        "priceMovers": "价格波动最大的商品（7 天）",
         "crewDeficit": "船员缺口",
         "crewSurplus": "船员盈余",
         "membersByRole": "按角色分组成员",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -187,6 +187,7 @@
         "shipsOfTheMonth": "月度飛船",
         "trendingShips": "瀏覽最多的飛船（30 天）",
         "mostWishlisted": "本月最受期待的飛船",
+        "priceMovers": "價格波動最大的商品（7 天）",
         "crewDeficit": "船員缺口",
         "crewSurplus": "船員盈餘",
         "membersByRole": "按角色分組成員",

--- a/app/jobs/cleanup/price_snapshots_job.rb
+++ b/app/jobs/cleanup/price_snapshots_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Cleanup
+  class PriceSnapshotsJob < ::Cleanup::BaseJob
+    # Two years of daily prices per terminal. Production holds roughly 3,500
+    # priced locations across commodities and ships, so this settles at a few
+    # million rows rather than growing without end.
+    RETENTION = 24.months
+
+    def perform
+      cutoff = RETENTION.ago.to_date
+
+      ItemPriceSnapshot.where(recorded_on: ...cutoff).in_batches(of: 10_000).delete_all
+    end
+  end
+end

--- a/app/lib/uex/commodity_price_syncer.rb
+++ b/app/lib/uex/commodity_price_syncer.rb
@@ -33,6 +33,8 @@ module Uex
       desired = collect(prices, commodities:, terminals:, unknown:)
       counts = persist_prices(desired, live: terminals.values.map { |terminal| terminal["name"].to_s.strip }.to_set)
 
+      record_price_history
+
       Result.new(
         created: counts.created,
         updated: counts.updated,

--- a/app/lib/uex/price_snapshot.rb
+++ b/app/lib/uex/price_snapshot.rb
@@ -58,6 +58,48 @@ module Uex
       counts
     end
 
+    # Copies what we now hold into the day's history.
+    #
+    # Deliberately outside `persist_prices` and its transaction: a removal pass
+    # that raises must not take the day's history down with it, and the rows are
+    # worth keeping either way. Reading back from `ItemPrice` rather than from
+    # the desired set is the same argument -- a terminal whose removal was held
+    # back is still a price we serve, so it belongs in the history.
+    #
+    # Delete-then-insert rather than an upsert: a second run on the same day is
+    # a correction, and replacing the day wholesale also drops rows for prices
+    # that have since gone away.
+    private def record_price_history(recorded_on: Date.current)
+      now = Time.current
+
+      rows = ItemPrice.where(item_type: self.class::ITEM_TYPE).map do |item_price|
+        {
+          item_type: item_price.item_type,
+          item_id: item_price.item_id,
+          location: item_price.location,
+          price_type: ItemPrice.price_types.fetch(item_price.price_type),
+          time_range: item_price.time_range && ItemPrice.time_ranges.fetch(item_price.time_range),
+          price: item_price.price,
+          recorded_on: recorded_on,
+          created_at: now,
+          updated_at: now
+        }
+      end
+
+      ItemPriceSnapshot.transaction do
+        ItemPriceSnapshot.where(item_type: self.class::ITEM_TYPE, recorded_on:).delete_all
+        ItemPriceSnapshot.insert_all(rows) if rows.any?
+      end
+
+      # The syncers only run in production, where nobody is watching the return
+      # value. A day that recorded nothing has to be visible in the log.
+      Rails.logger.info(
+        "[#{self.class.name}] recorded #{rows.size} #{self.class::ITEM_TYPE.downcase} price snapshots for #{recorded_on}"
+      )
+
+      rows.size
+    end
+
     # Decided per terminal, because that is the only granularity at which the
     # question is answerable. A terminal gone from the terminals feed has closed,
     # so its rows go. Otherwise the test is whether it reported at anything like

--- a/app/lib/uex/price_syncer.rb
+++ b/app/lib/uex/price_syncer.rb
@@ -131,6 +131,8 @@ module Uex
     private def persist(desired, live:, unmatched:)
       counts = persist_prices(desired, live:)
 
+      record_price_history
+
       Result.new(
         created: counts.created,
         updated: counts.updated,

--- a/app/models/item_price_snapshot.rb
+++ b/app/models/item_price_snapshot.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# One day's price for one item at one terminal.
+#
+# Written after each UEX sync, from what we hold rather than from what the feed
+# listed: a terminal whose removal the syncer held back is still a price we are
+# serving, so it belongs in the history too.
+# == Schema Information
+#
+# Table name: item_price_snapshots
+#
+#  id          :uuid             not null, primary key
+#  item_type   :string           not null
+#  location    :string           not null
+#  price       :decimal(15, 2)   not null
+#  price_type  :integer          not null
+#  recorded_on :date             not null
+#  time_range  :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  item_id     :uuid             not null
+#
+# Indexes
+#
+#  index_item_price_snapshots_on_item                  (item_type,item_id)
+#  index_item_price_snapshots_on_item_and_day          (item_type,item_id,location,price_type,time_range,recorded_on) UNIQUE NULLS NOT DISTINCT
+#  index_item_price_snapshots_on_item_and_recorded_on  (item_type,item_id,recorded_on)
+#  index_item_price_snapshots_on_recorded_on           (recorded_on)
+#
+class ItemPriceSnapshot < ApplicationRecord
+  belongs_to :item, polymorphic: true
+
+  # Sourced from ItemPrice rather than retyped -- a snapshot that disagreed with
+  # the table it is a copy of would be worse than no snapshot.
+  enum :price_type, ItemPrice.price_types, validate: true
+  enum :time_range, ItemPrice.time_ranges, validate: {allow_nil: true}
+
+  scope :on_day, ->(day) { where(recorded_on: day) }
+  scope :recorded_since, ->(day) { where(recorded_on: day..) }
+  scope :oldest_first, -> { order(:recorded_on) }
+
+  validates :location, presence: true
+  validates :price, presence: true
+  validates :recorded_on, presence: true
+end

--- a/app/views/api/v1/commodities/price_history.jbuilder
+++ b/app/views/api/v1/commodities/price_history.jbuilder
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+json.array! @price_history do |day|
+  json.recorded_on day[:recorded_on]
+  json.sold_lowest day[:sold_lowest]
+  json.sold_average day[:sold_average]
+  json.sold_highest day[:sold_highest]
+  json.bought_lowest day[:bought_lowest]
+  json.bought_average day[:bought_average]
+  json.bought_highest day[:bought_highest]
+end

--- a/config/routes/api/commodities_routes.rb
+++ b/config/routes/api/commodities_routes.rb
@@ -1,4 +1,8 @@
-resources :commodities, only: [:index]
+resources :commodities, param: :slug, only: [:index] do
+  member do
+    get :price_history, path: "price-history"
+  end
+end
 
 namespace :filters do
   resources :commodities, only: [] do

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -103,6 +103,7 @@ v1_api_routes = lambda do
     get "ships-of-the-month", to: "base#ships_of_the_month"
     get "trending-ships", to: "base#trending_ships"
     get "most-wishlisted", to: "base#most_wishlisted"
+    get "price-movers", to: "base#price_movers"
   end
 end
 

--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -73,6 +73,10 @@ cleanup_visits_job:
   cron: '0 0 1 * *' # Monthly on the first day at 0:00
   class: 'Cleanup::VisitsJob'
   queue: 'cleanup'
+cleanup_price_snapshots_job:
+  cron: '30 0 1 * *' # Monthly on the first day at 0:30
+  class: 'Cleanup::PriceSnapshotsJob'
+  queue: 'cleanup'
 fleet_event_starting_soon_job:
   cron: '*/5 * * * *' # Every 5 minutes
   class: 'Notifications::FleetEventStartingSoonJob'

--- a/db/migrate/20260903160000_create_item_price_snapshots.rb
+++ b/db/migrate/20260903160000_create_item_price_snapshots.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# What the UEX feed said a thing cost on a given day.
+#
+# `item_prices` is a snapshot the daily sync overwrites in place, so yesterday's
+# prices do not exist anywhere. One row per item, terminal and price type per
+# day is what turns that into a history.
+class CreateItemPriceSnapshots < ActiveRecord::Migration[8.1]
+  def change
+    create_table :item_price_snapshots, id: :uuid do |t|
+      t.references :item, type: :uuid, polymorphic: true, null: false
+      t.string :location, null: false
+      t.integer :price_type, null: false
+      t.integer :time_range
+      t.decimal :price, precision: 15, scale: 2, null: false
+      t.date :recorded_on, null: false
+
+      t.timestamps
+    end
+
+    # Mirrors the key `ItemPrice` itself is unique on, plus the day. Rentals
+    # carry a `time_range` and everything else leaves it null, so the index has
+    # to treat two nulls as equal or it would let a day be recorded twice.
+    add_index :item_price_snapshots,
+      %i[item_type item_id location price_type time_range recorded_on],
+      unique: true,
+      nulls_not_distinct: true,
+      name: "index_item_price_snapshots_on_item_and_day"
+
+    add_index :item_price_snapshots, %i[item_type item_id recorded_on],
+      name: "index_item_price_snapshots_on_item_and_recorded_on"
+
+    # Retention deletes by date across every item type.
+    add_index :item_price_snapshots, :recorded_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -847,6 +847,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_140000) do
     t.integer "unit", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["inventory_id"], name: "index_inventory_items_on_inventory_id"
+  end
+
+  create_table "item_price_snapshots", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "item_id", null: false
+    t.string "item_type", null: false
+    t.string "location", null: false
+    t.decimal "price", precision: 15, scale: 2, null: false
+    t.integer "price_type", null: false
+    t.date "recorded_on", null: false
+    t.integer "time_range"
+    t.datetime "updated_at", null: false
+    t.index ["item_type", "item_id", "location", "price_type", "time_range", "recorded_on"], name: "index_item_price_snapshots_on_item_and_day", unique: true, nulls_not_distinct: true
+    t.index ["item_type", "item_id", "recorded_on"], name: "index_item_price_snapshots_on_item_and_recorded_on"
+    t.index ["item_type", "item_id"], name: "index_item_price_snapshots_on_item"
+    t.index ["recorded_on"], name: "index_item_price_snapshots_on_recorded_on"
   end
 
   create_table "item_prices", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -40,6 +40,34 @@ paths:
                 "$ref": "#/components/schemas/Commodities"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/commodities/{slug}/price-history":
+    parameters:
+    - name: slug
+      in: path
+      schema:
+        type: string
+      description: Commodity slug
+      required: true
+    get:
+      summary: Commodity Price History
+      tags:
+      - Commodities
+      operationId: commodityPriceHistory
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CommodityPricePointsList"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/compare/share":
     post:
       summary: Create a short share URL for a comparison
@@ -9553,6 +9581,19 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/BarChartStatsList"
+  "/stats/price-movers":
+    get:
+      summary: Stats Price Movers
+      tags:
+      - Stats
+      operationId: priceMovers
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BarChartStatsList"
   "/stats/quick-stats":
     get:
       summary: Stats
@@ -11355,6 +11396,45 @@ components:
       - createdAt
       - updatedAt
       title: Commodity
+    CommodityPricePoint:
+      type: object
+      properties:
+        recordedOn:
+          type: string
+          format: date
+        soldLowest:
+          type:
+          - number
+          - 'null'
+        soldAverage:
+          type:
+          - number
+          - 'null'
+        soldHighest:
+          type:
+          - number
+          - 'null'
+        boughtLowest:
+          type:
+          - number
+          - 'null'
+        boughtAverage:
+          type:
+          - number
+          - 'null'
+        boughtHighest:
+          type:
+          - number
+          - 'null'
+      required:
+      - recordedOn
+      additionalProperties: false
+      title: CommodityPricePoint
+    CommodityPricePointsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/CommodityPricePoint"
+      title: CommodityPricePointsList
     CommodityQuery:
       type: object
       properties:

--- a/test/integration/api/v1/commodities_price_history_test.rb
+++ b/test/integration/api/v1/commodities_price_history_test.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::CommoditiesPriceHistoryTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/commodities/{slug}/price-history" do
+    parameter name: "slug", in: :path, schema: {type: :string}, description: "Commodity slug", required: true
+
+    get("Commodity Price History") do
+      operationId "commodityPriceHistory"
+      tags "Commodities"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::V1::Schemas::Commodities::CommodityPricePointsList
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  test "GET /commodities/:slug/price-history spans the terminals of each day" do
+    commodity = create(:commodity)
+    record(commodity, price: 100, price_type: "sell", location: "Area 18")
+    record(commodity, price: 140, price_type: "sell", location: "Lorville")
+
+    assert_api_response :get, 200, path_params: {slug: commodity.slug} do
+      day = parsed_body.sole
+
+      assert_equal 100, day["soldLowest"].to_i
+      assert_equal 120, day["soldAverage"].to_i
+      assert_equal 140, day["soldHighest"].to_i
+    end
+  end
+
+  # `sell` is the shop selling and `bought` the shop buying, the perspective the
+  # commodity's own `soldAt` and `boughtAt` already use.
+  test "GET /commodities/:slug/price-history keeps the two directions apart" do
+    commodity = create(:commodity)
+    record(commodity, price: 100, price_type: "sell", location: "Area 18")
+    record(commodity, price: 80, price_type: "buy", location: "Area 18")
+
+    assert_api_response :get, 200, path_params: {slug: commodity.slug} do
+      day = parsed_body.sole
+
+      assert_equal 100, day["soldAverage"].to_i
+      assert_equal 80, day["boughtAverage"].to_i
+    end
+  end
+
+  test "GET /commodities/:slug/price-history returns the days oldest first" do
+    commodity = create(:commodity)
+    record(commodity, price: 10, recorded_on: 3.days.ago.to_date)
+    record(commodity, price: 20, recorded_on: 1.day.ago.to_date)
+
+    assert_api_response :get, 200, path_params: {slug: commodity.slug} do
+      assert_equal [10, 20], parsed_body.map { |day| day["soldAverage"].to_i }
+    end
+  end
+
+  test "GET /commodities/:slug/price-history leaves out days beyond the window" do
+    commodity = create(:commodity)
+    record(commodity, price: 10, recorded_on: 200.days.ago.to_date)
+
+    assert_api_response :get, 200, path_params: {slug: commodity.slug} do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /commodities/:slug/price-history answers for a commodity nothing has priced" do
+    commodity = create(:commodity)
+
+    assert_api_response :get, 200, path_params: {slug: commodity.slug} do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /commodities/:slug/price-history returns 404 for an unknown commodity" do
+    assert_api_response :get, 404, path_params: {slug: "unknown-commodity"}
+  end
+
+  private def record(commodity, price:, price_type: "sell", location: "Area 18", recorded_on: Date.current)
+    ItemPriceSnapshot.create!(
+      item: commodity, location:, price_type:, price:, recorded_on:
+    )
+  end
+end

--- a/test/integration/api/v1/stats_price_movers_test.rb
+++ b/test/integration/api/v1/stats_price_movers_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::StatsPriceMoversTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/stats/price-movers" do
+    get("Stats Price Movers") do
+      operationId "priceMovers"
+      tags "Stats"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Shared::V1::Schemas::BarChartStatsList
+      end
+    end
+  end
+
+  test "GET /stats/price-movers returns chart data" do
+    assert_api_response :get, 200
+  end
+
+  test "GET /stats/price-movers reports what a week did to the price" do
+    commodity = create(:commodity)
+    record(commodity, price: 100, recorded_on: 8.days.ago.to_date)
+    record(commodity, price: 175, recorded_on: Date.current)
+
+    assert_api_response :get, 200 do
+      assert_equal [commodity.name], parsed_body.map { |mover| mover["label"] }
+      assert_equal [75], parsed_body.map { |mover| mover["count"] }
+    end
+  end
+
+  # A drop is as much a mover as a rise, so ranking by value rather than by size
+  # of the move would push the steepest fall off the end of the chart.
+  test "GET /stats/price-movers ranks a fall beside a rise" do
+    faller = create(:commodity)
+    riser = create(:commodity)
+    record(faller, price: 1000, recorded_on: 8.days.ago.to_date)
+    record(faller, price: 100, recorded_on: Date.current)
+    record(riser, price: 100, recorded_on: 8.days.ago.to_date)
+    record(riser, price: 200, recorded_on: Date.current)
+
+    assert_api_response :get, 200 do
+      assert_equal [faller.name, riser.name], parsed_body.map { |mover| mover["label"] }
+      assert_equal [-900, 100], parsed_body.map { |mover| mover["count"] }
+    end
+  end
+
+  test "GET /stats/price-movers leaves out a commodity that did not move" do
+    commodity = create(:commodity)
+    record(commodity, price: 100, recorded_on: 8.days.ago.to_date)
+    record(commodity, price: 100, recorded_on: Date.current)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  # Nothing to compare against until a second week of collecting.
+  test "GET /stats/price-movers answers with one day of history" do
+    commodity = create(:commodity)
+    record(commodity, price: 100, recorded_on: Date.current)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  private def record(commodity, price:, recorded_on:, price_type: "sell", location: "Area 18")
+    ItemPriceSnapshot.create!(
+      item: commodity, location:, price_type:, price:, recorded_on:
+    )
+  end
+end

--- a/test/lib/uex/commodity_price_syncer_test.rb
+++ b/test/lib/uex/commodity_price_syncer_test.rb
@@ -143,5 +143,53 @@ module Uex
       assert_match(/\*\*Aslarite\*\* — UEX id `999`/, body)
       assert_no_match(/created=/, body)
     end
+
+    test "#run records the day's prices as history" do
+      sync
+
+      held = ItemPrice.where(item_type: "Commodity")
+      recorded = ItemPriceSnapshot.where(item_type: "Commodity", recorded_on: Date.current)
+
+      assert_operator held.count, :>, 0
+      assert_equal held.count, recorded.count
+      assert_equal held.pluck(:price).sort, recorded.pluck(:price).sort
+      assert_equal held.pluck(:location).sort, recorded.pluck(:location).sort
+    end
+
+    # A second run the same day is a correction, not a second day.
+    test "#run replaces the day it already recorded" do
+      sync
+      first = ItemPriceSnapshot.where(item_type: "Commodity").count
+
+      sync
+
+      assert_equal first, ItemPriceSnapshot.where(item_type: "Commodity").count
+    end
+
+    test "#run leaves earlier days alone" do
+      commodity = @commodities[:gold]
+      ItemPriceSnapshot.create!(
+        item: commodity, location: "Old Terminal", price_type: "sell",
+        price: 1, recorded_on: 30.days.ago.to_date
+      )
+
+      sync
+
+      assert ItemPriceSnapshot.exists?(location: "Old Terminal", recorded_on: 30.days.ago.to_date)
+    end
+
+    # Ships are synced by the other syncer on its own schedule, so one must not
+    # clear the other's day.
+    test "#run leaves another item type's history alone" do
+      model = create(:model)
+      ItemPriceSnapshot.create!(
+        item: model, location: "Astro Armada", price_type: "sell",
+        price: 100, recorded_on: Date.current
+      )
+
+      sync
+
+      assert_equal 1, ItemPriceSnapshot.where(item_type: "Model").count
+    end
   end
 end

--- a/test/lib/uex/price_syncer_test.rb
+++ b/test/lib/uex/price_syncer_test.rb
@@ -295,5 +295,26 @@ module Uex
     private def sync(overrides = {})
       Uex::PriceSyncer.new(client: uex_client_stub(overrides)).run
     end
+
+    test "#run records the day's ship prices as history" do
+      sync
+
+      held = ItemPrice.where(item_type: "Model")
+      recorded = ItemPriceSnapshot.where(item_type: "Model", recorded_on: Date.current)
+
+      assert_operator held.count, :>, 0
+      assert_equal held.count, recorded.count
+    end
+
+    # Rentals are the only rows carrying a time_range, and the unique index has
+    # to keep them apart from the sale at the same terminal.
+    test "#run records a rental beside the sale at the same terminal" do
+      sync
+
+      rentals = ItemPriceSnapshot.where(item_type: "Model", price_type: "rental")
+
+      assert_operator rentals.count, :>, 0
+      assert_equal ["1-day"], rentals.pluck(:time_range).uniq
+    end
   end
 end


### PR DESCRIPTION
Phase 4 of the stats plan (#4697): snapshot the UEX prices before the next sync replaces them, and read the history two ways.

## Why

`item_prices` is a snapshot, not a log. `Loaders::UexPricesJob` and `Loaders::UexCommodityPricesJob` run daily in production and `persist_prices` rewrites the table in place, so what a commodity or a ship cost yesterday exists nowhere. `time_range` looks like it might help and does not — it is a rental period, not a timestamp.

## A correction to the plan

The plan said to snapshot commodities per terminal and components/equipment as a daily per-item aggregate, on the basis that the second syncer covered 13,569 components and pieces of gear. **It does not.** `Uex::PriceSyncer::ITEM_TYPE` is `"Model"` — the second syncer prices **ships**, buy and rent. Components and equipment carry prices too, but only ones an admin typed in through `Admin::Api::V1::ItemPricesController`; no daily sync touches them, so nothing about them is being lost.

That removes the reason for the split. The aggregate was proposed to keep 13k items from becoming millions of rows a year; production prices roughly 650 ship locations a day against ~2,900 commodity ones. So both are recorded **per terminal**, in one table, which is also strictly more informative — an aggregate can be derived from per-terminal rows and never the other way round. Say the word if you would rather have the ship side aggregated after all; it is a smaller change now than later.

## What changed

**Recording.** `item_price_snapshots`, polymorphic, one row per item, terminal, price type and day, written by both syncers.

- **Outside `persist_prices` and its transaction**, deliberately: a removal pass that raises must not take the day's history down with it.
- It reads back from `ItemPrice` rather than from the desired set, for the same reason the syncer holds back suspicious removals — a terminal whose removal was skipped is still a price we serve, so it belongs in the history.
- Delete-then-insert rather than upsert. A second run the same day is a correction, and replacing the day wholesale also drops rows for prices that have since gone away.
- The unique index uses `nulls_not_distinct`. Only rentals carry a `time_range`; without it every non-rental row could be recorded twice in a day.
- It logs the row count. The syncers only run in production where nobody reads a return value, and a day that recorded nothing has to be visible.

**Retention.** `Cleanup::PriceSnapshotsJob`, monthly, 24 months.

**Reading.** `/commodities/:slug/price-history` folds 90 days into a row per day — lowest, average, highest, kept apart by direction — aggregated in Postgres so the window costs a few hundred rows. `/stats/price-movers` compares the newest recorded day against the newest one at least a week older, with a panel on `/stats`.

`sold` is the shop selling and `bought` the shop buying, matching the `soldAt`/`boughtAt` vocabulary the commodity payload already uses rather than inventing a second one for the same thing.

## Verification

- 6 syncer tests through the existing `UexFixtures` stub client, so they exercise the real sync path: the day recorded matches what we hold, a re-run replaces its day, earlier days survive, one item type does not clear the other's day, and a rental is recorded beside the sale at the same terminal.
- 6 endpoint tests for price history, 5 for movers. **One of them caught a real bug**: `pluck` casts an enum back to its name, so comparing against `ItemPrice.price_types["sell"]` (the integer) put every price in the wrong direction. Buy and sell would have been silently swapped on the chart.
- Retention verified by running the job against seeded rows: 30 months old gone, 1 month old kept.
- `115 tests, 305 assertions, 0 failures` across the UEX suite and every commodity and stats integration test. `standardrb` clean, `pnpm lint:ts` exits 0, label in all seven locales.

## Not in scope

- **The commodity history panel the plan asked for.** There is no public commodity page — `resources :commodities` is `only: [:index]` and the frontend has no commodities route at all. The endpoint is ready for one; the panel needs the page first.
- The movers panel names commodities that currently link nowhere, for the same reason.
- I did not open `/stats` in a browser.
- Component and equipment prices are untouched. They are hand-entered and not overwritten daily, so there is no history being lost to rescue.

🤖