### PR TITLE
feat(mobile): pull down to reload a page's data

### DIFF
--- a/app/frontend/admin/App.vue
+++ b/app/frontend/admin/App.vue
@@ -21,6 +21,7 @@ import { useI18nStore } from "@/shared/stores/i18n";
 import { useAppStore } from "@/admin/stores/app";
 import { storeToRefs } from "pinia";
 import FetchProgressBar from "@/shared/components/FetchProgressBar/index.vue";
+import PullToRefresh from "@/shared/components/PullToRefresh/index.vue";
 import { useMobile } from "@/shared/composables/useMobile";
 import { useMetaInfo } from "@/shared/composables/useMetaInfo";
 import { useI18n } from "@/shared/composables/useI18n";
@@ -32,6 +33,7 @@ import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useImportUpdates } from "@/admin/composables/useImportUpdates";
 import { useAxiosInterceptors } from "@/admin/composables/useAxiosInterceptors";
 import { useMe as useMeQuery } from "@/services/fyAdminApi";
+import { useQueryClient } from "@tanstack/vue-query";
 
 const { t } = useI18n();
 
@@ -65,6 +67,14 @@ const pageKey = (viewRoute: { path: string }) =>
 const appStore = useAppStore();
 
 const mobile = useMobile();
+
+const queryClient = useQueryClient();
+
+const mainInner = ref<HTMLElement | null>(null);
+
+// Same reason as the frontend's: the admin manifest is `standalone` too, so an
+// installed admin has no reload button either. See frontend/App.vue.
+const refreshPage = () => queryClient.invalidateQueries();
 
 const navStore = useNavStore();
 
@@ -184,6 +194,12 @@ const setNoScroll = () => {
     class="app-body"
   >
     <FetchProgressBar />
+    <PullToRefresh
+      v-if="mobile"
+      :target="mainInner"
+      :refresh="refreshPage"
+      :disabled="!navCollapsed || overlayVisible"
+    />
     <BackgroundImage />
 
     <div class="app-content">
@@ -191,7 +207,7 @@ const setNoScroll = () => {
         <AdminNavigation />
       </transition>
       <div class="main-wrapper">
-        <div class="main-inner">
+        <div ref="mainInner" class="main-inner">
           <AppNavigationHeader />
 
           <router-view v-slot="{ Component, route: viewRoute }">

--- a/app/frontend/entrypoints/admin.scss
+++ b/app/frontend/entrypoints/admin.scss
@@ -10,4 +10,5 @@
 @import "@/stylesheets/shared/links";
 @import "@/stylesheets/shared/layout";
 @import "@/stylesheets/shared/scroll";
+@import "@/stylesheets/shared/pull-to-refresh";
 @import "@/stylesheets/admin/base";

--- a/app/frontend/entrypoints/frontend.scss
+++ b/app/frontend/entrypoints/frontend.scss
@@ -10,6 +10,7 @@
 @import "@/stylesheets/shared/links";
 @import "@/stylesheets/shared/layout";
 @import "@/stylesheets/shared/scroll";
+@import "@/stylesheets/shared/pull-to-refresh";
 @import "@/stylesheets/frontend/partials";
 @import "@/stylesheets/frontend/pages";
 @import "@/stylesheets/frontend/base";

--- a/app/frontend/frontend/App.vue
+++ b/app/frontend/frontend/App.vue
@@ -31,7 +31,9 @@ import { useMobile } from "@/shared/composables/useMobile";
 import { useComlink } from "@/shared/composables/useComlink";
 import { useAhoy } from "@/frontend/composables/useAhoy";
 import { useMe as useMeQuery } from "@/services/fyApi";
+import { useQueryClient } from "@tanstack/vue-query";
 import FetchProgressBar from "@/shared/components/FetchProgressBar/index.vue";
+import PullToRefresh from "@/shared/components/PullToRefresh/index.vue";
 import { BtnVariantsEnum } from "@/shared/components/base/Btn/types";
 import { useAxiosInterceptors } from "@/frontend/composables/useAxiosInterceptors";
 import { useCheckStoreVersion } from "@/shared/composables/useCheckStoreVersion";
@@ -88,6 +90,20 @@ watch(
     setNoScroll();
   },
 );
+
+const queryClient = useQueryClient();
+
+const mainInner = ref<HTMLElement | null>(null);
+
+/*
+ * Installed as a PWA there is no reload button, and `refetchOnWindowFocus` is
+ * off, so a page left open keeps showing what it had when it was opened. This
+ * is the way back to fresh data: every mounted query is marked stale and the
+ * active ones refetch, which is a reload of the page's data without paying for
+ * the app shell again -- and it keeps the scroll position and the filters that
+ * a document reload would throw away.
+ */
+const refreshPage = () => queryClient.invalidateQueries();
 
 const router = useRouter();
 
@@ -248,6 +264,12 @@ const setLocale = (locale: string) => {
     class="app-body"
   >
     <FetchProgressBar />
+    <PullToRefresh
+      v-if="mobile"
+      :target="mainInner"
+      :refresh="refreshPage"
+      :disabled="!navCollapsed || overlayVisible"
+    />
     <BackgroundImage />
 
     <div class="app-content">
@@ -256,6 +278,7 @@ const setLocale = (locale: string) => {
       </transition>
       <div class="main-wrapper">
         <div
+          ref="mainInner"
           class="main-inner"
           :class="{
             'main-inner--with-primary-action': route.meta.primaryAction,

--- a/app/frontend/shared/components/PullToRefresh/index.scss
+++ b/app/frontend/shared/components/PullToRefresh/index.scss
@@ -1,0 +1,85 @@
+$pull-to-refresh-size: 38px;
+
+.pull-to-refresh {
+  position: fixed;
+  top: -($pull-to-refresh-size + 8px);
+  left: 50%;
+  /* Above the page but below the top progress bar, which reports the refetch
+     the release starts and should stay the topmost thing on screen. */
+  z-index: 1030;
+  margin-top: env(safe-area-inset-top);
+  pointer-events: none;
+  transform: translate3d(-50%, 0, 0);
+  transition:
+    transform ease 0.25s,
+    opacity ease 0.25s;
+
+  /* While the finger is down the indicator is the finger's position, so it
+     cannot be interpolated towards it. */
+  &--pulling {
+    transition: none;
+  }
+
+  &__indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: $pull-to-refresh-size;
+    height: $pull-to-refresh-size;
+    font-size: 18px;
+    color: #c8c8c8;
+    background-color: rgba(darken($gray-darker, 7%), 0.95);
+    border: 1px solid rgba(30, 34, 38, 0.5);
+    border-radius: 50%;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
+
+    i {
+      transition: transform ease 0.25s;
+    }
+  }
+
+  &--pulling &__indicator i {
+    transition: none;
+  }
+
+  /* The pull has gone far enough that letting go will refetch — the only cue
+     the gesture gets, since it carries no label. */
+  &--armed &__indicator {
+    color: $primary;
+    border-color: rgba($primary, 0.8);
+    box-shadow: 0 2px 12px rgba(darken($primary, 20%), 0.6);
+  }
+
+  &--refreshing &__indicator {
+    color: $primary;
+    border-color: rgba($primary, 0.8);
+
+    i {
+      animation: pull-to-refresh-spin 0.9s linear infinite;
+    }
+  }
+}
+
+@keyframes pull-to-refresh-spin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* No continuous spin, and no travel either: the top progress bar is already
+   reporting the same refetch, so nothing is lost by holding still. */
+@media (prefers-reduced-motion: reduce) {
+  .pull-to-refresh {
+    transition: none;
+
+    &__indicator i,
+    &--refreshing &__indicator i {
+      animation: none;
+      transition: none;
+    }
+  }
+}

--- a/app/frontend/shared/components/PullToRefresh/index.vue
+++ b/app/frontend/shared/components/PullToRefresh/index.vue
@@ -1,0 +1,86 @@
+<script lang="ts">
+export default {
+  name: "PullToRefresh",
+};
+</script>
+
+<script lang="ts" setup>
+import {
+  usePullToRefresh,
+  PULL_LIMIT_PX,
+  PULL_THRESHOLD_PX,
+} from "@/shared/composables/usePullToRefresh";
+import { useI18n } from "@/shared/composables/useI18n";
+
+type Props = {
+  /*
+   * The element the gesture is read on, rather than the document: the modal,
+   * the off-canvas panel and the notification stack are all mounted beside it,
+   * so a pull inside one of those never reaches this listener at all.
+   */
+  target?: HTMLElement | null;
+  refresh: () => Promise<unknown> | unknown;
+  disabled?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  target: null,
+  disabled: false,
+});
+
+const { t } = useI18n();
+
+const target = computed(() => props.target);
+
+const disabled = computed(() => props.disabled);
+
+const { distance, pulling, refreshing, armed } = usePullToRefresh({
+  target,
+  refresh: () => props.refresh(),
+  disabled,
+});
+
+const style = computed(() => ({
+  transform: `translate3d(-50%, ${distance.value}px, 0)`,
+  opacity: String(Math.min(distance.value / PULL_THRESHOLD_PX, 1)),
+}));
+
+// Handed over to the spin animation the moment the pull is done, so the icon
+// does not jump back to its resting angle first.
+const iconStyle = computed(() => {
+  if (refreshing.value) {
+    return undefined;
+  }
+
+  // Half a turn over the whole pull, not more: the glyph repeats itself every
+  // 180deg, so a longer sweep would pass through its own resting shape on the
+  // way and read as the pull having snapped back.
+  return {
+    transform: `rotate(${(distance.value / PULL_LIMIT_PX) * 180}deg)`,
+  };
+});
+</script>
+
+<template>
+  <div
+    class="pull-to-refresh"
+    :class="{
+      'pull-to-refresh--pulling': pulling,
+      'pull-to-refresh--armed': armed,
+      'pull-to-refresh--refreshing': refreshing,
+    }"
+    :style="style"
+    data-test="pull-to-refresh"
+  >
+    <span class="pull-to-refresh__indicator" aria-hidden="true">
+      <i class="fa-duotone fa-rotate" :style="iconStyle" />
+    </span>
+    <span class="sr-only" role="status">
+      {{ refreshing ? t("labels.refreshing") : "" }}
+    </span>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/shared/composables/usePullToRefresh.spec.ts
+++ b/app/frontend/shared/composables/usePullToRefresh.spec.ts
@@ -1,0 +1,293 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, h, ref, type Ref } from "vue";
+import {
+  usePullToRefresh,
+  PULL_LIMIT_PX,
+  PULL_THRESHOLD_PX,
+} from "./usePullToRefresh";
+import { MINIMUM_WAIT_MS } from "./useMinimumDuration";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// The pull is damped, so the finger covers twice what the indicator does.
+const fingerTravelFor = (indicatorTravel: number) => indicatorTravel * 2;
+
+/*
+ * jsdom ships no TouchEvent, and the composable only ever reads `touches`,
+ * `target` and `cancelable` off the event - so the event carries just those.
+ */
+const touch = (type: string, clientY?: number) => {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+
+  if (clientY !== undefined) {
+    Object.defineProperty(event, "touches", { value: [{ clientY }] });
+  } else {
+    Object.defineProperty(event, "touches", { value: [] });
+  }
+
+  return event;
+};
+
+type RenderOptions = {
+  refresh?: () => Promise<unknown> | unknown;
+  disabled?: Ref<boolean>;
+};
+
+const render = async ({
+  refresh = () => undefined,
+  disabled,
+}: RenderOptions) => {
+  const state = { distance: 0, armed: false, refreshing: false };
+
+  // A component, because the composable hangs its listeners and its clean-up
+  // off the surrounding scope.
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        const root = ref<HTMLElement | null>(null);
+
+        const pull = usePullToRefresh({ target: root, refresh, disabled });
+
+        return () => {
+          state.distance = pull.distance.value;
+          state.armed = pull.armed.value;
+          state.refreshing = pull.refreshing.value;
+
+          return h("div", { ref: root }, [
+            h("div", { class: "content" }),
+            h("canvas"),
+          ]);
+        };
+      },
+    }),
+    { attachTo: document.body },
+  );
+
+  await flushPromises();
+
+  const root = wrapper.element as HTMLElement;
+
+  return {
+    wrapper,
+    state,
+    root,
+    content: root.querySelector(".content") as HTMLElement,
+    canvas: root.querySelector("canvas") as HTMLElement,
+  };
+};
+
+const advance = async (ms: number) => {
+  vi.advanceTimersByTime(ms);
+
+  await flushPromises();
+};
+
+const pull = async (from: HTMLElement, indicatorTravel: number) => {
+  from.dispatchEvent(touch("touchstart", 0));
+  from.dispatchEvent(touch("touchmove", fingerTravelFor(indicatorTravel)));
+
+  await flushPromises();
+};
+
+describe("usePullToRefresh", () => {
+  it("follows the finger at half speed, up to the limit", async () => {
+    const { state, root } = await render({});
+
+    await pull(root, 20);
+
+    expect(state.distance).toBe(20);
+    expect(state.armed).toBe(false);
+
+    root.dispatchEvent(
+      touch("touchmove", fingerTravelFor(PULL_LIMIT_PX + 200)),
+    );
+
+    await flushPromises();
+
+    expect(state.distance).toBe(PULL_LIMIT_PX);
+  });
+
+  it("refreshes when a pull past the threshold is released", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const { state, root } = await render({ refresh });
+
+    await pull(root, PULL_THRESHOLD_PX);
+
+    expect(state.armed).toBe(true);
+
+    root.dispatchEvent(touch("touchend"));
+
+    await flushPromises();
+
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(state.refreshing).toBe(true);
+    // Parked at the threshold rather than where the finger stopped.
+    expect(state.distance).toBe(PULL_THRESHOLD_PX);
+
+    await advance(MINIMUM_WAIT_MS);
+
+    expect(state.refreshing).toBe(false);
+    expect(state.distance).toBe(0);
+  });
+
+  it("holds the indicator up for an answer that arrives too fast to be seen", async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const { state, root } = await render({ refresh });
+
+    await pull(root, PULL_THRESHOLD_PX);
+
+    root.dispatchEvent(touch("touchend"));
+
+    await advance(MINIMUM_WAIT_MS - 100);
+
+    expect(state.refreshing).toBe(true);
+
+    await advance(100);
+
+    expect(state.refreshing).toBe(false);
+  });
+
+  it("stops on a refresh that fails", async () => {
+    const refresh = vi.fn().mockRejectedValue(new Error("nope"));
+    const { state, root } = await render({ refresh });
+
+    await pull(root, PULL_THRESHOLD_PX);
+
+    root.dispatchEvent(touch("touchend"));
+
+    await advance(MINIMUM_WAIT_MS);
+
+    expect(state.refreshing).toBe(false);
+    expect(state.distance).toBe(0);
+  });
+
+  it("does not refresh a pull released short of the threshold", async () => {
+    const refresh = vi.fn();
+    const { state, root } = await render({ refresh });
+
+    await pull(root, PULL_THRESHOLD_PX - 10);
+
+    root.dispatchEvent(touch("touchend"));
+
+    await flushPromises();
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(state.distance).toBe(0);
+  });
+
+  it("hands the gesture back once the finger turns upwards", async () => {
+    const refresh = vi.fn();
+    const { state, root } = await render({ refresh });
+
+    await pull(root, PULL_THRESHOLD_PX);
+
+    root.dispatchEvent(touch("touchmove", -10));
+
+    await flushPromises();
+
+    expect(state.distance).toBe(0);
+
+    // Back past the threshold without a fresh touchstart: the gesture is over.
+    root.dispatchEvent(touch("touchmove", fingerTravelFor(PULL_THRESHOLD_PX)));
+    root.dispatchEvent(touch("touchend"));
+
+    await flushPromises();
+
+    expect(refresh).not.toHaveBeenCalled();
+    expect(state.distance).toBe(0);
+  });
+
+  it("keeps its hands off a pull that belongs to an inner scroller", async () => {
+    const refresh = vi.fn();
+    const { state, content } = await render({ refresh });
+
+    // jsdom has no layout, so the scroll position has to be declared.
+    Object.defineProperty(content, "scrollTop", { value: 40 });
+
+    await pull(content, PULL_THRESHOLD_PX);
+
+    content.dispatchEvent(touch("touchend"));
+
+    await flushPromises();
+
+    expect(state.distance).toBe(0);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("keeps its hands off a canvas, which reads the drag itself", async () => {
+    const refresh = vi.fn();
+    const { state, canvas } = await render({ refresh });
+
+    await pull(canvas, PULL_THRESHOLD_PX);
+
+    canvas.dispatchEvent(touch("touchend"));
+
+    await flushPromises();
+
+    expect(state.distance).toBe(0);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does nothing while a drawer or a modal has the screen", async () => {
+    const refresh = vi.fn();
+    const disabled = ref(true);
+    const { state, root } = await render({ refresh, disabled });
+
+    await pull(root, PULL_THRESHOLD_PX);
+
+    root.dispatchEvent(touch("touchend"));
+
+    await flushPromises();
+
+    expect(state.distance).toBe(0);
+    expect(refresh).not.toHaveBeenCalled();
+
+    disabled.value = false;
+
+    await flushPromises();
+    await pull(root, PULL_THRESHOLD_PX);
+
+    root.dispatchEvent(touch("touchend"));
+
+    await flushPromises();
+
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the page from scrolling under a pull it has taken over", async () => {
+    const { root } = await render({});
+
+    root.dispatchEvent(touch("touchstart", 0));
+
+    const move = touch("touchmove", fingerTravelFor(20));
+    const prevented = vi.spyOn(move, "preventDefault");
+
+    root.dispatchEvent(move);
+
+    await flushPromises();
+
+    expect(prevented).toHaveBeenCalled();
+  });
+
+  it("leaves a downward scroll to the page", async () => {
+    const { root } = await render({});
+
+    root.dispatchEvent(touch("touchstart", 0));
+
+    const move = touch("touchmove", -20);
+    const prevented = vi.spyOn(move, "preventDefault");
+
+    root.dispatchEvent(move);
+
+    await flushPromises();
+
+    expect(prevented).not.toHaveBeenCalled();
+  });
+});

--- a/app/frontend/shared/composables/usePullToRefresh.ts
+++ b/app/frontend/shared/composables/usePullToRefresh.ts
@@ -1,0 +1,218 @@
+import { MINIMUM_WAIT_MS } from "@/shared/composables/useMinimumDuration";
+
+/*
+ * How far the indicator travels before the pull is armed, and where it stops
+ * following the finger. Both are the indicator's travel rather than the
+ * finger's: the pull is damped, so the finger covers twice as much.
+ */
+export const PULL_THRESHOLD_PX = 72;
+export const PULL_LIMIT_PX = 108;
+
+// Undamped, the threshold is crossed before the gesture reads as deliberate,
+// and every downward flick at the top of a list refetches the page.
+const PULL_DAMPING = 0.5;
+
+type UsePullToRefreshOptions = {
+  target: Ref<HTMLElement | null> | ComputedRef<HTMLElement | null>;
+  refresh: () => Promise<unknown> | unknown;
+  disabled?: Ref<boolean> | ComputedRef<boolean>;
+};
+
+export const usePullToRefresh = ({
+  target,
+  refresh,
+  disabled,
+}: UsePullToRefreshOptions) => {
+  const distance = ref(0);
+  const pulling = ref(false);
+  const refreshing = ref(false);
+
+  const armed = computed(() => distance.value >= PULL_THRESHOLD_PX);
+
+  // Negative while iOS rubber-bands the document, which is the middle of the
+  // gesture we are here to read - so anything at or above the top counts.
+  const atTop = () =>
+    (window.scrollY || document.documentElement.scrollTop) <= 0;
+
+  /*
+   * A pull that starts inside something holding its own scroll position belongs
+   * to that scroller, not to the page: a table scrolled halfway down would
+   * otherwise refetch on the way back up. A canvas is excluded outright,
+   * because the 3D views read the drag themselves.
+   */
+  const ownedByContent = (from: EventTarget | null, root: HTMLElement) => {
+    let node = from instanceof Element ? from : null;
+
+    while (node && node !== root) {
+      if (node.tagName === "CANVAS" || node.scrollTop > 0) {
+        return true;
+      }
+
+      node = node.parentElement;
+    }
+
+    return false;
+  };
+
+  let floor: ReturnType<typeof setTimeout> | undefined;
+
+  const clearFloor = () => {
+    if (floor) {
+      clearTimeout(floor);
+      floor = undefined;
+    }
+  };
+
+  const waitOutFloor = () =>
+    new Promise((resolve) => {
+      floor = setTimeout(resolve, MINIMUM_WAIT_MS);
+    });
+
+  let startY = 0;
+  let tracking = false;
+
+  const release = () => {
+    tracking = false;
+    pulling.value = false;
+    distance.value = 0;
+  };
+
+  const onTouchStart = (event: TouchEvent) => {
+    tracking = false;
+
+    if (refreshing.value || disabled?.value) {
+      return;
+    }
+
+    if (event.touches.length !== 1 || !atTop() || !target.value) {
+      return;
+    }
+
+    if (ownedByContent(event.target, target.value)) {
+      return;
+    }
+
+    startY = event.touches[0].clientY;
+    tracking = true;
+  };
+
+  const onTouchMove = (event: TouchEvent) => {
+    if (!tracking) {
+      return;
+    }
+
+    if (event.touches.length !== 1 || !atTop()) {
+      release();
+
+      return;
+    }
+
+    const delta = event.touches[0].clientY - startY;
+
+    // The finger turned back past where it started: this is a scroll after all,
+    // and the page gets the rest of the gesture untouched.
+    if (delta <= 0) {
+      release();
+
+      return;
+    }
+
+    // Nothing may scroll or bounce under a pull we have taken over, or the
+    // content and the indicator travel down together.
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
+    pulling.value = true;
+    distance.value = Math.min(delta * PULL_DAMPING, PULL_LIMIT_PX);
+  };
+
+  // A query that fails reports itself through its own error state; all the
+  // indicator owes it is to stop.
+  const ignoreRefreshError = () => undefined;
+
+  const onTouchEnd = async () => {
+    if (!tracking) {
+      return;
+    }
+
+    tracking = false;
+    pulling.value = false;
+
+    if (!armed.value) {
+      distance.value = 0;
+
+      return;
+    }
+
+    refreshing.value = true;
+
+    // Parked at the threshold rather than wherever the finger stopped: the
+    // spinner has to hold still while it spins.
+    distance.value = PULL_THRESHOLD_PX;
+
+    await Promise.all([
+      Promise.resolve().then(refresh).catch(ignoreRefreshError),
+      waitOutFloor(),
+    ]);
+
+    clearFloor();
+
+    refreshing.value = false;
+    distance.value = 0;
+  };
+
+  const handleTouchEnd = () => {
+    void onTouchEnd();
+  };
+
+  let attached: HTMLElement | null = null;
+
+  const detach = () => {
+    if (!attached) {
+      return;
+    }
+
+    attached.removeEventListener("touchstart", onTouchStart);
+    attached.removeEventListener("touchmove", onTouchMove);
+    attached.removeEventListener("touchend", handleTouchEnd);
+    attached.removeEventListener("touchcancel", release);
+    attached = null;
+  };
+
+  const attach = (element: HTMLElement | null) => {
+    detach();
+
+    if (!element) {
+      return;
+    }
+
+    element.addEventListener("touchstart", onTouchStart, { passive: true });
+    // The one listener that cannot be passive: it is what keeps the page from
+    // scrolling under the pull.
+    element.addEventListener("touchmove", onTouchMove, { passive: false });
+    element.addEventListener("touchend", handleTouchEnd);
+    element.addEventListener("touchcancel", release);
+
+    attached = element;
+  };
+
+  watch(target, attach, { immediate: true });
+
+  // A drawer or a modal opening mid-pull takes the gesture with it.
+  watch(
+    () => disabled?.value,
+    (off) => {
+      if (off && !refreshing.value) {
+        release();
+      }
+    },
+  );
+
+  onScopeDispose(() => {
+    detach();
+    clearFloor();
+  });
+
+  return { distance, pulling, refreshing, armed };
+};

--- a/app/frontend/stylesheets/shared/pull-to-refresh.scss
+++ b/app/frontend/stylesheets/shared/pull-to-refresh.scss
@@ -1,0 +1,17 @@
+// The viewport's own pull-to-refresh, switched off for the apps that replace it.
+//
+// PullToRefresh reads the overscroll at the top of the page itself, and the two
+// gestures are the same drag: left on, Chrome reloads the document while the
+// component refetches its data, and the release does both at once.
+//
+// Only `html` governs the viewport — see scroll.scss, which owns the same
+// property for every inner scroll pane. `contain` rather than `none`, because
+// the elastic bounce is what makes the pull feel like it is being resisted.
+//
+// Imported by the frontend and admin entrypoints only: docs has no PullToRefresh
+// and so must keep the browser's.
+@media (max-width: $desktop-breakpoint) {
+  html {
+    overscroll-behavior-y: contain;
+  }
+}

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -28,6 +28,7 @@
       "expand": "Ausklappen",
       "distance": "Entfernung",
       "anonymous": "Anonym",
+      "refreshing": "Wird aktualisiert...",
       "toggleNavigation": "Navigation umschalten",
       "enableYoutube": "Klicken Sie, um Youtube-Einbettungen zu aktivieren, oder rechtsklicken Sie, um die Video-URL zu kopieren",
       "openInNewWindow": "Im Vollbild öffnen",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -28,6 +28,7 @@
       "expand": "Expand",
       "distance": "Distance",
       "anonymous": "Anonymous",
+      "refreshing": "Refreshing...",
       "toggleNavigation": "Toggle Navigation",
       "enableYoutube": "Click to enable Youtube embeds or right click to copy Video URL",
       "openInNewWindow": "Open in fullscreen",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -28,6 +28,7 @@
       "expand": "Expandir",
       "distance": "Distancia",
       "anonymous": "Anónimo",
+      "refreshing": "Actualizando...",
       "toggleNavigation": "Alternar navegación",
       "enableYoutube": "Haz clic para habilitar videos de YouTube o clic derecho para copiar URL del video",
       "openInNewWindow": "Abrir en pantalla completa",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -28,6 +28,7 @@
       "expand": "Agrandir",
       "distance": "Distance",
       "anonymous": "Anonyme",
+      "refreshing": "Actualisation...",
       "toggleNavigation": "Changer de navigation",
       "enableYoutube": "Cliquez pour activer les liens Youtube ou cliquez avec le bouton droit de la souris pour copier l'URL de la vidéo",
       "openInNewWindow": "Ouvrir en plein écran",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -28,6 +28,7 @@
       "expand": "Espandi",
       "distance": "Distanza",
       "anonymous": "Anonimo",
+      "refreshing": "Aggiornamento...",
       "toggleNavigation": "Attiva/disattiva navigazione",
       "enableYoutube": "Clicca per abilitare Youtube embeds o clicca con il tasto destro per copiare l'URL del video",
       "openInNewWindow": "Apri a schermo intero",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -28,6 +28,7 @@
       "expand": "展开",
       "distance": "距离",
       "anonymous": "匿名",
+      "refreshing": "正在刷新...",
       "toggleNavigation": "切换导航",
       "enableYoutube": "点击启用YouTube嵌入或右键复制视频链接",
       "openInNewWindow": "全屏打开",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -28,6 +28,7 @@
       "expand": "展開",
       "distance": "距離",
       "anonymous": "匿名",
+      "refreshing": "正在重新載入...",
       "toggleNavigation": "切換導航",
       "enableYoutube": "點擊啟用YouTube嵌入或右鍵複製視頻鏈接",
       "openInNewWindow": "全螢幕開啟",


### PR DESCRIPTION
## Was das löst

Installiert als PWA (`display: standalone`) gibt es keinen Reload-Button, und `refetchOnWindowFocus` ist in den QueryClient-Defaults aus. Eine offen gelassene Seite zeigt also weiter, was sie beim Öffnen hatte — ohne Möglichkeit, nach Neuerem zu fragen. Am Seitenanfang nach unten ziehen tut das jetzt.

## Wie

**Refetch statt Dokument-Reload.** Das Loslassen invalidiert jede gemountete Query — der Zug, den `ScDataSourceBar` schon macht, wenn sich der Build unter ihm ändert. Das behält Scroll-Position und Filter, die ein Dokument-Reload wegwirft, und `placeholderData` hält die alte Ansicht stehen, statt auf dem Rückweg durch Skeletons zu blinken.

**Die Listener hängen an `.main-inner`, nicht am Dokument.** Modal, Off-Canvas-Panel und Notification-Stack sind in `App.vue` Geschwister davon, ein Pull darin erreicht sie also nie — das ist der Großteil dessen, was ein Pull-to-Refresh sonst per Sonderfall abfangen müsste. Was übrig bleibt, ist explizit behandelt:

- ein Scroller mit eigener Scroll-Position (eine halb heruntergescrollte Tabelle würde sonst auf dem Rückweg refetchen)
- ein `<canvas>` — Fleetchart, Cargo-Grid und Holo-Viewer lesen den Drag selbst
- ein Finger, der mitten in der Geste nach oben zurückdreht

**`overscroll-behavior-y: contain`** verhindert, dass das eigene Pull-to-Refresh des Browsers parallel feuert — sonst lädt ein Loslassen das Dokument neu *und* refetcht seine Daten. Nur von den Frontend- und Admin-Entrypoints importiert: docs hat kein `PullToRefresh` und muss das des Browsers behalten.

**Gedämpft auf halbe Fingerbewegung** (72px Schwelle, 108px Limit). Ungedämpft ist die Schwelle überschritten, bevor die Geste als absichtlich lesbar ist, und jeder Abwärts-Flick am Listenanfang refetcht die Seite.

Icon ist `fa-duotone fa-rotate`, nicht `fa-arrows-rotate`: im Projekt heißt `arrows-rotate`/`sync` *Sync* (Kalender-Sync, RSI-Hangar, wiederkehrende Zahlung), `rotate` heißt *Neuladen/Retry* (Notification-Actions, Admin-Model-Reload). Der Sweep beim Ziehen ist auf 180° begrenzt, weil sich das Glyph alle 180° wiederholt — mehr lief durch die eigene Ruheform und las sich wie ein Zurückschnappen.

## Verifiziert

- 11 Vitest-Cases für die Composable. jsdom hat kein `TouchEvent`, die Events tragen deshalb nur `touches`/`target`/`cancelable` — genau das, was der Code liest.
- `pnpm lint:ts` exit 0, eslint + prettier clean, knip meldet nichts.
- `bin/vite build --mode=test` exit 0, SCSS kompiliert.

**Nicht verifiziert: die Geste auf echter Hardware.** Die Logik ist unit-getestet, aber wie sich Dämpfung und Schwelle am Daumen anfühlen, will einmal durchgezogen werden.

🤖
