### PR TITLE
Make every admin privilege grantable, and record an email change

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -40,8 +40,23 @@
 class AdminUser < ApplicationRecord
   include ResourceAccessConcern
 
+  # Every privilege an `Admin::*Policy` asks for has to appear here, or the
+  # policy names something nobody can be granted and the section it guards is
+  # silently super-admin-only. Fifteen were missing -- equipment, commodities,
+  # model_paints and the twelve model sub-resources -- not by decision, but
+  # because the list was never extended alongside the policies.
+  #
+  # Adding them grants nothing: an admin holds a privilege only once it is set
+  # on their account. `AdminUserPrivilegesTest` fails if a policy drifts out of
+  # this list again.
   RESOURCE_ACCESS = {
-    ship_data: %w[models model_modules components manufacturers vehicles images],
+    ship_data: %w[
+      models model_modules model_module_packages model_paints model_positions
+      model_hardpoints model_loaners model_snub_crafts model_upgrades
+      cargo_holds docks videos
+      components equipment commodities item_prices
+      manufacturers vehicles images
+    ],
     community: %w[fleets users supporters],
     system: %w[admins oauth_applications maintenance imports features workers pghero rsi-api-status stats]
   }.freeze

--- a/app/models/concerns/erasable_versions_concern.rb
+++ b/app/models/concerns/erasable_versions_concern.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Drops a record's versions when the record itself is destroyed.
+#
+# paper_trail keeps versions for a destroyed record on purpose -- that is how a
+# deletion stays auditable. For a row carrying somebody's personal data that is
+# the wrong default: `object_changes` holds the old values verbatim, so a
+# deleted account would leave its email and username behind in an append-only
+# table that no erasure path reaches.
+#
+# Include this where the versioned columns are personal data. Everything else
+# keeps paper_trail's behaviour, because a deleted ship or manufacturer is not
+# somebody's to erase.
+#
+# The trade is deliberate: erasure wins over the audit trail here. Who changed
+# an account and when is lost with the account, which is the correct answer for
+# a deletion request and the wrong one for an investigation. Nothing else on the
+# record survives either.
+module ErasableVersionsConcern
+  extend ActiveSupport::Concern
+
+  included do
+    # `after_destroy` rather than `before`: if the destroy is rolled back, the
+    # versions are still there. Indexed by (item_type, item_id), and deleted
+    # rather than destroyed -- a version has no callbacks worth running and a
+    # user's vehicles go one at a time through the same path.
+    after_destroy :erase_versions
+  end
+
+  private def erase_versions
+    PaperTrail::Version.where(item_type: self.class.name, item_id: id).delete_all
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,16 +75,24 @@
 #  index_users_on_username              (username) UNIQUE
 #
 class User < ApplicationRecord
+  # A version of a user row holds their old email and username verbatim, so it
+  # has to go when the account does.
+  include ErasableVersionsConcern
+
   attr_accessor :update_reason, :update_reason_description, :author_id
 
-  # Only an admin action sets `author_id`, so a loader write files nothing. The
-  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
-  # 4,830 equipment rows a week, and versioning those unconditionally would bury
-  # the handful of real edits the way Fleet's touch versions already do.
+  # Only an admin action sets `author_id`, so a change a user makes to their own
+  # account files nothing -- this records what an admin did to somebody else's.
+  #
+  # `unconfirmed_email` is in the list because devise is `reconfirmable`: an
+  # admin changing a confirmed user's address writes there and leaves `email`
+  # alone until the user confirms, so versioning `email` by itself would record
+  # the change nowhere. `email` still covers an account that was never confirmed,
+  # where devise writes it directly.
   has_paper_trail on: %i[update],
     only: %i[
-      username rsi_handle sale_notify public_hangar public_hangar_loaners
-      public_wishlist hide_owner tester
+      username email unconfirmed_email rsi_handle sale_notify public_hangar
+      public_hangar_loaners public_wishlist hide_owner tester
     ],
     if: ->(record) { record.author_id.present? },
     meta: {

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -40,6 +40,10 @@
 require "csv"
 
 class Vehicle < ApplicationRecord
+  # `name` and `serial` are whatever the owner typed, and a user's vehicles are
+  # destroyed along with the account.
+  include ErasableVersionsConcern
+
   attr_accessor :update_reason, :update_reason_description, :author_id
 
   # Only an admin action sets `author_id`, so a loader write files nothing. The

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -8842,7 +8842,20 @@ components:
       enum:
       - models
       - model_modules
+      - model_module_packages
+      - model_paints
+      - model_positions
+      - model_hardpoints
+      - model_loaners
+      - model_snub_crafts
+      - model_upgrades
+      - cargo_holds
+      - docks
+      - videos
       - components
+      - equipment
+      - commodities
+      - item_prices
       - manufacturers
       - vehicles
       - images
@@ -8861,7 +8874,20 @@ components:
       x-enumNames:
       - MODELS
       - MODEL_MODULES
+      - MODEL_MODULE_PACKAGES
+      - MODEL_PAINTS
+      - MODEL_POSITIONS
+      - MODEL_HARDPOINTS
+      - MODEL_LOANERS
+      - MODEL_SNUB_CRAFTS
+      - MODEL_UPGRADES
+      - CARGO_HOLDS
+      - DOCKS
+      - VIDEOS
       - COMPONENTS
+      - EQUIPMENT
+      - COMMODITIES
+      - ITEM_PRICES
       - MANUFACTURERS
       - VEHICLES
       - IMAGES

--- a/test/models/admin_edit_attribution_test.rb
+++ b/test/models/admin_edit_attribution_test.rb
@@ -69,6 +69,64 @@ class AdminEditAttributionTest < ActiveSupport::TestCase
       PaperTrail::Version.where(item_type: "Component").order(created_at: :desc).first.author_id
   end
 
+  # devise is `reconfirmable`, so an admin retyping a confirmed user's address
+  # writes `unconfirmed_email` and leaves `email` where it was. Versioning
+  # `email` alone would have recorded this nowhere.
+  test "an admin changing a confirmed user's email is recorded" do
+    user = create(:user, email: "before@example.test")
+    user.confirm
+
+    user.author_id = @admin.id
+    user.update!(email: "after@example.test")
+
+    changeset = PaperTrail::Version.where(item_type: "User", item_id: user.id)
+      .order(created_at: :desc).first.changeset
+
+    assert_equal "after@example.test", changeset["unconfirmed_email"].last
+    assert_equal "before@example.test", user.reload.email
+  end
+
+  test "a destroyed user takes its versions with it" do
+    user = create(:user)
+
+    user.author_id = @admin.id
+    user.update!(rsi_handle: "changed_by_admin")
+
+    assert_equal 1, PaperTrail::Version.where(item_type: "User", item_id: user.id).count
+
+    user.destroy!
+
+    assert_empty PaperTrail::Version.where(item_type: "User", item_id: user.id),
+      "an old email would outlive the account it belonged to"
+  end
+
+  test "a destroyed vehicle takes its versions with it" do
+    vehicle = create(:vehicle)
+
+    vehicle.author_id = @admin.id
+    vehicle.update!(serial: "SN-ADMIN-2")
+
+    assert_equal 1, PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id).count
+
+    vehicle.destroy!
+
+    assert_empty PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id)
+  end
+
+  # The catalogue is not somebody's to erase, so it keeps paper_trail's default.
+  test "a destroyed catalogue record keeps its versions" do
+    equipment = create(:equipment)
+
+    equipment.author_id = @admin.id
+    equipment.update!(name: "Renamed by an admin")
+
+    assert_equal 1, PaperTrail::Version.where(item_type: "Equipment", item_id: equipment.id).count
+
+    equipment.destroy!
+
+    assert_equal 1, PaperTrail::Version.where(item_type: "Equipment", item_id: equipment.id).count
+  end
+
   test "every versioned type the feed can carry is authorised and named" do
     feed_types = Admin::Api::V1::VersionsController::FEED_ACCESS_BY_ITEM_TYPE.keys
 

--- a/test/models/admin_user_privileges_test.rb
+++ b/test/models/admin_user_privileges_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AdminUserPrivilegesTest < ActiveSupport::TestCase
+  # The failure this catches is silent: a policy asking for a privilege that is
+  # not in the catalogue cannot be satisfied by any grant, so the section it
+  # guards becomes super-admin-only without anybody deciding that. Fifteen
+  # policies had drifted this way before the list was completed.
+  test "every privilege a policy asks for can actually be granted" do
+    Rails.application.eager_load!
+
+    asking_for_the_ungrantable = admin_policies.each_with_object({}) do |policy, gaps|
+      required = Array(policy.allocate.send(:resource_access)).map(&:to_s)
+      missing = required - AdminUser::AVAILABLE_PRIVILEGES
+
+      gaps[policy.name] = missing if missing.any?
+    end
+
+    assert_empty asking_for_the_ungrantable,
+      "these policies require a privilege absent from AdminUser::RESOURCE_ACCESS, " \
+      "so only a super admin can ever satisfy them: #{asking_for_the_ungrantable}"
+  end
+
+  test "every privilege in the catalogue is asked for by a policy" do
+    Rails.application.eager_load!
+
+    required = admin_policies.flat_map { |policy| Array(policy.allocate.send(:resource_access)).map(&:to_s) }
+
+    # Privileges guarding something other than a BasePolicy resource: the
+    # engines mounted behind the admin, and the maintenance tasks page.
+    #
+    # `admins` is a known inconsistency rather than a clean exception. The
+    # frontend route declares `access: ["admins"]`, so granting it reveals the
+    # section in the nav -- but `Admin::AdminUserPolicy` is not a BasePolicy and
+    # gates on `super_admin?` outright, so every call behind it still 403s.
+    # Granting the privilege therefore shows a page nobody can use. Left as-is:
+    # aligning them widens who can manage admin accounts, which is a decision
+    # rather than a fix.
+    outside_the_policies = %w[maintenance workers pghero admins]
+
+    assert_empty AdminUser::AVAILABLE_PRIVILEGES - required - outside_the_policies,
+      "these privileges can be granted but nothing checks them"
+  end
+
+  test "the catalogue has no duplicates across its groups" do
+    assert_equal AdminUser::AVAILABLE_PRIVILEGES.uniq, AdminUser::AVAILABLE_PRIVILEGES
+  end
+
+  private def admin_policies
+    Admin.constants.filter_map do |name|
+      const = Admin.const_get(name)
+
+      next unless const.is_a?(Class) && const < Admin::BasePolicy
+      # BasePolicy itself raises NotImplementedError rather than naming one.
+      next if const == Admin::BasePolicy
+
+      const
+    end
+  end
+end


### PR DESCRIPTION
Follow-up to #4706 and #4708, addressing the two things their bodies flagged as open decisions. Two independent commits, either can be dropped.

## 1. Fifteen privileges nobody could hold

`Admin::EquipmentPolicy` requires `equipment`, and `equipment` was not in `AdminUser::RESOURCE_ACCESS`. No grant could satisfy it, so the section was **super-admin-only — not by decision, but because the catalogue was never extended alongside the policy**.

I went looking for the three named in #4708 and found fifteen: `equipment`, `commodities`, `model_paints`, and the twelve model sub-resources behind hardpoints, loaners, positions, snub crafts, upgrades, module packages, docks, cargo holds, videos and item prices.

**Nothing is granted by this.** A privilege only applies once it is set on an account, so every admin keeps exactly the access they have today. The difference is that the access can now be given without making somebody a super admin.

`AdminUserPrivilegesTest` fails if a policy drifts out of the list again, or if a privilege is added that nothing checks.

### One case deliberately left alone

`admins` is grantable and the frontend route gates the nav on it — but `Admin::AdminUserPolicy` is not a `BasePolicy` and checks `super_admin?` outright, so granting it reveals a section whose every call returns 403. Aligning those widens who can manage admin accounts, which is a decision rather than a fix. The test records it as a known exception.

## 2. The email, and the erasure gap underneath it

#4708 left a user's email unversioned because a version row is append-only and no erasure path reached it — an old address would outlive the account. That was the right worry and the wrong fix: it also left the one admin action most worth recording unrecorded.

`ErasableVersionsConcern` closes it at the other end. A destroyed record takes its versions with it, so the append-only table stops being somewhere personal data hides. `User` and `Vehicle` include it — a vehicle's name and serial are whatever the owner typed, and a user's vehicles are destroyed with the account. The catalogue does not: a deleted manufacturer is nobody's to erase, and paper_trail keeps a deletion auditable on purpose.

The trade is deliberate and worth disagreeing with if you see it differently: **erasure wins**, so who changed an account and when is lost along with the account. Right for a deletion request, wrong for an investigation.

### A trap this turned up

With erasure in place the email is versioned — and so is `unconfirmed_email`. devise is `reconfirmable`, so an admin retyping a **confirmed** user's address writes `unconfirmed_email` and leaves `email` untouched until the user confirms, and the confirmation itself carries no author.

Versioning `email` alone would have recorded the change **nowhere** while looking like it worked. The test pins the real path: change a confirmed user's email, assert the version captured `unconfirmed_email` and that `email` has not moved.

## Testing

- `AdminUserPrivilegesTest`: every policy privilege is grantable, every grantable privilege is checked, no duplicates across groups
- `AdminEditAttributionTest` extended: a destroyed user and a destroyed vehicle take their versions; a destroyed catalogue record keeps them; the reconfirmable email path
- 561 model, 934 admin API, 1,416 public API integration tests — green
- `lint:ts` clean, admin schema regenerated and lints clean, public schema untouched

🤖