### PR TITLE
fix(stats): let the fleet and hangar charts show they are loading

### DIFF
--- a/app/frontend/frontend/components/Fleets/FleetStats/index.vue
+++ b/app/frontend/frontend/components/Fleets/FleetStats/index.vue
@@ -468,7 +468,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="vehiclesByModelOptions"
             key="vehicles-by-model"
             name="vehicles-by-model"
             :async-status="vehiclesByModelStatus"
@@ -518,7 +517,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByClassificationOptions"
             key="models-by-classification"
             name="models-by-classification"
             :async-status="modelsByClassificationStatus"
@@ -542,7 +540,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByManufacturerOptions"
             key="models-by-manufacturer"
             name="models-by-manufacturer"
             :async-status="modelsByManufacturerStatus"
@@ -568,7 +565,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByProductionStatusOptions"
             key="models-by-production-status"
             name="models-by-production-status"
             :async-status="modelsByProductionStatusStatus"
@@ -592,7 +588,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsBySizeOptions"
             key="models-by-size"
             name="models-by-size"
             :async-status="modelsBySizeStatus"

--- a/app/frontend/frontend/components/Fleets/PublicFleetStats/index.vue
+++ b/app/frontend/frontend/components/Fleets/PublicFleetStats/index.vue
@@ -410,7 +410,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="vehiclesByModelOptions"
             key="vehicles-by-model"
             name="vehicles-by-model"
             :async-status="vehiclesByModelStatus"
@@ -434,7 +433,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByClassificationOptions"
             key="models-by-classification"
             name="models-by-classification"
             :async-status="modelsByClassificationStatus"
@@ -460,7 +458,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByProductionStatusOptions"
             key="models-by-production-status"
             name="models-by-production-status"
             :async-status="modelsByProductionStatusStatus"
@@ -484,7 +481,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByManufacturerOptions"
             key="models-by-manufacturer"
             name="models-by-manufacturer"
             :async-status="modelsByManufacturerStatus"
@@ -510,7 +506,6 @@ const csvMetrics = computed<StatsMetric[]>(() => {
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsBySizeOptions"
             key="models-by-size"
             name="models-by-size"
             :async-status="modelsBySizeStatus"

--- a/app/frontend/frontend/components/Hangar/PublicHangarStats/index.vue
+++ b/app/frontend/frontend/components/Hangar/PublicHangarStats/index.vue
@@ -279,7 +279,6 @@ const csvMetrics = computed<StatsMetric[]>(() => [
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByClassificationOptions"
             key="models-by-classification"
             name="models-by-classification"
             :async-status="modelsByClassificationStatus"
@@ -303,7 +302,6 @@ const csvMetrics = computed<StatsMetric[]>(() => [
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsBySizeOptions"
             key="models-by-size"
             name="models-by-size"
             :async-status="modelsBySizeStatus"
@@ -329,7 +327,6 @@ const csvMetrics = computed<StatsMetric[]>(() => [
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByProductionStatusOptions"
             key="models-by-production-status"
             name="models-by-production-status"
             :async-status="modelsByProductionStatusStatus"
@@ -353,7 +350,6 @@ const csvMetrics = computed<StatsMetric[]>(() => [
         </PanelHeading>
         <PanelBody>
           <Chart
-            v-if="modelsByManufacturerOptions"
             key="models-by-manufacturer"
             name="models-by-manufacturer"
             :async-status="modelsByManufacturerStatus"


### PR DESCRIPTION
The charts sit blank while their data loads and then pop into existence. Reported on `/stats`; the same fault is on three more surfaces.

## Why

`Chart` handles its own lifecycle. It derives a `loading` flag from the `asyncStatus` it is handed and renders a `Loader` for it, alongside its own `failed` and `empty` states — and it uses `v-show` rather than `v-if` internally, with a comment saying `setupChart` needs the element to exist.

Guarding the component itself with `v-if="…Options"` threw all of that away. vue-query leaves `data` undefined until the request resolves, so the component never mounted, the panel body stayed empty, and the chart appeared from nothing when the data landed.

The component's own visual test at `Chart/visual.vue` drives exactly these states — its comment says Chart "takes its whole lifecycle through one `asyncStatus` bag of refs, so a demo can drive every state without a query behind it". The call sites made the loading half of that unreachable.

## What changed

Fourteen guards removed:

| | |
|---|---|
| `Fleets/FleetStats` | 5 |
| `Fleets/PublicFleetStats` | 5 |
| `Hangar/PublicHangarStats` | 4 |

Only `v-if`s inside a `<Chart>` element are touched — the sweep is scoped to that so an unrelated guard elsewhere in the same template survives. The two other `…Options` guards in the codebase (`MemberName`, `MemberContactMenu`) are `hasContactOptions` on menus and are untouched.

## Not in this PR

The five remaining on `/stats` belong to #4707, which removes them there. Touching them here would collide in the queue for no benefit.

## Verification

`pnpm lint:fix` and `pnpm lint:ts` both clean. The change is a removal only — 14 deletions, nothing added — and the evidence that it is correct is on the same pages: the charts that never carried the guard are the ones that already show a loader.

🤖