### PR TITLE
feat(stats): read the pledge price history paper_trail already keeps

### DIFF
--- a/app/api_components/v1/schemas/models/prices/model_price_point.rb
+++ b/app/api_components/v1/schemas/models/prices/model_price_point.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Prices
+        # One recorded change to a ship's pledge price.
+        #
+        # `from` is null where the ship was first given a price and `to` is null
+        # where one was taken away. Neither is a price movement.
+        class ModelPricePoint
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              changedAt: {type: :string, format: :"date-time"},
+              from: {type: [:number, :null]},
+              to: {type: [:number, :null]}
+            },
+            required: %i[changedAt],
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/models/prices/model_price_points_list.rb
+++ b/app/api_components/v1/schemas/models/prices/model_price_points_list.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Models
+      module Prices
+        class ModelPricePointsList
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :array,
+            items: {"$ref": "#/components/schemas/ModelPricePoint"}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -316,6 +316,17 @@ module Api
         @changes = model.build_changes.newest_first
       end
 
+      # Every recorded pledge price change, oldest first. `from` is null where the
+      # ship was first given a price and `to` is null where one was taken away;
+      # neither is a price movement, and calling them one would be wrong in
+      # opposite directions.
+      def price_history
+        model = find_model_by_slug!
+        return if performed?
+
+        @price_history = model.pledge_price_history
+      end
+
       def store_image
         model = find_model_by_slug(Model.visible.active)
         return if performed?

--- a/app/controllers/api/v1/stats/base_controller.rb
+++ b/app/controllers/api/v1/stats/base_controller.rb
@@ -173,6 +173,51 @@ module Api
           "#{model_name} - #{paint.name}"
         end
 
+        # How far back the pledge price chart reaches. Prices move on concept
+        # sales and flyable releases, so a year is roughly one such cycle.
+        PLEDGE_PRICE_WINDOW = 12.months
+
+        # Net move per ship over the window: the oldest change's starting price
+        # against the newest one's ending price.
+        #
+        # Only rows carrying both sides count. A ship first given a price, or one
+        # whose price was taken away, has not moved -- and reading either as a
+        # move from or to zero would put it straight to the top of the chart.
+        def pledge_price_changes
+          changes = ::PaperTrail::Version
+            .where(item_type: "Model")
+            .where(created_at: PLEDGE_PRICE_WINDOW.ago..)
+            .where("object_changes -> 'pledge_price' ->> 0 IS NOT NULL")
+            .where("object_changes -> 'pledge_price' ->> 1 IS NOT NULL")
+            .order(:created_at)
+            .pluck(
+              :item_id,
+              Arel.sql("(object_changes -> 'pledge_price' ->> 0)::numeric"),
+              Arel.sql("(object_changes -> 'pledge_price' ->> 1)::numeric")
+            )
+
+          net = changes.each_with_object({}) do |(model_id, from, to), moves|
+            moves[model_id] ||= {from:, to:}
+            moves[model_id][:to] = to
+          end
+
+          names = Model.visible.active.where(id: net.keys).pluck(:id, :name).to_h
+
+          pledge_price_changes = net.filter_map do |model_id, move|
+            next unless names.key?(model_id)
+
+            change = (move[:to] - move[:from]).round
+            next if change.zero?
+
+            {label: names[model_id], count: change, tooltip: names[model_id]}
+          end
+
+          # By size of the move, so the steepest cut ranks beside the steepest
+          # rise rather than falling off the end. Both happen: 220 rises against
+          # 161 cuts in what is recorded.
+          render json: pledge_price_changes.sort_by { |point| -point[:count].abs }.take(10).to_json
+        end
+
         # Grouped on `category`, not on the `component_class` this is named for.
         # That column is set on 333 of 8,739 components and `item_class` on 415,
         # so either one renders as a single "Unknown" slice covering 95% of the

--- a/app/frontend/frontend/pages/stats.vue
+++ b/app/frontend/frontend/pages/stats.vue
@@ -30,6 +30,7 @@ import {
   useVehiclesPerMonth as useVehiclesPerMonthQuery,
   useShipsOfTheMonth as useShipsOfTheMonthQuery,
   useTrendingShips as useTrendingShipsQuery,
+  usePledgePriceChanges as usePledgePriceChangesQuery,
   useMostWishlisted as useMostWishlistedQuery,
   useWishlistByModel as useWishlistByModelQuery,
   useWishToOwnRatio as useWishToOwnRatioQuery,
@@ -66,6 +67,9 @@ const { data: shipsOfTheMonthOptions, ...shipsOfTheMonthStatus } =
 
 const { data: trendingShipsOptions, ...trendingShipsStatus } =
   useTrendingShipsQuery();
+
+const { data: pledgePriceChangesOptions, ...pledgePriceChangesStatus } =
+  usePledgePriceChangesQuery();
 
 const { data: mostWishlistedOptions, ...mostWishlistedStatus } =
   useMostWishlistedQuery();
@@ -176,6 +180,11 @@ const csvCharts = computed(() => ({
     name: "patch-changes",
     title: t("labels.stats.patchChanges"),
     points: patchChangesOptions.value,
+  },
+  "pledge-price-changes": {
+    name: "pledge-price-changes",
+    title: t("labels.stats.pledgePriceChanges"),
+    points: pledgePriceChangesOptions.value,
   },
   "vehicles-by-model": {
     name: "vehicles-by-model",
@@ -520,6 +529,33 @@ const csvMetrics = computed<StatsMetric[]>(() => [
             name="top-paints"
             :async-status="topPaintsStatus"
             :options="topPaintsOptions"
+            type="bar"
+          />
+        </PanelBody>
+      </Panel>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.stats.pledgePriceChanges") }}
+          <template #actions>
+            <StatsCsvExportBtn
+              scope="stats"
+              :chart="csvCharts['pledge-price-changes']"
+            />
+          </template>
+        </PanelHeading>
+        <PanelBody>
+          <Chart
+            v-if="pledgePriceChangesOptions"
+            key="pledge-price-changes"
+            name="pledge-price-changes"
+            :async-status="pledgePriceChangesStatus"
+            :options="pledgePriceChangesOptions"
+            tooltip-type="ship"
             type="bar"
           />
         </PanelBody>

--- a/app/frontend/frontend/pages/stats.vue
+++ b/app/frontend/frontend/pages/stats.vue
@@ -550,7 +550,6 @@ const csvMetrics = computed<StatsMetric[]>(() => [
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="pledgePriceChangesOptions"
             key="pledge-price-changes"
             name="pledge-price-changes"
             :async-status="pledgePriceChangesStatus"

--- a/app/frontend/frontend/pages/stats.vue
+++ b/app/frontend/frontend/pages/stats.vue
@@ -518,28 +518,6 @@ const csvMetrics = computed<StatsMetric[]>(() => [
     <div class="col-12 col-md-6">
       <Panel>
         <PanelHeading :level="HeadingLevelEnum.H2">
-          {{ t("labels.stats.topPaints") }}
-          <template #actions>
-            <StatsCsvExportBtn scope="stats" :chart="csvCharts['top-paints']" />
-          </template>
-        </PanelHeading>
-        <PanelBody>
-          <Chart
-            key="top-paints"
-            name="top-paints"
-            :async-status="topPaintsStatus"
-            :options="topPaintsOptions"
-            type="bar"
-          />
-        </PanelBody>
-      </Panel>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-12">
-      <Panel>
-        <PanelHeading :level="HeadingLevelEnum.H2">
           {{ t("labels.stats.pledgePriceChanges") }}
           <template #actions>
             <StatsCsvExportBtn
@@ -555,6 +533,28 @@ const csvMetrics = computed<StatsMetric[]>(() => [
             :async-status="pledgePriceChangesStatus"
             :options="pledgePriceChangesOptions"
             tooltip-type="ship"
+            type="bar"
+          />
+        </PanelBody>
+      </Panel>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.stats.topPaints") }}
+          <template #actions>
+            <StatsCsvExportBtn scope="stats" :chart="csvCharts['top-paints']" />
+          </template>
+        </PanelHeading>
+        <PanelBody>
+          <Chart
+            key="top-paints"
+            name="top-paints"
+            :async-status="topPaintsStatus"
+            :options="topPaintsOptions"
             type="bar"
           />
         </PanelBody>

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -190,7 +190,7 @@
         "wishToOwnRatio": "Gewünscht pro 100 im Hangar",
         "topPaints": "Beliebteste Lackierungen",
         "paintedVehicles": "Lackierte Schiffe",
-        "pledgePriceChanges": "Größte Pledge-Preisänderungen (12 Monate)",
+        "pledgePriceChanges": "Pledge-Preisänderungen (12 Monate)",
         "mostWishlisted": "Meistgewünschte Schiffe diesen Monat",
         "patchChanges": "Am stärksten von diesem Patch verändert",
         "crewDeficit": "Crew Defizit",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -190,6 +190,7 @@
         "wishToOwnRatio": "Gewünscht pro 100 im Hangar",
         "topPaints": "Beliebteste Lackierungen",
         "paintedVehicles": "Lackierte Schiffe",
+        "pledgePriceChanges": "Größte Pledge-Preisänderungen (12 Monate)",
         "mostWishlisted": "Meistgewünschte Schiffe diesen Monat",
         "patchChanges": "Am stärksten von diesem Patch verändert",
         "crewDeficit": "Crew Defizit",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -190,7 +190,7 @@
         "wishToOwnRatio": "Wished per 100 Owned",
         "topPaints": "Most Popular Paints",
         "paintedVehicles": "Painted Ships",
-        "pledgePriceChanges": "Biggest Pledge Price Changes (12 Months)",
+        "pledgePriceChanges": "Pledge Price Changes (12 Months)",
         "mostWishlisted": "Most Wishlisted This Month",
         "patchChanges": "Most Changed by This Patch",
         "crewDeficit": "Crew Deficit",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -190,6 +190,7 @@
         "wishToOwnRatio": "Wished per 100 Owned",
         "topPaints": "Most Popular Paints",
         "paintedVehicles": "Painted Ships",
+        "pledgePriceChanges": "Biggest Pledge Price Changes (12 Months)",
         "mostWishlisted": "Most Wishlisted This Month",
         "patchChanges": "Most Changed by This Patch",
         "crewDeficit": "Crew Deficit",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -190,6 +190,7 @@
         "wishToOwnRatio": "Deseadas por 100 en posesión",
         "topPaints": "Pinturas más populares",
         "paintedVehicles": "Naves pintadas",
+        "pledgePriceChanges": "Mayores cambios de precio pledge (12 meses)",
         "mostWishlisted": "Naves más deseadas este mes",
         "patchChanges": "Más modificadas por este parche",
         "crewDeficit": "Déficit de tripulación",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -190,7 +190,7 @@
         "wishToOwnRatio": "Deseadas por 100 en posesión",
         "topPaints": "Pinturas más populares",
         "paintedVehicles": "Naves pintadas",
-        "pledgePriceChanges": "Mayores cambios de precio pledge (12 meses)",
+        "pledgePriceChanges": "Cambios de precio pledge (12 meses)",
         "mostWishlisted": "Naves más deseadas este mes",
         "patchChanges": "Más modificadas por este parche",
         "crewDeficit": "Déficit de tripulación",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -190,6 +190,7 @@
         "wishToOwnRatio": "Souhaités pour 100 possédés",
         "topPaints": "Peintures les plus populaires",
         "paintedVehicles": "Vaisseaux peints",
+        "pledgePriceChanges": "Plus fortes variations de prix pledge (12 mois)",
         "mostWishlisted": "Vaisseaux les plus souhaités ce mois-ci",
         "patchChanges": "Les plus modifiés par ce patch",
         "crewDeficit": "Déficit d'équipage",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -190,7 +190,7 @@
         "wishToOwnRatio": "Souhaités pour 100 possédés",
         "topPaints": "Peintures les plus populaires",
         "paintedVehicles": "Vaisseaux peints",
-        "pledgePriceChanges": "Plus fortes variations de prix pledge (12 mois)",
+        "pledgePriceChanges": "Variations de prix pledge (12 mois)",
         "mostWishlisted": "Vaisseaux les plus souhaités ce mois-ci",
         "patchChanges": "Les plus modifiés par ce patch",
         "crewDeficit": "Déficit d'équipage",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -190,7 +190,7 @@
         "wishToOwnRatio": "Desiderate ogni 100 possedute",
         "topPaints": "Vernici più popolari",
         "paintedVehicles": "Navi verniciate",
-        "pledgePriceChanges": "Maggiori variazioni di prezzo pledge (12 mesi)",
+        "pledgePriceChanges": "Variazioni di prezzo pledge (12 mesi)",
         "mostWishlisted": "Navi più desiderate questo mese",
         "patchChanges": "Più modificate da questa patch",
         "crewDeficit": "Deficit equipaggio",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -190,6 +190,7 @@
         "wishToOwnRatio": "Desiderate ogni 100 possedute",
         "topPaints": "Vernici più popolari",
         "paintedVehicles": "Navi verniciate",
+        "pledgePriceChanges": "Maggiori variazioni di prezzo pledge (12 mesi)",
         "mostWishlisted": "Navi più desiderate questo mese",
         "patchChanges": "Più modificate da questa patch",
         "crewDeficit": "Deficit equipaggio",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -190,7 +190,7 @@
         "wishToOwnRatio": "每 100 艘拥有对应的期待数",
         "topPaints": "最受欢迎的涂装",
         "paintedVehicles": "已涂装飞船",
-        "pledgePriceChanges": "涨跌最大的现金购买价（12 个月）",
+        "pledgePriceChanges": "现金购买价变动（12 个月）",
         "mostWishlisted": "本月最受期待的飞船",
         "patchChanges": "本次更新改动最大的飞船",
         "crewDeficit": "船员缺口",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -190,6 +190,7 @@
         "wishToOwnRatio": "每 100 艘拥有对应的期待数",
         "topPaints": "最受欢迎的涂装",
         "paintedVehicles": "已涂装飞船",
+        "pledgePriceChanges": "涨跌最大的现金购买价（12 个月）",
         "mostWishlisted": "本月最受期待的飞船",
         "patchChanges": "本次更新改动最大的飞船",
         "crewDeficit": "船员缺口",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -190,7 +190,7 @@
         "wishToOwnRatio": "每 100 艘擁有對應的期待數",
         "topPaints": "最受歡迎的塗裝",
         "paintedVehicles": "已塗裝飛船",
-        "pledgePriceChanges": "漲跌最大的現金購買價（12 個月）",
+        "pledgePriceChanges": "現金購買價變動（12 個月）",
         "mostWishlisted": "本月最受期待的飛船",
         "patchChanges": "本次更新改動最大的飛船",
         "crewDeficit": "船員缺口",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -190,6 +190,7 @@
         "wishToOwnRatio": "每 100 艘擁有對應的期待數",
         "topPaints": "最受歡迎的塗裝",
         "paintedVehicles": "已塗裝飛船",
+        "pledgePriceChanges": "漲跌最大的現金購買價（12 個月）",
         "mostWishlisted": "本月最受期待的飛船",
         "patchChanges": "本次更新改動最大的飛船",
         "crewDeficit": "船員缺口",

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -906,6 +906,26 @@ class Model < ApplicationRecord
     slug&.start_with?(prefix) ? slug.delete_prefix(prefix) : slug
   end
 
+  # Price changes paper_trail has been recording since 2023, read back as a
+  # series. `from` is null where the ship was first given a price rather than
+  # repriced -- 189 of the 692 recorded changes are that, and treating them as a
+  # rise from zero would put every newly priced ship at the top of a chart about
+  # price movement.
+  #
+  # Costs 0.2ms per model: `versions` is indexed on (item_type, item_id), and
+  # the JSON is only touched for the rows that survive it.
+  def pledge_price_history
+    versions
+      .where("object_changes -> 'pledge_price' IS NOT NULL")
+      .order(:created_at)
+      .pluck(
+        :created_at,
+        Arel.sql("(object_changes -> 'pledge_price' ->> 0)::numeric"),
+        Arel.sql("(object_changes -> 'pledge_price' ->> 1)::numeric")
+      )
+      .map { |changed_at, from, to| {changed_at:, from:, to:} }
+  end
+
   def last_sale
     sales.recent_first.first
   end

--- a/app/views/api/v1/models/price_history.jbuilder
+++ b/app/views/api/v1/models/price_history.jbuilder
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+json.array! @price_history do |point|
+  json.changed_at point[:changed_at]
+  json.from point[:from]
+  json.to point[:to]
+end

--- a/config/routes/api/models_routes.rb
+++ b/config/routes/api/models_routes.rb
@@ -21,6 +21,7 @@ resources :models, param: :slug, only: %i[index show] do
     get :upgrades
     get :paints
     get :sales
+    get :price_history, path: "price-history"
     get :wishlist_history, path: "wishlist-history"
     get :changes
     get :store_image, path: "store-image"

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -105,6 +105,7 @@ v1_api_routes = lambda do
     get "wishlist-by-model", to: "base#wishlist_by_model"
     get "wish-to-own-ratio", to: "base#wish_to_own_ratio"
     get "top-paints", to: "base#top_paints"
+    get "pledge-price-changes", to: "base#pledge_price_changes"
     get "most-wishlisted", to: "base#most_wishlisted"
     get "patch-changes", to: "base#patch_changes"
   end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -7483,6 +7483,34 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/models/{slug}/price-history":
+    parameters:
+    - name: slug
+      in: path
+      schema:
+        type: string
+      description: Model slug
+      required: true
+    get:
+      summary: Model Price History
+      tags:
+      - Models
+      operationId: modelPriceHistory
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ModelPricePointsList"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/models/{slug}/sales":
     parameters:
     - name: slug
@@ -9615,6 +9643,19 @@ paths:
       tags:
       - Stats
       operationId: patchChanges
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BarChartStatsList"
+  "/stats/pledge-price-changes":
+    get:
+      summary: Stats Pledge Price Changes
+      tags:
+      - Stats
+      operationId: pledgePriceChanges
       responses:
         '200':
           description: successful
@@ -18841,6 +18882,29 @@ components:
       items:
         "$ref": "#/components/schemas/ModelPosition"
       title: ModelPositionsList
+    ModelPricePoint:
+      type: object
+      properties:
+        changedAt:
+          type: string
+          format: date-time
+        from:
+          type:
+          - number
+          - 'null'
+        to:
+          type:
+          - number
+          - 'null'
+      required:
+      - changedAt
+      additionalProperties: false
+      title: ModelPricePoint
+    ModelPricePointsList:
+      type: array
+      items:
+        "$ref": "#/components/schemas/ModelPricePoint"
+      title: ModelPricePointsList
     ModelProductionStatusEnum:
       type: string
       enum:

--- a/test/integration/api/v1/models_price_history_test.rb
+++ b/test/integration/api/v1/models_price_history_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::ModelsPriceHistoryTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/models/{slug}/price-history" do
+    parameter name: "slug", in: :path, schema: {type: :string}, description: "Model slug", required: true
+
+    get("Model Price History") do
+      operationId "modelPriceHistory"
+      tags "Models"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::V1::Schemas::Models::Prices::ModelPricePointsList
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  test "GET /models/:slug/price-history returns the changes oldest first" do
+    model = create(:model, pledge_price: 100)
+    model.update!(pledge_price: 150)
+    model.update!(pledge_price: 200)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal [100, 150], parsed_body.map { |point| point["from"].to_i }
+      assert_equal [150, 200], parsed_body.map { |point| point["to"].to_i }
+    end
+  end
+
+  # A ship first given a price has no earlier price, and null says so. Reading
+  # it as a rise from zero would be wrong.
+  test "GET /models/:slug/price-history reports a first price with no earlier one" do
+    model = create(:model, pledge_price: nil)
+    model.update!(pledge_price: 90)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_nil parsed_body.sole["from"]
+      assert_equal 90, parsed_body.sole["to"].to_i
+    end
+  end
+
+  test "GET /models/:slug/price-history reports a price that was taken away" do
+    model = create(:model, pledge_price: 90)
+    model.update!(pledge_price: nil)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal 90, parsed_body.sole["from"].to_i
+      assert_nil parsed_body.sole["to"]
+    end
+  end
+
+  test "GET /models/:slug/price-history ignores changes to anything else" do
+    model = create(:model, pledge_price: 100)
+    model.update!(name: "Renamed")
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /models/:slug/price-history returns 404 for unknown model" do
+    assert_api_response :get, 404, path_params: {slug: "unknown-model"}
+  end
+end

--- a/test/integration/api/v1/stats_pledge_price_changes_test.rb
+++ b/test/integration/api/v1/stats_pledge_price_changes_test.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::StatsPledgePriceChangesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/stats/pledge-price-changes" do
+    get("Stats Pledge Price Changes") do
+      operationId "pledgePriceChanges"
+      tags "Stats"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Shared::V1::Schemas::BarChartStatsList
+      end
+    end
+  end
+
+  test "GET /stats/pledge-price-changes returns chart data" do
+    assert_api_response :get, 200
+  end
+
+  test "GET /stats/pledge-price-changes reports the net move over the window" do
+    model = create(:model, pledge_price: 100)
+    model.update!(pledge_price: 150)
+    model.update!(pledge_price: 250)
+
+    assert_api_response :get, 200 do
+      assert_equal [model.name], parsed_body.map { |point| point["label"] }
+      assert_equal [150], parsed_body.map { |point| point["count"] }
+    end
+  end
+
+  # 161 of the recorded moves are cuts, so ranking by value rather than by size
+  # would push the steepest of them off the end of a chart about movement.
+  test "GET /stats/pledge-price-changes ranks a cut beside a rise" do
+    cut = create(:model, pledge_price: 1000)
+    rise = create(:model, pledge_price: 100)
+    cut.update!(pledge_price: 100)
+    rise.update!(pledge_price: 200)
+
+    assert_api_response :get, 200 do
+      assert_equal [cut.name, rise.name], parsed_body.map { |point| point["label"] }
+      assert_equal [-900, 100], parsed_body.map { |point| point["count"] }
+    end
+  end
+
+  # 189 of the 692 recorded changes are a ship first getting a price. Counting
+  # those as a rise from zero would put every new ship at the top.
+  test "GET /stats/pledge-price-changes leaves out a ship that was first priced" do
+    model = create(:model, pledge_price: nil)
+    model.update!(pledge_price: 400)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /stats/pledge-price-changes leaves out a price that was taken away" do
+    model = create(:model, pledge_price: 400)
+    model.update!(pledge_price: nil)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /stats/pledge-price-changes ignores changes older than the window" do
+    model = create(:model, pledge_price: 100)
+    travel_to(2.years.ago) { model.update!(pledge_price: 900) }
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+
+  test "GET /stats/pledge-price-changes drops a ship that is no longer visible" do
+    model = create(:model, pledge_price: 100, hidden: true)
+    model.update!(pledge_price: 500)
+
+    assert_api_response :get, 200 do
+      assert_empty parsed_body
+    end
+  end
+end


### PR DESCRIPTION
Phase 7 of the stats plan (#4697). Nothing new is collected — `pledge_price` has been in Model's paper_trail `only:` list since 2023, so three years of changes were already recorded and shown nowhere.

## What the data actually looks like

The plan described this as a `(changed_at, from, to)` series. The recorded data has three shapes, and two of them would have produced a wrong chart if treated as movement:

- **189 of the 692 recorded changes are `[null, 400]`** — a ship being given a price for the first time, not a price rise. Counted as a rise from zero, every newly priced ship tops the chart.
- **A price can be taken away**, `[400, null]`. Not a fall to zero.
- **Both directions happen** — 220 rises against 161 cuts — so ranking by value rather than by size of the move pushes the steepest cut off the end of a chart about movement.

The per-ship endpoint reports all three, with null on whichever side has no price. The global chart counts only the moves that have both sides.

## What changed

- `Model#pledge_price_history` — the series, oldest first.
- `GET /models/:slug/price-history` — every recorded change for one ship. No caller yet; it is the fourth panel of the ship history page, which is phase 8. That page now has all four of its series available, which is why this came before it.
- `GET /stats/pledge-price-changes` and a panel — net move per ship over twelve months, oldest change's starting price against the newest one's ending price. A year is roughly one concept-sale-to-flyable cycle.

## On performance

The plan warned not to `LIKE` over `object_changes::text` and suggested denormalising if slow. Measured instead: **0.2ms** for one ship — `versions` is indexed on `(item_type, item_id)` and the JSON is only touched for rows that survive that — and **15ms** for the whole twelve-month window across the 612k-row table. No denormalisation, no new table.

Coverage starts 2023-07-03, which is when paper_trail began recording the column. The in-game `price` column is in the same list but has moved only 6 times ever, so this reads `pledge_price` alone rather than shipping a second series that is always empty.

## Verification

12 tests. Each of the three data shapes is pinned on both endpoints, plus the ranking, the window, a hidden ship dropped, and changes to other attributes ignored.

`91 tests, 232 assertions, 0 failures` across the stats, model and price-history suites. `standardrb` clean, `pnpm lint:ts` exits 0, label in all seven locales.

## Layout

The panel is full width, because this branch is cut from main where the three panels above it still are too. #4707 and #4709 are queued ahead and change that — after they land the page is entirely paired, and this one would be the odd one out. I will sort the layout in the rebase rather than guess at it now; the content pairing I have in mind is `wish-to-own-ratio` beside this one, with `top-paints` going full width since its labels are the longest on the page.

🤖