### PR TITLE
Record who changed what, on everything an admin can edit

### DIFF
--- a/app/controllers/admin/api/v1/commodities_controller.rb
+++ b/app/controllers/admin/api/v1/commodities_controller.rb
@@ -37,7 +37,7 @@ module Admin
         end
 
         def update
-          return if @commodity.update_with_facts(commodity_params)
+          return if @commodity.update_with_facts(commodity_params.merge(author_id: current_user.id))
 
           render json: ValidationError.new("commodity.update", errors: @commodity.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/components_controller.rb
+++ b/app/controllers/admin/api/v1/components_controller.rb
@@ -38,7 +38,7 @@ module Admin
         end
 
         def update
-          return if @component.update_with_facts(component_params)
+          return if @component.update_with_facts(component_params.merge(author_id: current_user.id))
 
           render json: ValidationError.new("component.update", errors: @component.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/equipment_controller.rb
+++ b/app/controllers/admin/api/v1/equipment_controller.rb
@@ -52,7 +52,7 @@ module Admin
         end
 
         def update
-          return if @equipment.update_with_facts(equipment_params)
+          return if @equipment.update_with_facts(equipment_params.merge(author_id: current_user.id))
 
           render json: ValidationError.new("equipment.update", errors: @equipment.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/funding_goals_controller.rb
+++ b/app/controllers/admin/api/v1/funding_goals_controller.rb
@@ -37,7 +37,7 @@ module Admin
         end
 
         def update
-          return if @funding_goal.update(funding_goal_params)
+          return if @funding_goal.update(funding_goal_params.merge(author_id: current_user.id))
 
           render json: ValidationError.new("funding_goal.update", errors: @funding_goal.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/manufacturers_controller.rb
+++ b/app/controllers/admin/api/v1/manufacturers_controller.rb
@@ -53,7 +53,7 @@ module Admin
         end
 
         def update
-          return if @manufacturer.update(manufacturer_params.merge(icon_override).merge(logo_override))
+          return if @manufacturer.update(manufacturer_params.merge(icon_override).merge(logo_override).merge(author_id: current_user.id))
 
           render json: ValidationError.new("manufacturer.update", errors: @manufacturer.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/model_paints_controller.rb
+++ b/app/controllers/admin/api/v1/model_paints_controller.rb
@@ -37,7 +37,7 @@ module Admin
         end
 
         def update
-          return if @model_paint.update(model_paint_params)
+          return if @model_paint.update(model_paint_params.merge(author_id: current_user.id))
 
           render json: ValidationError.new("model_paint.update", errors: @model_paint.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/supporter_contributions_controller.rb
+++ b/app/controllers/admin/api/v1/supporter_contributions_controller.rb
@@ -78,7 +78,7 @@ module Admin
         end
 
         def update
-          return if @supporter_contribution.update(supporter_contribution_params)
+          return if @supporter_contribution.update(supporter_contribution_params.merge(author_id: current_user.id))
 
           render json: ValidationError.new("supporter_contribution.update", errors: @supporter_contribution.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/users_controller.rb
+++ b/app/controllers/admin/api/v1/users_controller.rb
@@ -39,7 +39,7 @@ module Admin
         end
 
         def update
-          return if @user.update(user_params)
+          return if @user.update(user_params.merge(author_id: current_user.id))
 
           render json: ValidationError.new("user.update", errors: @user.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/vehicles_controller.rb
+++ b/app/controllers/admin/api/v1/vehicles_controller.rb
@@ -26,7 +26,7 @@ module Admin
         end
 
         def update
-          return if @vehicle.update(vehicle_params)
+          return if @vehicle.update(vehicle_params.merge(author_id: current_user.id))
 
           render json: ValidationError.new("vehicle.update", errors: @vehicle.errors), status: :bad_request
         end

--- a/app/controllers/admin/api/v1/versions_controller.rb
+++ b/app/controllers/admin/api/v1/versions_controller.rb
@@ -33,15 +33,33 @@ module Admin
         # can walk one item to its authorisation root, but a feed cannot do that
         # for every row it returns.
         #
-        # These three are the types that record *who* made the change -- they map
-        # `author_id` through paper_trail's `meta:`. Component is deliberately
-        # absent: it is versioned, but carries no `author_id` accessor, so a
-        # component edit is unattributed and would join the feed as an anonymous
-        # row. Worth closing separately; it is a gap in Component, not here.
+        # Every type that records who changed it, against the privilege its
+        # policy requires. Mirrors `Admin::*Policy#resource_access` -- that
+        # method is private, so the mapping is written out rather than asked for.
+        #
+        # `equipment`, `commodities` and `model_paints` are not in
+        # `AdminUser::AVAILABLE_PRIVILEGES`, so today only a super admin can hold
+        # them. That is pre-existing and true of the admin pages themselves, not
+        # something this map introduces.
         FEED_ACCESS_BY_ITEM_TYPE = {
           "Model" => :models,
           "ModelModule" => :model_modules,
-          "Fleet" => :fleets
+          "ModelPaint" => :model_paints,
+          "Component" => :components,
+          "Equipment" => :equipment,
+          "Commodity" => :commodities,
+          "Manufacturer" => :manufacturers,
+          "Fleet" => :fleets,
+          "Vehicle" => :vehicles,
+          "User" => :users,
+          "FundingGoal" => :supporters,
+          "SupporterContribution" => :supporters
+        }.freeze
+
+        # What to call a row in the feed. Everything else answers to `name`.
+        FEED_NAME_COLUMN = {
+          "User" => :username,
+          "FundingGoal" => :title
         }.freeze
 
         def recent
@@ -78,7 +96,7 @@ module Admin
 
             item_type.constantize
               .where(id: rows.map(&:item_id))
-              .pluck(:id, :name)
+              .pluck(:id, FEED_NAME_COLUMN.fetch(item_type, :name))
               .each { |id, name| names[[item_type, id]] = name }
           end
         end

--- a/app/lib/versioned_item.rb
+++ b/app/lib/versioned_item.rb
@@ -33,7 +33,15 @@ class VersionedItem
     "Inventory" => [:holder],
     "InventoryItem" => [:inventory, :holder],
     "Model" => [],
-    "ModelModule" => []
+    "ModelModule" => [],
+    "ModelPaint" => [],
+    "Equipment" => [],
+    "Commodity" => [],
+    "Manufacturer" => [],
+    "Vehicle" => [],
+    "User" => [],
+    "FundingGoal" => [],
+    "SupporterContribution" => []
   }.freeze
 
   TYPES = ROOTS.keys.freeze
@@ -43,7 +51,14 @@ class VersionedItem
     "Fleet" => ::Admin::FleetPolicy,
     "Model" => ::Admin::ModelPolicy,
     "ModelModule" => ::Admin::ModelModulePolicy,
-    "User" => ::Admin::UserPolicy
+    "ModelPaint" => ::Admin::ModelPaintPolicy,
+    "Equipment" => ::Admin::EquipmentPolicy,
+    "Commodity" => ::Admin::CommodityPolicy,
+    "Manufacturer" => ::Admin::ManufacturerPolicy,
+    "Vehicle" => ::Admin::VehiclePolicy,
+    "User" => ::Admin::UserPolicy,
+    "FundingGoal" => ::Admin::FundingGoalPolicy,
+    "SupporterContribution" => ::Admin::SupporterContributionPolicy
   }.freeze
 
   def self.supported?(item_type)

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -25,6 +25,27 @@
 #  index_commodities_on_uex_code        (uex_code)
 #
 class Commodity < ApplicationRecord
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # Only an admin action sets `author_id`, so a loader write files nothing. The
+  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
+  # 4,830 equipment rows a week, and versioning those unconditionally would bury
+  # the handful of real edits the way Fleet's touch versions already do.
+  has_paper_trail on: %i[update],
+    only: %i[
+      name description commodity_type uex_id uex_code sc_key sc_ref
+    ],
+    if: ->(record) { record.author_id.present? },
+    # `version` here is the sc_data build the row was last loaded from, and
+    # paper_trail claims that name for its own accessor unless told otherwise.
+    # Component already carries this rename for the same reason.
+    version: :paper_trail_version,
+    versions: {name: :paper_trail_versions},
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
   include AttachmentRansackers
   include ItemPriceConcern
   include ScDataVersioned

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -54,6 +54,11 @@ class Component < ApplicationRecord
   # The associations are renamed because PaperTrail's default `version` reader
   # shadows this table's `version` column -- left alone, an update writes NULL
   # over the build a component was last seen in.
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # No `if:` guard, unlike the models versioned alongside this one: Component
+  # already records loader changes and its history page shows them. This adds
+  # the author the record never carried, nothing else.
   has_paper_trail on: %i[update],
     only: %i[
       name description size grade item_type item_class component_class component_sub_type
@@ -61,7 +66,12 @@ class Component < ApplicationRecord
       inventory_consumption tracking_signal manufacturer_id hidden
     ],
     version: :paper_trail_version,
-    versions: {name: :paper_trail_versions}
+    versions: {name: :paper_trail_versions},
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
 
   belongs_to :manufacturer, optional: true
 

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -44,6 +44,31 @@
 #  index_equipment_on_slot             (slot)
 #
 class Equipment < ApplicationRecord
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # Only an admin action sets `author_id`, so a loader write files nothing. The
+  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
+  # 4,830 equipment rows a week, and versioning those unconditionally would bury
+  # the handful of real edits the way Fleet's touch versions already do.
+  has_paper_trail on: %i[update],
+    only: %i[
+      name description equipment_type item_type sub_type weapon_class
+      slot size grade rate_of_fire range storage volume damage_reduction
+      temperature_rating radiation_protection radiation_scrub_rate
+      g_force_tolerance core_compatibility backpack_compatibility
+      manufacturer_id hidden sc_key sc_ref
+    ],
+    if: ->(record) { record.author_id.present? },
+    # `version` here is the sc_data build the row was last loaded from, and
+    # paper_trail claims that name for its own accessor unless told otherwise.
+    # Component already carries this rename for the same reason.
+    version: :paper_trail_version,
+    versions: {name: :paper_trail_versions},
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
   include AttachmentRansackers
   include ItemPriceConcern
   include ScDataVersioned

--- a/app/models/funding_goal.rb
+++ b/app/models/funding_goal.rb
@@ -20,6 +20,22 @@
 #  index_funding_goals_on_ended_at        (ended_at)
 #
 class FundingGoal < ApplicationRecord
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # Only an admin action sets `author_id`, so a loader write files nothing. The
+  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
+  # 4,830 equipment rows a week, and versioning those unconditionally would bury
+  # the handful of real edits the way Fleet's touch versions already do.
+  has_paper_trail on: %i[update],
+    only: %i[
+      title description amount_cents currency effective_from ended_at
+    ],
+    if: ->(record) { record.author_id.present? },
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
   paginates_per 30
 
   DEFAULT_SORTING_PARAMS = "effective_from desc"

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -25,6 +25,22 @@
 #  index_manufacturers_on_slug  (slug) UNIQUE
 #
 class Manufacturer < ApplicationRecord
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # Only an admin action sets `author_id`, so a loader write files nothing. The
+  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
+  # 4,830 equipment rows a week, and versioning those unconditionally would bury
+  # the handful of real edits the way Fleet's touch versions already do.
+  has_paper_trail on: %i[update],
+    only: %i[
+      name long_name code description known_for sc_ref
+    ],
+    if: ->(record) { record.author_id.present? },
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
   include ActionView::Helpers::OutputSafetyHelper
   include ActiveStorageVariants
   include AttachmentRansackers

--- a/app/models/model_paint.rb
+++ b/app/models/model_paint.rb
@@ -36,6 +36,23 @@
 #  fk_rails_...  (component_id => components.id) ON DELETE => nullify
 #
 class ModelPaint < ApplicationRecord
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # Only an admin action sets `author_id`, so a loader write files nothing. The
+  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
+  # 4,830 equipment rows a week, and versioning those unconditionally would bury
+  # the handful of real edits the way Fleet's touch versions already do.
+  has_paper_trail on: %i[update],
+    only: %i[
+      name description model_id active hidden on_sale pledge_price
+      production_status production_note store_url
+    ],
+    if: ->(record) { record.author_id.present? },
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
   include ActiveStorageVariants
 
   paginates_per 30

--- a/app/models/supporter_contribution.rb
+++ b/app/models/supporter_contribution.rb
@@ -33,6 +33,23 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class SupporterContribution < ApplicationRecord
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # Only an admin action sets `author_id`, so a loader write files nothing. The
+  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
+  # 4,830 equipment rows a week, and versioning those unconditionally would bury
+  # the handful of real edits the way Fleet's touch versions already do.
+  has_paper_trail on: %i[update],
+    only: %i[
+      name amount_cents currency anonymous recurring
+      started_at ended_at note user_id
+    ],
+    if: ->(record) { record.author_id.present? },
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
   paginates_per 30
 
   # Touch so a linked account's cached public profile picks the badge up.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,6 +75,23 @@
 #  index_users_on_username              (username) UNIQUE
 #
 class User < ApplicationRecord
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # Only an admin action sets `author_id`, so a loader write files nothing. The
+  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
+  # 4,830 equipment rows a week, and versioning those unconditionally would bury
+  # the handful of real edits the way Fleet's touch versions already do.
+  has_paper_trail on: %i[update],
+    only: %i[
+      username rsi_handle sale_notify public_hangar public_hangar_loaners
+      public_wishlist hide_owner tester
+    ],
+    if: ->(record) { record.author_id.present? },
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
   include UrlFieldConcern
   include ActiveStorageVariants
   include Rails.application.routes.url_helpers

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -40,6 +40,23 @@
 require "csv"
 
 class Vehicle < ApplicationRecord
+  attr_accessor :update_reason, :update_reason_description, :author_id
+
+  # Only an admin action sets `author_id`, so a loader write files nothing. The
+  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
+  # 4,830 equipment rows a week, and versioning those unconditionally would bury
+  # the handful of real edits the way Fleet's touch versions already do.
+  has_paper_trail on: %i[update],
+    only: %i[
+      name serial wanted flagship public name_visible sale_notify hidden
+      loaner bought_via
+    ],
+    if: ->(record) { record.author_id.present? },
+    meta: {
+      author_id: :author_id,
+      reason: :update_reason,
+      reason_description: :update_reason_description
+    }
   paginates_per 30
   max_paginates_per 240
   per_page_steps [15, 30, 60, 120, 240, :all]

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -16549,6 +16549,14 @@ components:
       - InventoryItem
       - Model
       - ModelModule
+      - ModelPaint
+      - Equipment
+      - Commodity
+      - Manufacturer
+      - Vehicle
+      - User
+      - FundingGoal
+      - SupporterContribution
       x-enumNames:
       - COMPONENT
       - FLEET
@@ -16560,6 +16568,14 @@ components:
       - INVENTORY_ITEM
       - MODEL
       - MODEL_MODULE
+      - MODEL_PAINT
+      - EQUIPMENT
+      - COMMODITY
+      - MANUFACTURER
+      - VEHICLE
+      - USER
+      - FUNDING_GOAL
+      - SUPPORTER_CONTRIBUTION
       title: VersionItemTypeEnum
     VersionRevertInput:
       type: object

--- a/test/integration/admin/api/v1/versions_recent_test.rb
+++ b/test/integration/admin/api/v1/versions_recent_test.rb
@@ -84,6 +84,44 @@ class Admin::Api::V1::VersionsRecentTest < ActionDispatch::IntegrationTest
     assert_equal ["ModelModule"], item_types
   end
 
+  # Equipment gained versioning alongside the feed; before that an equipment
+  # edit was recorded nowhere at all.
+  test "GET /versions/recent lists an equipment edit under its own name" do
+    admin = create(:admin_user, super_admin: true)
+    equipment = create(:equipment, name: "Before")
+
+    equipment.author_id = admin.id
+    equipment.update!(name: "After")
+
+    sign_in admin
+
+    assert_api_response :get, 200
+
+    item = response.parsed_body["items"].first
+
+    assert_equal "Equipment", item["itemType"]
+    assert_equal "After", item["itemName"]
+    assert_equal admin.username, item["author"]["username"]
+  end
+
+  # A user is labelled by username, not by a `name` column it does not have.
+  test "GET /versions/recent labels a user edit with its username" do
+    admin = create(:admin_user, super_admin: true)
+    user = create(:user, rsi_handle: "before")
+
+    user.author_id = admin.id
+    user.update!(rsi_handle: "after")
+
+    sign_in admin
+
+    assert_api_response :get, 200
+
+    item = response.parsed_body["items"].first
+
+    assert_equal "User", item["itemType"]
+    assert_equal user.username, item["itemName"]
+  end
+
   test "GET /versions/recent returns nothing for an admin with no versioned access" do
     admin = create(:admin_user, resource_access: [:stats])
     model = create(:model, name: "Before")

--- a/test/models/admin_edit_attribution_test.rb
+++ b/test/models/admin_edit_attribution_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# The whole point of versioning these models is attribution, so the gate that
+# keeps loader writes out of the version table is the behaviour worth pinning.
+class AdminEditAttributionTest < ActiveSupport::TestCase
+  # One entry per model that gained versioning, with a field the admin edits and
+  # a value to change it to. A model added to the group without a line here is
+  # untested, which the count assertion at the bottom catches.
+  CASES = {
+    Equipment => {name: "Renamed by an admin"},
+    Commodity => {name: "Renamed by an admin"},
+    Manufacturer => {known_for: "Renamed by an admin"},
+    ModelPaint => {production_note: "Noted by an admin"},
+    Vehicle => {serial: "SN-ADMIN-1"},
+    User => {rsi_handle: "renamed_by_admin"},
+    FundingGoal => {title: "Renamed by an admin"},
+    SupporterContribution => {note: "Noted by an admin"}
+  }.freeze
+
+  setup do
+    @admin = create(:admin_user)
+  end
+
+  CASES.each do |klass, attributes|
+    factory = klass.name.underscore.to_sym
+
+    test "#{klass} files a version when an admin makes the change" do
+      record = create(factory)
+
+      assert_difference -> { PaperTrail::Version.where(item_type: klass.name).count }, 1 do
+        record.author_id = @admin.id
+        record.update!(attributes)
+      end
+
+      version = PaperTrail::Version.where(item_type: klass.name).order(created_at: :desc).first
+
+      assert_equal @admin.id, version.author_id
+      assert_equal attributes.keys.map(&:to_s), version.changeset.keys
+    end
+
+    # A loader writes the same columns and sets no author. Without the guard the
+    # UEX sync alone would file a version for every commodity every morning.
+    test "#{klass} files nothing when no author made the change" do
+      record = create(factory)
+
+      assert_no_difference -> { PaperTrail::Version.where(item_type: klass.name).count } do
+        record.update!(attributes)
+      end
+    end
+  end
+
+  # Component keeps recording loader changes -- its history page shows them --
+  # so it is the one model here without the author guard.
+  test "Component records a change with no author, and carries one when given" do
+    component = create(:component)
+
+    assert_difference -> { PaperTrail::Version.where(item_type: "Component").count }, 1 do
+      component.update!(name: "Renamed by a loader")
+    end
+
+    assert_nil PaperTrail::Version.where(item_type: "Component").order(created_at: :desc).first.author_id
+
+    component.author_id = @admin.id
+    component.update!(name: "Renamed by an admin")
+
+    assert_equal @admin.id,
+      PaperTrail::Version.where(item_type: "Component").order(created_at: :desc).first.author_id
+  end
+
+  test "every versioned type the feed can carry is authorised and named" do
+    feed_types = Admin::Api::V1::VersionsController::FEED_ACCESS_BY_ITEM_TYPE.keys
+
+    # A type in the feed with no VersionedItem entry would be returned with an
+    # `itemType` outside the schema's enum.
+    assert_empty feed_types - ::VersionedItem::TYPES
+
+    feed_types.each do |item_type|
+      klass = item_type.constantize
+      column = Admin::Api::V1::VersionsController::FEED_NAME_COLUMN.fetch(item_type, :name)
+
+      assert_includes klass.column_names, column.to_s, "#{item_type} has no #{column} to label it with"
+      assert ::VersionedItem::POLICIES.key?(item_type), "#{item_type} has no policy to authorise it"
+    end
+  end
+end


### PR DESCRIPTION
> **Stacked on #4706.** Base is `feat/admin-dashboard-rework`, not `main` — review that one first, and this diff will shrink to its own commit once it merges.

## The gap

#4706 added a feed of recent admin edits. It could only ever show **four of the sixteen things an admin can change**.

Ten models were versioned, but only `Model`, `ModelModule`, `Fleet` and `FleetMembership` recorded *who* made the change. The other six admin sections were not versioned at all — an edit to a piece of equipment, a commodity, a manufacturer, a paint, a vehicle, a user, a funding goal or a supporter contribution left **no trace anywhere**: no history, no attribution, no revert.

Nine models change here. Eight gain versioning; `Component` only gains the author it never carried.

## Two decisions worth a look

**The author guard.** Every newly versioned model files a version only when `author_id` is set, which only an admin action does. This is not tidiness — measured on the development database, the UEX sync rewrites **all 232 commodities** and **1,526 of 4,830 equipment rows** in a week. Versioning those unconditionally would bury the handful of real edits exactly the way Fleet's touch versions already do, at 572,735 against 464 real ones.

The trade is deliberate: a loader change is not recorded, because the import reports already cover it and the question this answers is *who*.

`Component` is the exception and keeps no guard — it already records loader changes and its history page shows them, so adding one would have taken that away.

**A user's email is not versioned.** The other admin-editable fields on `User` are. A version row is append-only and an erasure request has no way to reach it, so an old email would outlive the account. Everything else in the list is a public identifier or a display preference. Easy to add if you'd rather have it.

## How the field lists were built

Each `only:` list is that model's admin controller params intersected with its real columns. An ActiveStorage attachment is not a column and cannot be versioned, which is why `store_image`, `logo`, `icon` and `avatar` are absent.

## Knock-on

The new types join `VersionedItem`, so the per-record history and the field-level revert reach them too, each authorised by the policy that already guards its admin page. `VersionItemTypeEnum` is derived from that list, so the admin schema grows with it.

## Something pre-existing you may want to know

`equipment`, `commodities` and `model_paints` are referenced by their policies but are **not in `AdminUser::AVAILABLE_PRIVILEGES`**. No non-super-admin can be granted them, so those sections are silently super-admin-only. Not introduced here and not changed here — changing it would alter the access model — but the feed inherits the same limit.

## Not covered

`Image`, whose admin edits are attachment moves rather than column changes; `AdminUser` and `OauthApplication`, where versioning credentials and scopes deserves its own thought.

## Testing

- New `test/models/admin_edit_attribution_test.rb`: 18 tests covering, per model, that an authored edit files a version and an unauthored one does not, plus a consistency check that every type the feed can carry is in `VersionedItem` and has a column to label it
- Feed integration tests extended for an equipment edit and for a user labelled by `username`
- 545 model tests, 1,407 public API integration tests, 934 admin API integration tests — green
- Two admin tests error locally on a missing Vite manifest (`entrypoints/email.scss`); they are the only two that deliver mail, they fail identically with this branch stashed, and CI builds assets

🤖