### PR TITLE
fix(cache): rebuild cached payloads when manufacturer artwork changes

### DIFF
--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -80,6 +80,32 @@ class Manufacturer < ApplicationRecord
     ["components", "models"]
   end
 
+  # Every payload that draws a manufacturer's picture -- a ship, a component, a
+  # module, and the hardpoint and loadout trees that nest those several partials
+  # deep -- embeds a URL that lives on this row rather than on theirs. A new logo
+  # or icon moves nothing those fragments are keyed on, so without this they go
+  # on serving the blob that happened to be attached when they were first
+  # rendered.
+  #
+  # One stamp over all the artwork rather than the manufacturer named in each
+  # key: the nested cases reach a manufacturer through a collection, sometimes a
+  # recursive one, where there is no single record a key could name.
+  #
+  # Counting as well as taking the maximum is what makes a purge move it --
+  # removing a logo leaves the newest remaining blob exactly where it was.
+  #
+  # Deliberately coarse: any manufacturer's new artwork invalidates all of them.
+  # `ScData::Loader::BaseLoader#attach_icon` compares checksums before it writes,
+  # so that is a build genuinely reworking an icon or an admin uploading a logo,
+  # not every load.
+  def self.artwork_version
+    Artwork.version ||= begin
+      attachments = ActiveStorage::Attachment.where(record_type: polymorphic_name, name: %w[logo icon])
+
+      [attachments.count, attachments.maximum(:created_at)&.to_f]
+    end
+  end
+
   def self.with_name
     where.not(name: nil)
   end

--- a/app/models/manufacturer/artwork.rb
+++ b/app/models/manufacturer/artwork.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Manufacturer
+  # Where the artwork stamp is held for the request or the job in hand.
+  #
+  # `ActiveSupport::CurrentAttributes` rather than a memo of our own, because
+  # Rails resets it at the end of every unit of work: a list of thirty ships
+  # reads the stamp once, and the value cannot survive into the next request on
+  # the same thread. Same reasoning as ScData::Current.
+  class Artwork < ActiveSupport::CurrentAttributes
+    attribute :version
+  end
+end

--- a/app/views/admin/api/v1/components/_component.jbuilder
+++ b/app/views/admin/api/v1/components/_component.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", component, component.item_prices_cache_key] do
+json.cache! ["v1", component, component.item_prices_cache_key, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/components/base", component:)
 end

--- a/app/views/admin/api/v1/equipment/_equipment.jbuilder
+++ b/app/views/admin/api/v1/equipment/_equipment.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", equipment, equipment.item_prices_cache_key] do
+json.cache! ["v1", equipment, equipment.item_prices_cache_key, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/equipment/base", equipment:)
 end

--- a/app/views/admin/api/v1/hardpoints/_hardpoint.jbuilder
+++ b/app/views/admin/api/v1/hardpoints/_hardpoint.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["admin-v1", hardpoint] do
+json.cache! ["admin-v1", hardpoint, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/hardpoints/base", hardpoint:)
 end

--- a/app/views/admin/api/v1/model_hardpoint_loadouts/_model_hardpoint_loadout.jbuilder
+++ b/app/views/admin/api/v1/model_hardpoint_loadouts/_model_hardpoint_loadout.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model_hardpoint_loadout] do
+json.cache! ["v1", model_hardpoint_loadout, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/model_hardpoint_loadouts/base", model_hardpoint_loadout:)
 end

--- a/app/views/admin/api/v1/model_hardpoints/_model_hardpoint.jbuilder
+++ b/app/views/admin/api/v1/model_hardpoints/_model_hardpoint.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model_hardpoint] do
+json.cache! ["v1", model_hardpoint, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/model_hardpoints/base", model_hardpoint:)
 end

--- a/app/views/admin/api/v1/model_module_packages/_model_module_package.jbuilder
+++ b/app/views/admin/api/v1/model_module_packages/_model_module_package.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model_module_package] do
+json.cache! ["v1", model_module_package, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/model_module_packages/base", model_module_package:)
 end

--- a/app/views/admin/api/v1/model_modules/_model_module.jbuilder
+++ b/app/views/admin/api/v1/model_modules/_model_module.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model_module] do
+json.cache! ["v1", model_module, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/model_modules/base", model_module:)
 end

--- a/app/views/admin/api/v1/model_paints/_model_paint.jbuilder
+++ b/app/views/admin/api/v1/model_paints/_model_paint.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model_paint] do
+json.cache! ["v1", model_paint, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/model_paints/base", model_paint:)
 end

--- a/app/views/admin/api/v1/models/_model.jbuilder
+++ b/app/views/admin/api/v1/models/_model.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model, local_assigns.fetch(:extended, false)] do
+json.cache! ["v1", model, Manufacturer.artwork_version, local_assigns.fetch(:extended, false)] do
   json.partial!("admin/api/v1/models/base", model:, extended: local_assigns.fetch(:extended, false))
 end

--- a/app/views/admin/api/v1/vehicles/_vehicle.jbuilder
+++ b/app/views/admin/api/v1/vehicles/_vehicle.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", vehicle.model, vehicle] do
+json.cache! ["v1", vehicle.model, Manufacturer.artwork_version, vehicle] do
   json.partial!("admin/api/v1/vehicles/base", vehicle:)
 end

--- a/app/views/api/v1/components/_component.jbuilder
+++ b/app/views/api/v1/components/_component.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", component, component.item_prices_cache_key] do
+json.cache! ["v1", component, component.item_prices_cache_key, Manufacturer.artwork_version] do
   json.partial!("api/v1/components/base", component:)
 end

--- a/app/views/api/v1/equipment/_equipment.jbuilder
+++ b/app/views/api/v1/equipment/_equipment.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", equipment, equipment.item_prices_cache_key] do
+json.cache! ["v1", equipment, equipment.item_prices_cache_key, Manufacturer.artwork_version] do
   json.partial!("api/v1/equipment/base", equipment:)
 end

--- a/app/views/api/v1/fleet_vehicles/_vehicle.jbuilder
+++ b/app/views/api/v1/fleet_vehicles/_vehicle.jbuilder
@@ -3,7 +3,7 @@
 # Owner contact links live here rather than in the shared public partial: this
 # list is scoped to fleet members by FleetVehiclePolicy, while the same partial
 # also renders public hangars, where an owner shares a name and nothing more.
-json.cache! ["v1-fleet", vehicle.model, vehicle.user, vehicle] do
+json.cache! ["v1-fleet", vehicle.model, Manufacturer.artwork_version, vehicle.user, vehicle] do
   json.partial!("api/v1/public/vehicles/base", vehicle:)
 
   unless vehicle.user.hide_owner?

--- a/app/views/api/v1/hardpoints/_hardpoint.jbuilder
+++ b/app/views/api/v1/hardpoints/_hardpoint.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", hardpoint, hardpoint.component] do
+json.cache! ["v1", hardpoint, hardpoint.component, Manufacturer.artwork_version] do
   json.partial!("api/v1/hardpoints/base", hardpoint:)
 end

--- a/app/views/api/v1/model_hardpoints/_model_hardpoint.jbuilder
+++ b/app/views/api/v1/model_hardpoints/_model_hardpoint.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", hardpoint] do
+json.cache! ["v1", hardpoint, Manufacturer.artwork_version] do
   json.partial!("api/v1/model_hardpoints/base", hardpoint:)
 end

--- a/app/views/api/v1/model_module_packages/_model_module_package.jbuilder
+++ b/app/views/api/v1/model_module_packages/_model_module_package.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", module_package] do
+json.cache! ["v1", module_package, Manufacturer.artwork_version] do
   json.partial!("api/v1/model_module_packages/base", module_package:)
 end

--- a/app/views/api/v1/model_modules/_model_module.jbuilder
+++ b/app/views/api/v1/model_modules/_model_module.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model_module] do
+json.cache! ["v1", model_module, Manufacturer.artwork_version] do
   json.partial!("api/v1/model_modules/base", model_module:)
 end

--- a/app/views/api/v1/models/_model.jbuilder
+++ b/app/views/api/v1/models/_model.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model, local_assigns.fetch(:extended, false)] do
+json.cache! ["v1", model, Manufacturer.artwork_version, local_assigns.fetch(:extended, false)] do
   json.partial!("api/v1/models/base", model:, extended: local_assigns.fetch(:extended, false))
 end

--- a/app/views/api/v1/models/hardpoints.jbuilder
+++ b/app/views/api/v1/models/hardpoints.jbuilder
@@ -3,4 +3,4 @@
 json.array! @hardpoints,
   partial: "api/v1/hardpoints/base",
   as: :hardpoint,
-  cached: ->(hardpoint) { ["v1", hardpoint, hardpoint.component] }
+  cached: ->(hardpoint) { ["v1", hardpoint, hardpoint.component, Manufacturer.artwork_version] }

--- a/app/views/api/v1/models/modules.jbuilder
+++ b/app/views/api/v1/models/modules.jbuilder
@@ -2,7 +2,7 @@
 
 json.items do
   json.array! @model_modules do |model_module|
-    json.cache! ["v1", model_module] do
+    json.cache! ["v1", model_module, Manufacturer.artwork_version] do
       json.partial!("api/v1/model_modules/base", model_module:)
     end
     json.slot @module_slots[model_module.id]

--- a/app/views/api/v1/public/vehicles/_vehicle.jbuilder
+++ b/app/views/api/v1/public/vehicles/_vehicle.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", vehicle.model, vehicle.user, vehicle] do
+json.cache! ["v1", vehicle.model, Manufacturer.artwork_version, vehicle.user, vehicle] do
   json.partial!("api/v1/public/vehicles/base", vehicle:)
 end

--- a/app/views/api/v1/vehicle_loadouts/_vehicle_loadout.jbuilder
+++ b/app/views/api/v1/vehicle_loadouts/_vehicle_loadout.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", vehicle_loadout] do
+json.cache! ["v1", vehicle_loadout, Manufacturer.artwork_version] do
   json.partial!("api/v1/vehicle_loadouts/base", vehicle_loadout:, extended: local_assigns.fetch(:extended, false))
 end

--- a/app/views/api/v1/vehicles/_vehicle.jbuilder
+++ b/app/views/api/v1/vehicles/_vehicle.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", vehicle.model, vehicle] do
+json.cache! ["v1", vehicle.model, Manufacturer.artwork_version, vehicle] do
   json.partial!("api/v1/vehicles/base", vehicle:)
 end

--- a/test/integration/api/v1/components_test.rb
+++ b/test/integration/api/v1/components_test.rb
@@ -110,4 +110,24 @@ class Api::V1::ComponentsTest < ActionDispatch::IntegrationTest
       assert_includes names, older.name
     end
   end
+
+  # The logo hangs off the manufacturer, so it moves nothing the component's own
+  # cache key names -- see Manufacturer.artwork_version.
+  test "GET /components serves a manufacturer logo replaced after the payload was cached" do
+    manufacturer = create(:manufacturer, :with_logo)
+    component = create(:component, manufacturer:)
+
+    with_fragment_caching do
+      get "/api/v1/components", params: {q: {"nameCont" => component.name}}
+      cached_url = response.parsed_body["items"].first.dig("manufacturer", "logo", "url")
+
+      manufacturer.logo.attach(
+        Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/image.jpg"), "image/jpeg")
+      )
+
+      get "/api/v1/components", params: {q: {"nameCont" => component.name}}
+
+      assert_not_equal cached_url, response.parsed_body["items"].first.dig("manufacturer", "logo", "url")
+    end
+  end
 end

--- a/test/integration/api/v1/equipment_test.rb
+++ b/test/integration/api/v1/equipment_test.rb
@@ -108,4 +108,24 @@ class Api::V1::EquipmentTest < ActionDispatch::IntegrationTest
       assert_equal "2", rifle["size"]
     end
   end
+
+  # The icon hangs off the manufacturer, so it moves nothing the equipment's own
+  # cache key names -- see Manufacturer.artwork_version.
+  test "GET /equipment serves a manufacturer icon replaced after the payload was cached" do
+    manufacturer = create(:manufacturer, :with_icon)
+    create(:equipment, name: "Arclight Sidearm", manufacturer:)
+
+    with_fragment_caching do
+      get "/api/v1/equipment", params: {q: {"nameCont" => "Arclight"}}
+      cached_url = response.parsed_body["items"].first.dig("manufacturer", "icon", "url")
+
+      manufacturer.icon.attach(
+        Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/image.jpg"), "image/jpeg")
+      )
+
+      get "/api/v1/equipment", params: {q: {"nameCont" => "Arclight"}}
+
+      assert_not_equal cached_url, response.parsed_body["items"].first.dig("manufacturer", "icon", "url")
+    end
+  end
 end

--- a/test/integration/api/v1/models_index_test.rb
+++ b/test/integration/api/v1/models_index_test.rb
@@ -70,4 +70,43 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
       assert_equal 2, parsed_body["items"].count
     end
   end
+
+  # The logo and the icon hang off the manufacturer, so neither one moves the
+  # model's own `updated_at` -- the cache key has to name the manufacturer or the
+  # list keeps serving the picture the first request happened to render.
+  test "GET /models serves a manufacturer logo replaced after the payload was cached" do
+    manufacturer = create(:manufacturer, :with_logo)
+    create(:model, manufacturer:)
+
+    with_fragment_caching do
+      get "/api/v1/models"
+      cached_url = response.parsed_body["items"].first.dig("manufacturer", "logo", "url")
+
+      manufacturer.logo.attach(
+        Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/image.jpg"), "image/jpeg")
+      )
+
+      get "/api/v1/models"
+
+      assert_not_equal cached_url, response.parsed_body["items"].first.dig("manufacturer", "logo", "url")
+    end
+  end
+
+  test "GET /models serves a manufacturer icon replaced after the payload was cached" do
+    manufacturer = create(:manufacturer, :with_icon)
+    create(:model, manufacturer:)
+
+    with_fragment_caching do
+      get "/api/v1/models"
+      cached_url = response.parsed_body["items"].first.dig("manufacturer", "icon", "url")
+
+      manufacturer.icon.attach(
+        Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/image.jpg"), "image/jpeg")
+      )
+
+      get "/api/v1/models"
+
+      assert_not_equal cached_url, response.parsed_body["items"].first.dig("manufacturer", "icon", "url")
+    end
+  end
 end

--- a/test/integration/api/v1/models_modules_test.rb
+++ b/test/integration/api/v1/models_modules_test.rb
@@ -49,4 +49,25 @@ class Api::V1::ModelsModulesTest < ActionDispatch::IntegrationTest
   test "GET /models/:slug/modules returns 404 for unknown model" do
     assert_api_response :get, 404, path_params: {slug: "unknown-model"}
   end
+
+  # The logo hangs off the manufacturer, so it moves nothing the module's own
+  # cache key names -- see Manufacturer.artwork_version.
+  test "GET /models/:slug/modules serves a manufacturer logo replaced after the payload was cached" do
+    manufacturer = create(:manufacturer, :with_logo)
+    model = create(:model)
+    create(:module_hardpoint, model:, model_module: create(:model_module, manufacturer:))
+
+    with_fragment_caching do
+      get "/api/v1/models/#{model.slug}/modules"
+      cached_url = response.parsed_body["items"].first.dig("manufacturer", "logo", "url")
+
+      manufacturer.logo.attach(
+        Rack::Test::UploadedFile.new(Rails.root.join("test/fixtures/files/image.jpg"), "image/jpeg")
+      )
+
+      get "/api/v1/models/#{model.slug}/modules"
+
+      assert_not_equal cached_url, response.parsed_body["items"].first.dig("manufacturer", "logo", "url")
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,6 +68,29 @@ def mock_omniauth(provider, uid: "123456", email: "oauth@example.com", nickname:
   )
 end
 
+# Fragment caching is off in test, so a cache-key regression cannot show up in a
+# plain request test. This turns it on around a block with a store of its own, so
+# the second request in the block reads what the first one wrote.
+#
+# `ActionController::API` is listed separately because it is not a subclass of
+# `ActionController::Base` -- every API controller here descends from it, so
+# setting the flag on `Base` alone leaves the JSON endpoints uncached and the
+# block passes whatever the cache keys say.
+CACHING_CONTROLLER_BASES = [ActionController::Base, ActionController::API].freeze
+
+def with_fragment_caching
+  previous_store = Rails.cache
+  previous_flags = CACHING_CONTROLLER_BASES.map(&:perform_caching)
+
+  Rails.cache = ActiveSupport::Cache::MemoryStore.new
+  CACHING_CONTROLLER_BASES.each { |base| base.perform_caching = true }
+
+  yield
+ensure
+  Rails.cache = previous_store
+  CACHING_CONTROLLER_BASES.zip(previous_flags).each { |base, flag| base.perform_caching = flag }
+end
+
 module ActiveSupport
   class TestCase
     parallelize(workers: :number_of_processors)


### PR DESCRIPTION
Changing a manufacturer's logo or icon did not invalidate the cached model payload — the ships list went on serving the old blob URL until the ship itself changed.

## The bug

`logo` and `icon` are ActiveStorage attachments on the **manufacturer** row. Attaching one moves `manufacturers.updated_at` and nothing else. But `models/_base.jbuilder` embeds both picture URLs, and `models/_model.jbuilder` was keyed on `["v1", model, extended]` — so the model fragment never noticed.

It is not only models. Walking the jbuilder partial graph transitively (grep finds direct renderers only, which undercounts badly) turns up **25 cached fragments** that draw a manufacturer picture: components, equipment, modules, model paints, module packages, the vehicle partials in hangar/fleet/public, and the hardpoint and loadout trees that nest components several partials deep.

## The fix

`Manufacturer.artwork_version` — the count and newest `created_at` of the manufacturer `logo`/`icon` attachments, read once per request or job via `ActiveSupport::CurrentAttributes` (same pattern as `ScData::Current`). Counting as well as taking the maximum is what makes a *purge* move it: removing a logo leaves the newest remaining blob exactly where it was.

That one element now appears in all 23 keys that needed it. The remaining 2 are the manufacturer's own fragments, which are keyed on the manufacturer and were already correct.

### Why one stamp rather than naming the manufacturer in each key

Naming `component.manufacturer` works only where the manufacturer is one hop from the cached record. Most of these fragments reach it through a collection, sometimes a recursive one — `hardpoints/_hardpoint` recurses into child hardpoints, `vehicle_loadouts/_vehicle_loadout` reaches components three partials down — where there is no single record a key could name. A first pass did it per-record and could not cover those.

It is coarse by design: any manufacturer's new artwork invalidates all of them. `ScData::Loader::BaseLoader#attach_icon` compares checksums before it writes, so that is a build genuinely reworking an icon or an admin uploading a logo, not every load.

### Why not touch the dependent rows

`Model` has an `updated_at`-filtered endpoint. Touching its rows would list every ship of that manufacturer under `/models/updated` after a picture swap.

## Tests

Fragment caching is off in the test environment, so a cache-key regression cannot show up in a request test at all. `with_fragment_caching` turns it on around a block with a store of its own. It sets the flag on `ActionController::API` as well as `ActionController::Base` — API is not a subclass of Base, and every API controller here descends from API, so setting it on Base alone leaves the JSON endpoints uncached and the test passes without proving anything. That was a real dead end on the way here.

Five tests across `models_index`, `components`, `equipment` and `models_modules`. Negative control: freezing `artwork_version` to a constant fails all five.

Full API + admin integration suite green locally (2379 tests), standardrb clean.

## Not fixed here

`hardpoints/_hardpoint` is keyed on `hardpoint.component` but recurses into child hardpoints whose components are not in the key at all — a child component change was already stale before this PR. Separate bug, left alone.

🤖
