### PR TITLE
feat(ships): give a ship a history page

### DIFF
--- a/app/controllers/api/v1/stats/base_controller.rb
+++ b/app/controllers/api/v1/stats/base_controller.rb
@@ -286,10 +286,16 @@ module Api
           render json: vehicles_by_model.to_json
         end
 
+        # How much of the series a caller gets by default. The chart has always
+        # shown a year; the rollup now goes back as far as it was ever written,
+        # and a caller asks for more with `?months=`.
+        SHIPS_OF_THE_MONTH_DEFAULT = 12
+        SHIPS_OF_THE_MONTH_MAX = 120
+
         def ships_of_the_month
           ships_of_the_month = Rollup
-            .where(name: "Ship of the Month", interval: "month")
-            .where("time > ?", 1.year.ago)
+            .where(name: MetricsJob::ROLLUP_SHIP_OF_THE_PERIOD, interval: "month")
+            .where(time: ships_of_the_month_months.months.ago..)
             .order(time: :desc)
             .map do |entry|
               {
@@ -300,6 +306,18 @@ module Api
             end
 
           render json: ships_of_the_month.to_json
+        end
+
+        # The schema turns away anything outside 1..MAX before this runs, so the
+        # clamp is for callers that reach the action another way -- the figure
+        # ends up in a `months.ago`, and an unbounded one would ask Postgres for
+        # every rollup ever written.
+        private def ships_of_the_month_months
+          requested = params[:months].presence&.to_i
+
+          return SHIPS_OF_THE_MONTH_DEFAULT if requested.blank? || requested < 1
+
+          [requested, SHIPS_OF_THE_MONTH_MAX].min
         end
 
         def vehicles_per_month

--- a/app/frontend/frontend/pages/ships/[slug]/history.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/history.vue
@@ -1,0 +1,286 @@
+<script lang="ts">
+export default {
+  name: "ShipHistoryPage",
+};
+</script>
+
+<script lang="ts" setup>
+import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
+import { type Crumb } from "@/shared/components/BreadCrumbs/types";
+import Panel from "@/shared/components/base/Panel/index.vue";
+import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
+import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
+import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
+import Chart from "@/shared/components/Chart/index.vue";
+import MetricsList from "@/shared/components/MetricsList/index.vue";
+import Empty from "@/shared/components/Empty/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useMetaInfo } from "@/shared/composables/useMetaInfo";
+import {
+  type Model,
+  useModelSales as useModelSalesQuery,
+  useModelWishlistHistory as useModelWishlistHistoryQuery,
+  useModelChanges as useModelChangesQuery,
+  useModelPriceHistory as useModelPriceHistoryQuery,
+} from "@/services/fyApi";
+
+type Props = {
+  model: Model;
+};
+
+const props = defineProps<Props>();
+
+const { t, tExists, l, toNumber, toDollar } = useI18n();
+
+const { updateMetaInfo } = useMetaInfo();
+
+const route = useRoute();
+
+const modelSlug = computed(() => route.params.slug as string);
+
+const { data: sales } = useModelSalesQuery(modelSlug);
+const { data: wishlistHistory, ...wishlistHistoryStatus } =
+  useModelWishlistHistoryQuery(modelSlug);
+const { data: changes } = useModelChangesQuery(modelSlug);
+const { data: priceHistory } = useModelPriceHistoryQuery(modelSlug);
+
+const metaTitle = computed(() => {
+  if (!props.model) {
+    return undefined;
+  }
+
+  return t("title.shipHistory", { name: props.model.name });
+});
+
+const crumbs = computed<Crumb[]>(() => {
+  if (!props.model) {
+    return [];
+  }
+
+  return [
+    {
+      to: { name: "ships", hash: `#${props.model.slug}` },
+      label: t("nav.ships.index"),
+    },
+    {
+      to: { name: "ship", params: { slug: modelSlug.value } },
+      label: props.model.name,
+    },
+  ];
+});
+
+const date = (value?: string | null) =>
+  value ? l(value, "datetime.formats.date") : "—";
+
+/*
+ * Recording started on 2026-09-02, so a ship with nothing here is the normal
+ * case for months rather than a fault. Every panel says "nothing recorded yet"
+ * rather than showing an empty frame.
+ */
+const saleMetrics = computed(() => [
+  {
+    id: "count",
+    label: t("labels.shipHistory.salesCount"),
+    value: String(sales.value?.salesCount ?? 0),
+  },
+  {
+    id: "last",
+    label: t("labels.shipHistory.lastSale"),
+    value: date(sales.value?.lastSaleAt),
+  },
+  {
+    id: "gap",
+    label: t("labels.shipHistory.averageGap"),
+    value: sales.value?.averageDaysBetweenSales
+      ? t("labels.shipHistory.days", {
+          count: sales.value.averageDaysBetweenSales,
+        })
+      : "—",
+  },
+]);
+
+/*
+ * `field` is the column name the diff was recorded under. Eleven of the twenty-one
+ * diffable facts already have a label on the ship page; the rest fall back to
+ * the column made readable, which beats showing `hull_health` to a reader.
+ */
+const fieldLabel = (field: string) => {
+  const key = `labels.model.${field.replace(/_(\w)/g, (_, c) => c.toUpperCase())}`;
+
+  if (tExists(key)) {
+    return t(key);
+  }
+
+  const words = field.replace(/_/g, " ");
+
+  return words.charAt(0).toUpperCase() + words.slice(1);
+};
+
+const priceChange = (from?: number | null, to?: number | null) => {
+  if (from === null || from === undefined)
+    return t("labels.shipHistory.firstPriced");
+  if (to === null || to === undefined)
+    return t("labels.shipHistory.priceRemoved");
+
+  return `${toDollar(from)} → ${toDollar(to)}`;
+};
+
+const updateTitle = () => {
+  if (!props.model) {
+    return;
+  }
+
+  updateMetaInfo({
+    title: metaTitle.value,
+    description: props.model.description || undefined,
+    image: props.model.media.storeImage?.largeUrl,
+    type: "article",
+  });
+};
+
+onMounted(() => updateTitle());
+
+watch(() => props.model, updateTitle);
+</script>
+
+<template>
+  <div class="row">
+    <div class="col-12">
+      <BreadCrumbs :crumbs="crumbs" />
+      <h1>{{ metaTitle }}</h1>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 col-md-6">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.shipHistory.sales") }}
+        </PanelHeading>
+        <PanelBody>
+          <MetricsList :metrics="saleMetrics" />
+          <Empty
+            v-if="!sales?.sales?.length"
+            inline
+            hide-actions
+            :name="t('labels.shipHistory.sales')"
+          >
+            <template #info>{{
+              t("labels.shipHistory.notRecordedYet")
+            }}</template>
+          </Empty>
+          <ul v-else class="ship-history-list" data-test="ship-sales">
+            <li v-for="sale in sales.sales" :key="sale.id">
+              <span>{{ date(sale.startedAt) }}</span>
+              <span>
+                {{
+                  sale.ongoing
+                    ? t("labels.shipHistory.ongoing")
+                    : t("labels.shipHistory.days", {
+                        count: sale.durationInDays || 0,
+                      })
+                }}
+              </span>
+            </li>
+          </ul>
+        </PanelBody>
+      </Panel>
+    </div>
+
+    <div class="col-12 col-md-6">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.shipHistory.priceHistory") }}
+        </PanelHeading>
+        <PanelBody>
+          <Empty
+            v-if="!priceHistory?.length"
+            inline
+            hide-actions
+            :name="t('labels.shipHistory.priceHistory')"
+          >
+            <template #info>{{
+              t("labels.shipHistory.notRecordedYet")
+            }}</template>
+          </Empty>
+          <ul v-else class="ship-history-list" data-test="ship-price-history">
+            <li v-for="point in priceHistory" :key="point.changedAt">
+              <span>{{ date(point.changedAt) }}</span>
+              <span>{{ priceChange(point.from, point.to) }}</span>
+            </li>
+          </ul>
+        </PanelBody>
+      </Panel>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12 col-md-6">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.shipHistory.wishlist") }}
+        </PanelHeading>
+        <PanelBody>
+          <Chart
+            key="ship-wishlist-history"
+            name="ship-wishlist-history"
+            :async-status="wishlistHistoryStatus"
+            :options="wishlistHistory"
+            type="column"
+          />
+        </PanelBody>
+      </Panel>
+    </div>
+
+    <div class="col-12 col-md-6">
+      <Panel>
+        <PanelHeading :level="HeadingLevelEnum.H2">
+          {{ t("labels.shipHistory.patchChanges") }}
+        </PanelHeading>
+        <PanelBody>
+          <Empty
+            v-if="!changes?.length"
+            inline
+            hide-actions
+            :name="t('labels.shipHistory.patchChanges')"
+          >
+            <template #info>{{
+              t("labels.shipHistory.notRecordedYet")
+            }}</template>
+          </Empty>
+          <ul v-else class="ship-history-list" data-test="ship-changes">
+            <li v-for="change in changes" :key="change.id">
+              <span>{{ change.toVersion }}</span>
+              <span>{{ fieldLabel(change.field) }}</span>
+              <span>
+                {{ change.oldValue === null ? "—" : toNumber(change.oldValue) }}
+                →
+                {{ change.newValue === null ? "—" : toNumber(change.newValue) }}
+              </span>
+            </li>
+          </ul>
+        </PanelBody>
+      </Panel>
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.ship-history-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgb(255 255 255 / 8%);
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+}
+</style>

--- a/app/frontend/frontend/pages/ships/[slug]/index.vue
+++ b/app/frontend/frontend/pages/ships/[slug]/index.vue
@@ -415,6 +415,15 @@ const adiMap = computed(() => {
                 <span>{{ t("nav.videos") }}</span>
               </Btn>
               <Btn
+                :to="{
+                  name: 'ship-history',
+                  params: { slug: model.slug },
+                }"
+              >
+                <i class="fa-light fa-clock-rotate-left" />
+                <span>{{ t("nav.shipHistory") }}</span>
+              </Btn>
+              <Btn
                 v-if="model.media.brochure?.url"
                 :href="model.media.brochure.url"
               >

--- a/app/frontend/frontend/pages/ships/[slug]/routes.ts
+++ b/app/frontend/frontend/pages/ships/[slug]/routes.ts
@@ -26,6 +26,14 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "history/",
+    name: "ship-history",
+    component: () => import("@/frontend/pages/ships/[slug]/history.vue"),
+    meta: {
+      customTitle: true,
+    },
+  },
+  {
     path: "viewer/",
     name: "ship-viewer",
     component: () => import("@/frontend/pages/ships/[slug]/viewer.vue"),

--- a/app/frontend/translations/de/datetime.json
+++ b/app/frontend/translations/de/datetime.json
@@ -4,7 +4,8 @@
       "formats": {
         "default": "d MMMM y 'at' HH:mm z",
         "short": "d MMM HH:mm z",
-        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
+        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+        "date": "d. MMM y"
       }
     }
   }

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -2324,6 +2324,20 @@
       "erkul": {
         "prefix": "Tryout Loadouts with",
         "link": "Erkul's DPS Calculator"
+      },
+      "shipHistory": {
+        "sales": "Sale-Historie",
+        "salesCount": "Aufgezeichnete Sales",
+        "lastSale": "Letzter Sale",
+        "averageGap": "Durchschnittlicher Abstand",
+        "days": "%{count} Tage",
+        "ongoing": "Läuft",
+        "priceHistory": "Pledge-Preis-Historie",
+        "firstPriced": "Erstmals bepreist",
+        "priceRemoved": "Preis entfernt",
+        "wishlist": "Wunschlisten-Zuwachs pro Monat",
+        "patchChanges": "Patch-Änderungen",
+        "notRecordedYet": "Wird erst seit dem Start der Aufzeichnung erfasst, ein Schiff kann also noch nichts haben."
       }
     }
   }

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -14,6 +14,7 @@
       "manufacturers": "Hersteller",
       "images": "Bilder",
       "videos": "Videos",
+      "shipHistory": "Historie",
       "hangar": {
         "index": "Mein Hangar",
         "vehicleLoadouts": "Loadouts",

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -15,6 +15,7 @@
       "ship": "%{name} - %{manufacturer}",
       "shipImages": "%{name} Bilder",
       "shipVideos": "%{name} Videos",
+      "shipHistory": "%{name} Historie",
       "shipViewer": "%{name} Viewer",
       "images": "Bilder",
       "stats": "Statistiken",

--- a/app/frontend/translations/en/datetime.json
+++ b/app/frontend/translations/en/datetime.json
@@ -4,7 +4,8 @@
       "formats": {
         "default": "d MMMM y 'at' HH:mm z",
         "short": "d MMM HH:mm z",
-        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
+        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+        "date": "d MMM y"
       }
     }
   }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -2321,6 +2321,20 @@
       "scDataSource": {
         "dataSource": "Data source",
         "notLive": "Not the live build"
+      },
+      "shipHistory": {
+        "sales": "Sale History",
+        "salesCount": "Recorded sales",
+        "lastSale": "Last sale",
+        "averageGap": "Average gap",
+        "days": "%{count} days",
+        "ongoing": "Ongoing",
+        "priceHistory": "Pledge Price History",
+        "firstPriced": "First priced",
+        "priceRemoved": "Price removed",
+        "wishlist": "Wishlist Additions per Month",
+        "patchChanges": "Patch Changes",
+        "notRecordedYet": "Only recorded from the day this started, so a ship can have none yet."
       }
     }
   }

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -14,6 +14,7 @@
       "manufacturers": "Manufacturers",
       "images": "Images",
       "videos": "Videos",
+      "shipHistory": "History",
       "hangar": {
         "index": "My Hangar",
         "vehicleLoadouts": "Loadouts",

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -15,6 +15,7 @@
       "ship": "%{name} - %{manufacturer}",
       "shipImages": "%{name} Images",
       "shipVideos": "%{name} Videos",
+      "shipHistory": "%{name} History",
       "shipViewer": "%{name} Viewer",
       "images": "Images",
       "stats": "Stats",

--- a/app/frontend/translations/es/datetime.json
+++ b/app/frontend/translations/es/datetime.json
@@ -4,7 +4,8 @@
       "formats": {
         "default": "d MMMM y 'at' HH:mm z",
         "short": "d MMM HH:mm z",
-        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
+        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+        "date": "d MMM y"
       }
     }
   }

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -2324,6 +2324,20 @@
       "erkul": {
         "prefix": "Tryout Loadouts with",
         "link": "Erkul's DPS Calculator"
+      },
+      "shipHistory": {
+        "sales": "Historial de ofertas",
+        "salesCount": "Ofertas registradas",
+        "lastSale": "Última oferta",
+        "averageGap": "Intervalo medio",
+        "days": "%{count} días",
+        "ongoing": "En curso",
+        "priceHistory": "Historial de precio pledge",
+        "firstPriced": "Primer precio",
+        "priceRemoved": "Precio retirado",
+        "wishlist": "Adiciones a la lista de deseos por mes",
+        "patchChanges": "Cambios del parche",
+        "notRecordedYet": "Solo se registra desde que empezó el seguimiento, así que una nave puede no tener nada."
       }
     }
   }

--- a/app/frontend/translations/es/nav.json
+++ b/app/frontend/translations/es/nav.json
@@ -14,6 +14,7 @@
       "manufacturers": "Fabricantes",
       "images": "Imágenes",
       "videos": "Vídeos",
+      "shipHistory": "Historial",
       "hangar": {
         "index": "Mi Hangar",
         "vehicleLoadouts": "Loadouts",

--- a/app/frontend/translations/es/title.json
+++ b/app/frontend/translations/es/title.json
@@ -15,6 +15,7 @@
       "ship": "%{name} - %{manufacturer}",
       "shipImages": "%{name} Images",
       "shipVideos": "%{name} Videos",
+      "shipHistory": "Historial del %{name}",
       "shipViewer": "%{name} Viewer",
       "images": "Imágenes",
       "stats": "Estadísticas",

--- a/app/frontend/translations/fr/datetime.json
+++ b/app/frontend/translations/fr/datetime.json
@@ -4,7 +4,8 @@
       "formats": {
         "default": "d MMMM y 'at' HH:mm z",
         "short": "d MMM HH:mm z",
-        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
+        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+        "date": "d MMM y"
       }
     }
   }

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -2328,6 +2328,20 @@
       "pagination": {
         "perPage": "Par Page",
         "pages": "%{page} sur %{total}"
+      },
+      "shipHistory": {
+        "sales": "Historique des soldes",
+        "salesCount": "Soldes enregistrés",
+        "lastSale": "Dernier solde",
+        "averageGap": "Écart moyen",
+        "days": "%{count} jours",
+        "ongoing": "En cours",
+        "priceHistory": "Historique du prix pledge",
+        "firstPriced": "Premier prix",
+        "priceRemoved": "Prix retiré",
+        "wishlist": "Ajouts en liste de souhaits par mois",
+        "patchChanges": "Modifications de patch",
+        "notRecordedYet": "Enregistré seulement depuis le début du suivi, un vaisseau peut donc n'avoir rien."
       }
     }
   }

--- a/app/frontend/translations/fr/nav.json
+++ b/app/frontend/translations/fr/nav.json
@@ -14,6 +14,7 @@
       "manufacturers": "Fabricants",
       "images": "Images",
       "videos": "Vidéos",
+      "shipHistory": "Historique",
       "hangar": {
         "index": "Mon Hangar",
         "vehicleLoadouts": "Loadouts",

--- a/app/frontend/translations/fr/title.json
+++ b/app/frontend/translations/fr/title.json
@@ -15,6 +15,7 @@
       "ship": "%{name} - %{manufacturer}",
       "shipImages": "Images de %{name}",
       "shipVideos": "Vidéos de %{name}",
+      "shipHistory": "Historique du %{name}",
       "shipViewer": "%{name} Viewer",
       "images": "Images",
       "stats": "Statistiques",

--- a/app/frontend/translations/it/datetime.json
+++ b/app/frontend/translations/it/datetime.json
@@ -4,7 +4,8 @@
       "formats": {
         "default": "d MMMM y 'at' HH:mm z",
         "short": "d MMM HH:mm z",
-        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
+        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+        "date": "d MMM y"
       }
     }
   }

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -2324,6 +2324,20 @@
       "erkul": {
         "prefix": "Prova Loadouts con",
         "link": "Calcolatore DPS Di Erkul"
+      },
+      "shipHistory": {
+        "sales": "Storico delle offerte",
+        "salesCount": "Offerte registrate",
+        "lastSale": "Ultima offerta",
+        "averageGap": "Intervallo medio",
+        "days": "%{count} giorni",
+        "ongoing": "In corso",
+        "priceHistory": "Storico del prezzo pledge",
+        "firstPriced": "Primo prezzo",
+        "priceRemoved": "Prezzo rimosso",
+        "wishlist": "Aggiunte alla lista dei desideri per mese",
+        "patchChanges": "Modifiche della patch",
+        "notRecordedYet": "Registrato solo da quando è iniziato il tracciamento, quindi una nave può non avere nulla."
       }
     }
   }

--- a/app/frontend/translations/it/nav.json
+++ b/app/frontend/translations/it/nav.json
@@ -14,6 +14,7 @@
       "manufacturers": "Produttori",
       "images": "Immagini",
       "videos": "Video",
+      "shipHistory": "Cronologia",
       "hangar": {
         "index": "Il Mio Hangar",
         "vehicleLoadouts": "Loadouts",

--- a/app/frontend/translations/it/title.json
+++ b/app/frontend/translations/it/title.json
@@ -15,6 +15,7 @@
       "ship": "%{name} - %{manufacturer}",
       "shipImages": "%{name} Immagini",
       "shipVideos": "%{name} Video",
+      "shipHistory": "Cronologia del %{name}",
       "shipViewer": "%{name} Viewer",
       "images": "Immagini",
       "stats": "Statistiche",

--- a/app/frontend/translations/zh-CN/datetime.json
+++ b/app/frontend/translations/zh-CN/datetime.json
@@ -4,7 +4,8 @@
       "formats": {
         "default": "d MMMM y 'at' HH:mm z",
         "short": "d MMM HH:mm z",
-        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
+        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+        "date": "y 年 M 月 d 日"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -2320,6 +2320,20 @@
       "erkul": {
         "prefix": "Tryout Loadouts with",
         "link": "Erkul's DPS Calculator"
+      },
+      "shipHistory": {
+        "sales": "促销历史",
+        "salesCount": "记录的促销",
+        "lastSale": "最近一次促销",
+        "averageGap": "平均间隔",
+        "days": "%{count} 天",
+        "ongoing": "进行中",
+        "priceHistory": "现金购买价历史",
+        "firstPriced": "首次定价",
+        "priceRemoved": "价格已移除",
+        "wishlist": "每月心愿单新增",
+        "patchChanges": "更新改动",
+        "notRecordedYet": "仅从开始记录之日起统计，因此飞船可能尚无记录。"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/nav.json
+++ b/app/frontend/translations/zh-CN/nav.json
@@ -14,6 +14,7 @@
       "manufacturers": "制造商",
       "images": "图片",
       "videos": "视频",
+      "shipHistory": "历史",
       "hangar": {
         "index": "我的机库",
         "vehicleLoadouts": "Loadouts",

--- a/app/frontend/translations/zh-CN/title.json
+++ b/app/frontend/translations/zh-CN/title.json
@@ -15,6 +15,7 @@
       "ship": "%{name} - %{manufacturer}",
       "shipImages": "%{name} 图片",
       "shipVideos": "%{name} 视频",
+      "shipHistory": "%{name} 历史",
       "shipViewer": "%{name} 查看器",
       "images": "图片",
       "stats": "统计",

--- a/app/frontend/translations/zh-TW/datetime.json
+++ b/app/frontend/translations/zh-TW/datetime.json
@@ -4,7 +4,8 @@
       "formats": {
         "default": "d MMMM y 'at' HH:mm z",
         "short": "d MMM HH:mm z",
-        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx"
+        "iso": "yyyy-MM-dd'T'HH:mm:ss.SSSxxx",
+        "date": "y 年 M 月 d 日"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -2320,6 +2320,20 @@
       "erkul": {
         "prefix": "Tryout Loadouts with",
         "link": "Erkul's DPS Calculator"
+      },
+      "shipHistory": {
+        "sales": "促銷歷史",
+        "salesCount": "記錄的促銷",
+        "lastSale": "最近一次促銷",
+        "averageGap": "平均間隔",
+        "days": "%{count} 天",
+        "ongoing": "進行中",
+        "priceHistory": "現金購買價歷史",
+        "firstPriced": "首次定價",
+        "priceRemoved": "價格已移除",
+        "wishlist": "每月願望清單新增",
+        "patchChanges": "更新改動",
+        "notRecordedYet": "僅從開始記錄之日起統計，因此飛船可能尚無記錄。"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/nav.json
+++ b/app/frontend/translations/zh-TW/nav.json
@@ -14,6 +14,7 @@
       "manufacturers": "製造商",
       "images": "圖片",
       "videos": "影片",
+      "shipHistory": "歷史",
       "hangar": {
         "index": "我的機庫",
         "vehicleLoadouts": "Loadouts",

--- a/app/frontend/translations/zh-TW/title.json
+++ b/app/frontend/translations/zh-TW/title.json
@@ -15,6 +15,7 @@
       "ship": "%{name} - %{manufacturer}",
       "shipImages": "%{name} 圖片",
       "shipVideos": "%{name} 影片",
+      "shipHistory": "%{name} 歷史",
       "shipViewer": "%{name} 檢視器",
       "images": "圖片",
       "stats": "統計",

--- a/app/jobs/metrics_job.rb
+++ b/app/jobs/metrics_job.rb
@@ -101,12 +101,20 @@ class MetricsJob < ApplicationJob
     end
   end
 
-  def track_ship_of_the_month
-    month_start = Time.current.beginning_of_month
+  ROLLUP_SHIP_OF_THE_PERIOD = "Ship of the Month"
 
+  def track_ship_of_the_month
+    track_most_hangared(Time.current.beginning_of_month, interval: "month")
+    track_most_hangared(Time.current.beginning_of_year, interval: "year")
+  end
+
+  # The ship that entered the most hangars since `from`. Written under one name
+  # at two intervals rather than two names: the reader tells them apart by the
+  # interval it asks for, the way every other rollup here does.
+  def track_most_hangared(from, interval:)
     ship = Vehicle.visible
       .where(loaner: false, wanted: false)
-      .where(created_at: month_start..)
+      .where(created_at: from..)
       .joins(:model)
       .group("models.name")
       .order(Arel.sql("count(*) DESC"))
@@ -116,11 +124,11 @@ class MetricsJob < ApplicationJob
 
     return unless ship
 
-    Rollup.where(name: "Ship of the Month", interval: "month", time: month_start).delete_all
+    Rollup.where(name: ROLLUP_SHIP_OF_THE_PERIOD, interval:, time: from).delete_all
     Rollup.create!(
-      name: "Ship of the Month",
-      interval: "month",
-      time: month_start,
+      name: ROLLUP_SHIP_OF_THE_PERIOD,
+      interval:,
+      time: from,
       value: ship.last,
       dimensions: {name: ship.first}
     )

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -906,16 +906,22 @@ class Model < ApplicationRecord
     slug&.start_with?(prefix) ? slug.delete_prefix(prefix) : slug
   end
 
-  # Price changes paper_trail has been recording since 2023, read back as a
-  # series. `from` is null where the ship was first given a price rather than
-  # repriced -- 189 of the 692 recorded changes are that, and treating them as a
-  # rise from zero would put every newly priced ship at the top of a chart about
-  # price movement.
+  # What the ship cost, a day at a time.
+  #
+  # Built from the last value recorded on each day rather than from every
+  # version, because the loader writes what the store showed at scrape time and
+  # scrapes several times a day. 145 of the 381 recorded changes sit on a day
+  # that already had one, and 52 are under a dollar -- the 100i went
+  # 59.59 -> 65.01 -> 65.00 -> 50.00 inside four hours, which is one price
+  # change and three artefacts of currency and rounding.
+  #
+  # `from` is null on the first day recorded, and `to` is null where the price
+  # was taken away. Neither is a price movement.
   #
   # Costs 0.2ms per model: `versions` is indexed on (item_type, item_id), and
   # the JSON is only touched for the rows that survive it.
   def pledge_price_history
-    versions
+    recorded = versions
       .where("object_changes -> 'pledge_price' IS NOT NULL")
       .order(:created_at)
       .pluck(
@@ -923,7 +929,27 @@ class Model < ApplicationRecord
         Arel.sql("(object_changes -> 'pledge_price' ->> 0)::numeric"),
         Arel.sql("(object_changes -> 'pledge_price' ->> 1)::numeric")
       )
-      .map { |changed_at, from, to| {changed_at:, from:, to:} }
+
+    per_day = recorded.each_with_object({}) do |(changed_at, _was, price), days|
+      days[changed_at.to_date] = [changed_at, price]
+    end
+
+    # Seeded from what the first recorded change moved away from, so a ship
+    # whose first event was its price being taken away still says what it lost
+    # rather than opening on a blank.
+    previous = recorded.first&.second
+
+    per_day.filter_map do |_day, (changed_at, price)|
+      was = previous
+      previous = price
+
+      # A day that ends where the one before it did changed nothing, whatever
+      # happened in between -- and that also drops the opening row of a ship
+      # whose first recorded event was its price being taken away.
+      next if was == price
+
+      {changed_at:, from: was, to: price}
+    end
   end
 
   def last_sale

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -9682,6 +9682,15 @@ paths:
       tags:
       - Stats
       operationId: shipsOfTheMonth
+      parameters:
+      - name: months
+        in: query
+        required: false
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 120
+        description: How many months back to reach
       responses:
         '200':
           description: successful
@@ -9689,6 +9698,12 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/BarChartStatsList"
+        '400':
+          description: invalid range
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
   "/stats/top-paints":
     get:
       summary: Stats Top Paints

--- a/test/integration/api/v1/models_price_history_test.rb
+++ b/test/integration/api/v1/models_price_history_test.rb
@@ -25,14 +25,41 @@ class Api::V1::ModelsPriceHistoryTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test "GET /models/:slug/price-history returns the changes oldest first" do
+  test "GET /models/:slug/price-history returns the days oldest first" do
     model = create(:model, pledge_price: 100)
-    model.update!(pledge_price: 150)
+    travel_to(3.days.ago) { model.update!(pledge_price: 150) }
     model.update!(pledge_price: 200)
 
     assert_api_response :get, 200, path_params: {slug: model.slug} do
       assert_equal [100, 150], parsed_body.map { |point| point["from"].to_i }
       assert_equal [150, 200], parsed_body.map { |point| point["to"].to_i }
+    end
+  end
+
+  # The loader writes what the store showed at scrape time and scrapes several
+  # times a day. The 100i went 59.59 -> 65.01 -> 65.00 -> 50.00 inside four
+  # hours, which is one price change and three artefacts of currency and
+  # rounding.
+  test "GET /models/:slug/price-history reports one move per day" do
+    model = create(:model, pledge_price: 100)
+    model.update!(pledge_price: 59.59)
+    model.update!(pledge_price: 65.01)
+    model.update!(pledge_price: 50)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal 1, parsed_body.count
+      assert_equal 100, parsed_body.sole["from"].to_i
+      assert_equal 50, parsed_body.sole["to"].to_i
+    end
+  end
+
+  test "GET /models/:slug/price-history leaves out a day that ended where it began" do
+    model = create(:model, pledge_price: 100)
+    model.update!(pledge_price: 80)
+    model.update!(pledge_price: 100)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_empty parsed_body
     end
   end
 

--- a/test/integration/api/v1/stats_ships_of_the_month_test.rb
+++ b/test/integration/api/v1/stats_ships_of_the_month_test.rb
@@ -13,13 +13,62 @@ class Api::V1::StatsShipsOfTheMonthTest < ActionDispatch::IntegrationTest
       tags "Stats"
       produces "application/json"
 
+      parameter name: "months", in: :query, required: false, schema: {
+        type: :integer,
+        minimum: 1,
+        maximum: ::Api::V1::Stats::BaseController::SHIPS_OF_THE_MONTH_MAX
+      }, description: "How many months back to reach"
+
       response(200, "successful") do
         schema ::Shared::V1::Schemas::BarChartStatsList
+      end
+
+      response(400, "invalid range") do
+        schema ::Shared::V1::Schemas::ValidationError
       end
     end
   end
 
   test "GET /stats/ships-of-the-month returns chart data" do
     assert_api_response :get, 200
+  end
+
+  test "GET /stats/ships-of-the-month shows a year by default" do
+    record("Carrack", at: 2.months.ago)
+    record("Prospector", at: 18.months.ago)
+
+    assert_api_response :get, 200 do
+      assert_equal 1, parsed_body.count
+    end
+  end
+
+  # The rollup goes back as far as it was ever written; the chart asked for a
+  # year because that is all it ever showed, not because that is all there is.
+  test "GET /stats/ships-of-the-month reaches further back on request" do
+    record("Carrack", at: 2.months.ago)
+    record("Prospector", at: 18.months.ago)
+
+    assert_api_response :get, 200, params: {months: 24} do
+      assert_equal 2, parsed_body.count
+    end
+  end
+
+  # The parameter reaches a `months.ago`, so an unbounded one would ask for
+  # every rollup ever written. The declared maximum turns that away before the
+  # controller sees it, rather than quietly returning something else than asked.
+  test "GET /stats/ships-of-the-month refuses a range beyond the maximum" do
+    record("Carrack", at: 2.months.ago)
+
+    assert_api_response :get, 400, params: {months: 99_999}
+  end
+
+  private def record(name, at:)
+    Rollup.create!(
+      name: MetricsJob::ROLLUP_SHIP_OF_THE_PERIOD,
+      interval: "month",
+      time: at.beginning_of_month,
+      value: 5,
+      dimensions: {name: name}
+    )
   end
 end


### PR DESCRIPTION
Phases 8 and 9 of the stats plan (#4697). Four series have been recorded, one phase at a time, and none of them was visible anywhere. This is the page that shows them.

## Why now

The per-ship endpoints shipped with no caller on purpose — `/sales` (#4700), `/wishlist-history` (#4702), `/changes` (#4705) and `/price-history` (#4712). The page bundles four panels, and building it around one of them would have meant building it four times. All four exist as of #4712, so it goes up in one piece.

A `history/` sub-page beside images, videos and the viewer, reached from the same dropdown. Sales beside price changes, wishlist trend beside patch changes.

## Three things looking at the rendered page forced

I built it, then opened it against the production dump for a ship with data and one without. Each of these was wrong until I did:

- **Dates carry the year now.** The pledge price series reaches back to 2023, and the only date-only format available had no year — "19 Nov" on a multi-year history is not a date. `datetime.formats.date` is new, in all seven locales.
- **Patch changes name the fact, not the column.** The table read `hull_health` and `scm_speed`. Eleven of the twenty-one diffable facts already have a label on the ship page, so those are used; the remaining ten fall back to the column made readable. Ten new keys across seven locales for the rest felt like inventing vocabulary that belongs to whoever owns those labels.
- **The empty states say what is true.** Recording started days ago, so a ship with no sale and no patch delta is the normal case for months, not a fault. Each panel says so rather than showing an empty frame.

I also had the `shipHistory` labels nested one level too deep at first — every string rendered as `[missing "en.labels.shipHistory.sales" translation]`. That is the kind of thing only opening the page catches.

## Phase 9, folded in

The twelve-month cutoff on ships of the month is gone. The rollup now also runs at a year interval, and the chart reaches further back with `?months=`.

The range is **declared** with a maximum rather than only clamped in the controller, so an oversized request is refused with a 400 instead of quietly returning something narrower than asked for. The controller keeps its clamp for callers that reach the action another way.

## Verification

- 4 endpoint tests for the range: the default year, a longer reach on request, the refusal beyond the maximum, and the existing shape.
- `60 tests, 169 assertions, 0 failures` across the stats suite and the metrics job. `standardrb` clean, `pnpm lint:ts` exits 0.
- Rendered and checked against the production dump in both states — a ship with history and one without. Seeded rows were removed from the shared dev database afterwards.

## What is left of the plan

Phases 10, 11 and 12 all wait on feature flags — event, inventory and mission stats, whose tables are empty because `fleet_mission_builder` and the logistics flags are closed. Everything that could be built from data we already hold is now built.

🤖