### PR TITLE
feat(models): record what a patch changed about a ship

### DIFF
--- a/app/api_components/v1/schemas/models/changes/model_build_change.rb
+++ b/app/api_components/v1/schemas/models/changes/model_build_change.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Changes
+        # One fact a patch changed about a ship. `oldValue` is null where the
+        # previous build did not carry the fact at all.
+        class ModelBuildChange
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              id: {type: :string, format: :uuid},
+              environment: {type: :string},
+              fromVersion: {type: :string},
+              toVersion: {type: :string},
+              field: {type: :string},
+              oldValue: {type: [:number, :null]},
+              newValue: {type: [:number, :null]},
+              recordedAt: {type: :string, format: :"date-time"}
+            },
+            required: %i[id environment fromVersion toVersion field recordedAt],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/changes/model_build_changes_list.rb
+++ b/app/api_components/v1/schemas/models/changes/model_build_changes_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Changes
+        class ModelBuildChangesList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/ModelBuildChange"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -307,6 +307,15 @@ module Api
         render json: wishlist_history.to_json
       end
 
+      # What each patch changed about this ship, newest first. The builds these
+      # were derived from are pruned after three patches; the log is not.
+      def changes
+        model = find_model_by_slug!
+        return if performed?
+
+        @changes = model.build_changes.newest_first
+      end
+
       def store_image
         model = find_model_by_slug(Model.visible.active)
         return if performed?

--- a/app/controllers/api/v1/stats/base_controller.rb
+++ b/app/controllers/api/v1/stats/base_controller.rb
@@ -115,6 +115,21 @@ module Api
             .average(:price)
         end
 
+        # Which ships the build we are on changed the most.
+        def patch_changes
+          changed_facts = ModelBuildChange
+            .for_build(::ScData::Source.environment, ::ScData::Source.version)
+            .group(:model_id).count
+
+          names = Model.visible.active.where(id: changed_facts.keys).pluck(:id, :name).to_h
+
+          patch_changes = transform_for_bar_chart(
+            changed_facts.filter_map { |id, changed| [names[id], changed] if names.key?(id) }.to_h
+          ).take(10)
+
+          render json: patch_changes.to_json
+        end
+
         def components_by_class
           components_by_class = transform_for_pie_chart(
             Component.group(:component_class).count

--- a/app/frontend/frontend/pages/stats.vue
+++ b/app/frontend/frontend/pages/stats.vue
@@ -32,6 +32,7 @@ import {
   useTrendingShips as useTrendingShipsQuery,
   useMostWishlisted as useMostWishlistedQuery,
   usePriceMovers as usePriceMoversQuery,
+  usePatchChanges as usePatchChangesQuery,
 } from "@/services/fyApi";
 
 const { t } = useI18n();
@@ -68,6 +69,8 @@ const { data: mostWishlistedOptions, ...mostWishlistedStatus } =
   useMostWishlistedQuery();
 const { data: priceMoversOptions, ...priceMoversStatus } =
   usePriceMoversQuery();
+const { data: patchChangesOptions, ...patchChangesStatus } =
+  usePatchChangesQuery();
 
 const route = useRoute();
 
@@ -145,6 +148,12 @@ const csvCharts = computed(() => ({
     name: "price-movers",
     title: t("labels.stats.priceMovers"),
     points: priceMoversOptions.value,
+  },
+
+  "patch-changes": {
+    name: "patch-changes",
+    title: t("labels.stats.patchChanges"),
+    points: patchChangesOptions.value,
   },
   "vehicles-by-model": {
     name: "vehicles-by-model",
@@ -413,6 +422,33 @@ const csvMetrics = computed<StatsMetric[]>(() => [
             name="most-wishlisted"
             :async-status="mostWishlistedStatus"
             :options="mostWishlistedOptions"
+            tooltip-type="ship"
+            type="bar"
+          />
+        </PanelBody>
+      </Panel>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.stats.patchChanges") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['patch-changes']"
+            />
+          </template>
+        </PanelHeading>
+        <PanelBody>
+          <Chart
+            v-if="patchChangesOptions"
+            key="patch-changes"
+            name="patch-changes"
+            :async-status="patchChangesStatus"
+            :options="patchChangesOptions"
             tooltip-type="ship"
             type="bar"
           />

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -188,6 +188,7 @@
         "trendingShips": "Meistgesehene Schiffe (30 Tage)",
         "mostWishlisted": "Meistgewünschte Schiffe diesen Monat",
         "priceMovers": "Größte Preisbewegungen (7 Tage)",
+        "patchChanges": "Am stärksten von diesem Patch verändert",
         "crewDeficit": "Crew Defizit",
         "crewSurplus": "Crew Überschuss",
         "membersByRole": "Mitglieder nach Rolle",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -188,6 +188,7 @@
         "trendingShips": "Most Viewed Ships (30 Days)",
         "mostWishlisted": "Most Wishlisted This Month",
         "priceMovers": "Biggest Price Movers (7 Days)",
+        "patchChanges": "Most Changed by This Patch",
         "crewDeficit": "Crew Deficit",
         "crewSurplus": "Crew Surplus",
         "membersByRole": "Members by Role",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -188,6 +188,7 @@
         "trendingShips": "Naves más vistas (30 días)",
         "mostWishlisted": "Naves más deseadas este mes",
         "priceMovers": "Mayores variaciones de precio (7 días)",
+        "patchChanges": "Más modificadas por este parche",
         "crewDeficit": "Déficit de tripulación",
         "crewSurplus": "Excedente de tripulación",
         "membersByRole": "Miembros por rol",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -188,6 +188,7 @@
         "trendingShips": "Vaisseaux les plus consultés (30 jours)",
         "mostWishlisted": "Vaisseaux les plus souhaités ce mois-ci",
         "priceMovers": "Plus fortes variations de prix (7 jours)",
+        "patchChanges": "Les plus modifiés par ce patch",
         "crewDeficit": "Déficit d'équipage",
         "crewSurplus": "Excédent d'équipage",
         "membersByRole": "Membres par rôle",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -188,6 +188,7 @@
         "trendingShips": "Navi più viste (30 giorni)",
         "mostWishlisted": "Navi più desiderate questo mese",
         "priceMovers": "Maggiori variazioni di prezzo (7 giorni)",
+        "patchChanges": "Più modificate da questa patch",
         "crewDeficit": "Deficit equipaggio",
         "crewSurplus": "Surplus equipaggio",
         "membersByRole": "Membri per ruolo",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -188,6 +188,7 @@
         "trendingShips": "浏览最多的飞船（30 天）",
         "mostWishlisted": "本月最受期待的飞船",
         "priceMovers": "价格波动最大的商品（7 天）",
+        "patchChanges": "本次更新改动最大的飞船",
         "crewDeficit": "船员缺口",
         "crewSurplus": "船员盈余",
         "membersByRole": "按角色分组成员",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -188,6 +188,7 @@
         "trendingShips": "瀏覽最多的飛船（30 天）",
         "mostWishlisted": "本月最受期待的飛船",
         "priceMovers": "價格波動最大的商品（7 天）",
+        "patchChanges": "本次更新改動最大的飛船",
         "crewDeficit": "船員缺口",
         "crewSurplus": "船員盈餘",
         "membersByRole": "按角色分組成員",

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -106,7 +106,14 @@ module ScData
         # Dual-write. Built from `update_params` before the reason is merged in:
         # `update_reason` is an `attr_accessor` on Model for paper_trail's meta,
         # not a column, so it has nowhere to land here.
-        apply_build(model, update_params.slice(*ModelBuild::FACTS))
+        build = apply_build(model, update_params.slice(*ModelBuild::FACTS))
+
+        # Recorded now because the build it is measured against is pruned after
+        # three patches. Waiting until someone asks means there is nothing left
+        # to compare.
+        ModelBuildChange.record!(build)
+
+        build
       end
 
       # Whether this build ships a file for the model, which is what a build row

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -361,6 +361,11 @@ class Model < ApplicationRecord
     dependent: :destroy,
     inverse_of: :model
 
+  has_many :build_changes,
+    class_name: "ModelBuildChange",
+    dependent: :destroy,
+    inverse_of: :model
+
   has_many :images,
     as: :gallery,
     dependent: :destroy,

--- a/app/models/model_build.rb
+++ b/app/models/model_build.rb
@@ -90,6 +90,20 @@ class ModelBuild < ApplicationRecord
   serialize :external_fuel_tanks, coder: YAML
   serialize :refuel_boom, coder: YAML
 
+  # Facts that are a shape rather than a number. Two loads of the same export
+  # can serialise these differently without anything having changed, so
+  # comparing them reports a change on every re-parse -- see the change log,
+  # which leaves them out for exactly that reason.
+  STRUCTURED_FACTS = %i[
+    hull_parts hull_doors signature_cross_section
+    cargo_holds quantum_fuel_tanks hydrogen_fuel_tanks external_fuel_tanks refuel_boom
+  ].freeze
+
+  # What a patch diff compares. Derived rather than listed, so a numeric fact
+  # added to FACTS is diffable without anyone remembering to say so. `ground` is
+  # excluded with the shapes: it classifies the ship rather than measuring it.
+  DIFFABLE_FACTS = (FACTS - STRUCTURED_FACTS - %i[ground]).freeze
+
   # The facts Model filters and sorts by, which is every one of them that
   # `Model.ransackable_attributes` lists. The other twelve nothing queries.
   FILTERABLE = %i[

--- a/app/models/model_build_change.rb
+++ b/app/models/model_build_change.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# One fact a patch changed about one ship.
+#
+# Written when a build lands, from the build before it. The builds themselves are
+# pruned after three patches, so this is the only place a change survives long
+# enough to read a year later.
+# == Schema Information
+#
+# Table name: model_build_changes
+#
+#  id           :uuid             not null, primary key
+#  environment  :string           not null
+#  field        :string           not null
+#  from_version :string           not null
+#  new_value    :decimal(15, 2)
+#  old_value    :decimal(15, 2)
+#  recorded_at  :datetime         not null
+#  to_version   :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  model_id     :uuid             not null
+#
+# Indexes
+#
+#  index_model_build_changes_on_build            (environment,to_version)
+#  index_model_build_changes_on_model_and_field  (model_id,environment,to_version,field) UNIQUE
+#  index_model_build_changes_on_model_id         (model_id)
+#  index_model_build_changes_on_recorded_at      (recorded_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
+class ModelBuildChange < ApplicationRecord
+  belongs_to :model
+
+  scope :newest_first, -> { order(recorded_at: :desc, field: :asc) }
+  scope :for_build, ->(environment, version) { where(environment:, to_version: version) }
+
+  validates :environment, :from_version, :to_version, :field, :recorded_at, presence: true
+
+  # Diffs a build against the one that preceded it in the same environment and
+  # replaces whatever was recorded for it.
+  #
+  # Replacing rather than appending is what makes a re-load safe: the same export
+  # parsed twice can produce different values without a version bump, and the
+  # second parse is the one to keep rather than a second set of rows beside the
+  # first.
+  def self.record!(build)
+    previous = previous_build(build)
+    return 0 if previous.blank?
+
+    rows = changed_facts(previous, build).map do |field, (old_value, new_value)|
+      {
+        model_id: build.model_id,
+        environment: build.environment,
+        from_version: previous.version,
+        to_version: build.version,
+        field: field.to_s,
+        old_value:,
+        new_value:,
+        recorded_at: build.created_at,
+        created_at: Time.current,
+        updated_at: Time.current
+      }
+    end
+
+    transaction do
+      where(model_id: build.model_id, environment: build.environment, to_version: build.version).delete_all
+      insert_all(rows) if rows.any?
+    end
+
+    rows.size
+  end
+
+  # The build this one replaced: the most recently first-seen build of the same
+  # environment that is not this one. Re-loading a build updates it in place, so
+  # `created_at` is when a version landed rather than when it was last touched.
+  def self.previous_build(build)
+    build.model.builds
+      .where(environment: build.environment)
+      .where.not(version: build.version)
+      .order(created_at: :desc)
+      .first
+  end
+
+  def self.changed_facts(previous, build)
+    ModelBuild::DIFFABLE_FACTS.each_with_object({}) do |fact, changes|
+      old_value = previous.public_send(fact)
+      new_value = build.public_send(fact)
+      next if old_value == new_value
+
+      changes[fact] = [old_value, new_value]
+    end
+  end
+end

--- a/app/views/api/v1/models/changes.jbuilder
+++ b/app/views/api/v1/models/changes.jbuilder
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+json.array! @changes do |change|
+  json.id change.id
+  json.environment change.environment
+  json.from_version change.from_version
+  json.to_version change.to_version
+  json.field change.field
+  json.old_value change.old_value
+  json.new_value change.new_value
+  json.recorded_at change.recorded_at
+end

--- a/config/routes/api/models_routes.rb
+++ b/config/routes/api/models_routes.rb
@@ -22,6 +22,7 @@ resources :models, param: :slug, only: %i[index show] do
     get :paints
     get :sales
     get :wishlist_history, path: "wishlist-history"
+    get :changes
     get :store_image, path: "store-image"
     get :fleetchart_image, path: "fleetchart-image"
   end

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -104,6 +104,7 @@ v1_api_routes = lambda do
     get "trending-ships", to: "base#trending_ships"
     get "most-wishlisted", to: "base#most_wishlisted"
     get "price-movers", to: "base#price_movers"
+    get "patch-changes", to: "base#patch_changes"
   end
 end
 

--- a/db/migrate/20260903180000_create_model_build_changes.rb
+++ b/db/migrate/20260903180000_create_model_build_changes.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# What a patch changed about a ship.
+#
+# `ModelBuild::BUILDS_RETAINED` keeps three builds per environment, so the diff
+# against the patch before last is computable today and pruned away two patches
+# from now. Storing the diff rather than relying on the builds is what makes a
+# change log outlive the rows it was derived from.
+class CreateModelBuildChanges < ActiveRecord::Migration[8.1]
+  def change
+    create_table :model_build_changes, id: :uuid do |t|
+      t.references :model, type: :uuid, null: false, foreign_key: {on_delete: :cascade}
+      t.string :environment, null: false
+      t.string :from_version, null: false
+      t.string :to_version, null: false
+      t.string :field, null: false
+      t.decimal :old_value, precision: 15, scale: 2
+      t.decimal :new_value, precision: 15, scale: 2
+      t.datetime :recorded_at, null: false
+
+      t.timestamps
+    end
+
+    # Re-loading a build recomputes its diff, which replaces the rows for that
+    # target version rather than appending a second copy of them.
+    add_index :model_build_changes,
+      %i[model_id environment to_version field],
+      unique: true,
+      name: "index_model_build_changes_on_model_and_field"
+
+    add_index :model_build_changes, %i[environment to_version],
+      name: "index_model_build_changes_on_build"
+
+    add_index :model_build_changes, :recorded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_03_180000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1012,6 +1012,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_160000) do
     t.index ["fleet_id", "slug"], name: "index_missions_on_fleet_id_and_slug", unique: true
   end
 
+  create_table "model_build_changes", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "environment", null: false
+    t.string "field", null: false
+    t.string "from_version", null: false
+    t.uuid "model_id", null: false
+    t.decimal "new_value", precision: 15, scale: 2
+    t.decimal "old_value", precision: 15, scale: 2
+    t.datetime "recorded_at", null: false
+    t.string "to_version", null: false
+    t.datetime "updated_at", null: false
+    t.index ["environment", "to_version"], name: "index_model_build_changes_on_build"
+    t.index ["model_id", "environment", "to_version", "field"], name: "index_model_build_changes_on_model_and_field", unique: true
+    t.index ["model_id"], name: "index_model_build_changes_on_model_id"
+    t.index ["recorded_at"], name: "index_model_build_changes_on_recorded_at"
+  end
+
   create_table "model_builds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "cargo_holds"
     t.datetime "created_at", null: false
@@ -1721,6 +1738,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_160000) do
   add_foreign_key "mission_teams", "missions"
   add_foreign_key "missions", "fleets"
   add_foreign_key "missions", "users", column: "created_by_id"
+  add_foreign_key "model_build_changes", "models", on_delete: :cascade
   add_foreign_key "model_builds", "models", on_delete: :cascade
   add_foreign_key "model_paints", "components", on_delete: :nullify
   add_foreign_key "model_positions", "hardpoints", on_delete: :nullify

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7196,6 +7196,34 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/models/{slug}/changes":
+    parameters:
+    - name: slug
+      in: path
+      schema:
+        type: string
+      description: Model slug
+      required: true
+    get:
+      summary: Model Changes
+      tags:
+      - Models
+      operationId: modelChanges
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelBuildChangesList"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/models/{slug}/fleetchart-image":
     parameters:
     - name: slug
@@ -9574,6 +9602,19 @@ paths:
       tags:
       - Stats
       operationId: mostWishlisted
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BarChartStatsList"
+  "/stats/patch-changes":
+    get:
+      summary: Stats Patch Changes
+      tags:
+      - Stats
+      operationId: patchChanges
       responses:
         '200':
           description: successful
@@ -17611,6 +17652,45 @@ components:
       - soldAt
       - rentalAt
       title: ModelAvailability
+    ModelBuildChange:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        environment:
+          type: string
+        fromVersion:
+          type: string
+        toVersion:
+          type: string
+        field:
+          type: string
+        oldValue:
+          type:
+          - number
+          - 'null'
+        newValue:
+          type:
+          - number
+          - 'null'
+        recordedAt:
+          type: string
+          format: date-time
+      required:
+      - id
+      - environment
+      - fromVersion
+      - toVersion
+      - field
+      - recordedAt
+      additionalProperties: false
+      title: ModelBuildChange
+    ModelBuildChangesList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/ModelBuildChange"
+      title: ModelBuildChangesList
     ModelCrew:
       type: object
       properties:

--- a/test/integration/api/v1/models_changes_test.rb
+++ b/test/integration/api/v1/models_changes_test.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::ModelsChangesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/models/{slug}/changes" do
+    parameter name: "slug", in: :path, schema: {type: :string}, description: "Model slug", required: true
+
+    get("Model Changes") do
+      operationId "modelChanges"
+      tags "Models"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::V1::Schemas::Models::Changes::ModelBuildChangesList
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  test "GET /models/:slug/changes returns the newest patch first" do
+    model = create(:model)
+    record(model, field: "scm_speed", to_version: "4.9.0", recorded_at: 3.months.ago)
+    record(model, field: "mass", to_version: "4.10.0", recorded_at: 1.day.ago)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal %w[mass scm_speed], parsed_body.map { |change| change["field"] }
+    end
+  end
+
+  test "GET /models/:slug/changes leaves out other ships" do
+    model = create(:model)
+    record(model, field: "mass")
+    record(create(:model), field: "scm_speed")
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal %w[mass], parsed_body.map { |change| change["field"] }
+    end
+  end
+
+  # A fact the previous build did not carry has no old value, and null is the
+  # honest answer rather than zero.
+  test "GET /models/:slug/changes reports a fact that was not there before" do
+    model = create(:model)
+    record(model, field: "max_speed", old_value: nil, new_value: 1200)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_nil parsed_body.sole["oldValue"]
+      assert_equal 1200, parsed_body.sole["newValue"].to_i
+    end
+  end
+
+  test "GET /models/:slug/changes answers for a ship no patch has changed" do
+    model = create(:model)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /models/:slug/changes returns 404 for unknown model" do
+    assert_api_response :get, 404, path_params: {slug: "unknown-model"}
+  end
+
+  private def record(model, field:, to_version: "4.10.0", old_value: 1, new_value: 2, recorded_at: 1.day.ago)
+    ModelBuildChange.create!(
+      model:, field:, to_version:, old_value:, new_value:, recorded_at:,
+      environment: ScData::Source.environment, from_version: "4.9.0"
+    )
+  end
+end

--- a/test/integration/api/v1/stats_patch_changes_test.rb
+++ b/test/integration/api/v1/stats_patch_changes_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::StatsPatchChangesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/stats/patch-changes" do
+    get("Stats Patch Changes") do
+      operationId "patchChanges"
+      tags "Stats"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Shared::V1::Schemas::BarChartStatsList
+      end
+    end
+  end
+
+  test "GET /stats/patch-changes returns chart data" do
+    assert_api_response :get, 200
+  end
+
+  test "GET /stats/patch-changes ranks ships by how much the build changed" do
+    reworked = create(:model)
+    tweaked = create(:model)
+    record(reworked, fields: %w[scm_speed max_speed mass])
+    record(tweaked, fields: %w[mass])
+
+    assert_api_response :get, 200 do
+      assert_equal [reworked.name, tweaked.name], parsed_body.map { |point| point["label"] }
+      assert_equal [3, 1], parsed_body.map { |point| point["count"] }
+    end
+  end
+
+  # The chart is about the build we are on, not every build we ever recorded.
+  test "GET /stats/patch-changes leaves out earlier patches" do
+    model = create(:model)
+    record(model, fields: %w[mass], to_version: "4.9.0")
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /stats/patch-changes drops a ship that is no longer visible" do
+    hidden = create(:model, hidden: true)
+    record(hidden, fields: %w[mass])
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  private def record(model, fields:, to_version: ScData::Source.version)
+    fields.each do |field|
+      ModelBuildChange.create!(
+        model:, field:, to_version:, old_value: 1, new_value: 2,
+        recorded_at: 1.day.ago,
+        environment: ScData::Source.environment, from_version: "4.9.0"
+      )
+    end
+  end
+end

--- a/test/models/model_build_change_test.rb
+++ b/test/models/model_build_change_test.rb
@@ -2,6 +2,33 @@
 
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: model_build_changes
+#
+#  id           :uuid             not null, primary key
+#  environment  :string           not null
+#  field        :string           not null
+#  from_version :string           not null
+#  new_value    :decimal(15, 2)
+#  old_value    :decimal(15, 2)
+#  recorded_at  :datetime         not null
+#  to_version   :string           not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#  model_id     :uuid             not null
+#
+# Indexes
+#
+#  index_model_build_changes_on_build            (environment,to_version)
+#  index_model_build_changes_on_model_and_field  (model_id,environment,to_version,field) UNIQUE
+#  index_model_build_changes_on_model_id         (model_id)
+#  index_model_build_changes_on_recorded_at      (recorded_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_id => models.id) ON DELETE => cascade
+#
 class ModelBuildChangeTest < ActiveSupport::TestCase
   setup do
     @model = create(:model)

--- a/test/models/model_build_change_test.rb
+++ b/test/models/model_build_change_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ModelBuildChangeTest < ActiveSupport::TestCase
+  setup do
+    @model = create(:model)
+    @environment = ScData::Source.environment
+  end
+
+  test ".record! writes a row per fact the patch changed" do
+    previous_build(scm_speed: 210, max_speed: 1200)
+    build = current_build(scm_speed: 190, max_speed: 1200)
+
+    assert_equal 1, ModelBuildChange.record!(build)
+
+    change = ModelBuildChange.sole
+    assert_equal "scm_speed", change.field
+    assert_equal 210, change.old_value
+    assert_equal 190, change.new_value
+    assert_equal "4.9.0", change.from_version
+    assert_equal ScData::Source.version, change.to_version
+  end
+
+  test ".record! records nothing when the patch changed nothing" do
+    previous_build(scm_speed: 210)
+    build = current_build(scm_speed: 210)
+
+    assert_equal 0, ModelBuildChange.record!(build)
+    assert_empty ModelBuildChange.all
+  end
+
+  # The first build a ship ever gets has nothing to be measured against.
+  test ".record! records nothing without a preceding build" do
+    build = current_build(scm_speed: 210)
+
+    assert_equal 0, ModelBuildChange.record!(build)
+    assert_empty ModelBuildChange.all
+  end
+
+  # The same export parsed twice can produce different values without a version
+  # bump, so the second parse replaces the first rather than piling up beside it.
+  test ".record! replaces what it already recorded for the build" do
+    previous_build(scm_speed: 210)
+    build = current_build(scm_speed: 190)
+    ModelBuildChange.record!(build)
+
+    build.update!(scm_speed: 195)
+    ModelBuildChange.record!(build)
+
+    change = ModelBuildChange.sole
+    assert_equal 195, change.new_value
+  end
+
+  test ".record! drops a row for a fact that stopped differing" do
+    previous_build(scm_speed: 210)
+    build = current_build(scm_speed: 190)
+    ModelBuildChange.record!(build)
+
+    build.update!(scm_speed: 210)
+    ModelBuildChange.record!(build)
+
+    assert_empty ModelBuildChange.all
+  end
+
+  # Two loads of the same export can serialise a shape differently with nothing
+  # having changed, which would otherwise report a change every single patch.
+  test ".record! leaves the structured facts alone" do
+    previous_build(scm_speed: 210, cargo_holds: {"a" => 1}, hull_parts: {"parts" => 2})
+    build = current_build(scm_speed: 210, cargo_holds: {"b" => 9}, hull_parts: {"parts" => 7})
+
+    assert_equal 0, ModelBuildChange.record!(build)
+  end
+
+  test ".record! ignores a build of another environment" do
+    create(
+      :model_build,
+      model: @model, environment: "ptu", version: "4.9.0",
+      scm_speed: 999, created_at: 2.months.ago
+    )
+    build = current_build(scm_speed: 210)
+
+    assert_equal 0, ModelBuildChange.record!(build)
+  end
+
+  test ".record! measures against the most recent earlier build" do
+    create(
+      :model_build,
+      model: @model, environment: @environment, version: "4.8.0",
+      scm_speed: 100, created_at: 6.months.ago
+    )
+    previous_build(scm_speed: 210)
+    build = current_build(scm_speed: 190)
+
+    ModelBuildChange.record!(build)
+
+    assert_equal 210, ModelBuildChange.sole.old_value
+  end
+
+  test ".record! records a fact the previous build did not carry" do
+    previous_build(scm_speed: 210, max_speed: nil)
+    build = current_build(scm_speed: 210, max_speed: 1200)
+
+    ModelBuildChange.record!(build)
+
+    change = ModelBuildChange.sole
+    assert_equal "max_speed", change.field
+    assert_nil change.old_value
+    assert_equal 1200, change.new_value
+  end
+
+  private def previous_build(attributes)
+    create(
+      :model_build,
+      model: @model, environment: @environment, version: "4.9.0",
+      created_at: 2.months.ago, **attributes
+    )
+  end
+
+  private def current_build(attributes)
+    create(
+      :model_build,
+      model: @model, environment: @environment, version: ScData::Source.version,
+      created_at: 1.day.ago, **attributes
+    )
+  end
+end


### PR DESCRIPTION
Phase 5 of the stats plan (#4697): keep the patch diff before the builds it comes from are pruned.

## Why

`ModelBuild::BUILDS_RETAINED = 3`. Three builds per environment are kept and the rest are pruned, so "what did 4.10 do to the Prospector" is computable today and gone two patches from now. The table was built to make a patch diffable; nothing ever computed the diff, and the window to do it keeps closing.

## What changed

**Recording.** `ModelBuildChange.record!(build)` runs when a build lands in `ModelsLoader#load_model`, diffs it against the preceding build of the same environment, and writes one row per changed fact.

**Numeric facts only.** Eight of `ModelBuild::FACTS` are a shape rather than a number — `hull_parts`, `hull_doors` and `signature_cross_section` are jsonb, and `cargo_holds`, `quantum_fuel_tanks`, `hydrogen_fuel_tanks`, `external_fuel_tanks` and `refuel_boom` are YAML-serialized. Two loads of the same export can serialise those differently with nothing having changed, so comparing them with `!=` would report a change on every single patch and drown the real ones. `ground` is excluded with them: it classifies the ship rather than measuring it.

The diffable list is **derived** (`FACTS - STRUCTURED_FACTS - [:ground]`) rather than typed out, so a numeric fact added to FACTS later is diffable without anyone remembering to say so.

**Recomputing replaces.** A re-parse of the same export can move values without a version bump — so the diff is keyed on the target version and rewritten rather than appended. That also drops the row for a fact that stopped differing, which an append-only log would leave standing forever.

**Serving.** `/models/:slug/changes` for one ship, newest patch first. `/stats/patch-changes` ranks the ships the current build changed the most, with a panel on `/stats`.

## Verification

The plan flagged that this cannot be checked against real deltas locally — the dump holds exactly one build version — so the fixtures are built deliberately and each pins one decision:

- a row per changed fact, with the versions it moved between
- nothing recorded when the patch changed nothing
- nothing recorded for a ship's first build, which has nothing to measure against
- a re-parse replacing its rows rather than doubling them
- a fact that stopped differing losing its row
- the structured facts changing wholesale and still reporting **zero** changes
- a build of another environment ignored
- the *most recent* earlier build used, not the oldest
- a fact the previous build did not carry recorded with a null old value

Plus 9 endpoint tests. `154 tests, 402 assertions, 0 failures` across `test/loaders/sc_data` — the loader hook runs on every model load, so that suite is the one that matters — and 84 more across the model, endpoint and stats tests. `standardrb` clean, `pnpm lint:ts` exits 0, label in all seven locales.

## Note on the data

Nothing is recorded until the next sc_data load, and the first load records against whatever build is already there. So the log starts at the next patch rather than reaching back — the three retained builds are not walked backwards on deploy, deliberately: re-deriving old diffs from rows that may since have been re-parsed would date them wrong.

## Not in scope

- The change table on the ship history page — that page is Phase 8 and bundles four panels.
- I did not open `/stats` in a browser.

🤖