### PR TITLE
Let an admin clear the stuck imports the dashboard counts

### DIFF
--- a/app/api_components/admin/v1/schemas/import_cleanup_result.rb
+++ b/app/api_components/admin/v1/schemas/import_cleanup_result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class ImportCleanupResult
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            count: {type: :integer}
+          },
+          additionalProperties: false,
+          required: %w[count]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/import_bulk_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/import_bulk_input.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class ImportBulkInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              # The rows ticked in the table. Which of them the action has
+              # anything to do to is decided server side.
+              ids: {type: :array, items: {type: :string, format: :uuid}}
+            },
+            additionalProperties: false,
+            required: %w[ids]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/dashboard_controller.rb
+++ b/app/controllers/admin/api/v1/dashboard_controller.rb
@@ -14,11 +14,6 @@ module Admin
       class DashboardController < ::Admin::Api::BaseController
         include TrackingStatsConcern
 
-        # An import that entered `started` and is still there long after any run
-        # would have finished. Not a state of its own: the job died without ever
-        # reaching `fail`, so nothing marked it.
-        STUCK_IMPORT_AFTER = 1.hour
-
         # A failure from last year is history, not a to-do. The dashboard asks
         # what needs attention now; /imports/ holds the rest.
         RECENT_FAILURE_WINDOW = 24.hours
@@ -56,12 +51,7 @@ module Admin
           @dashboard[:failed_imports_count] =
             Import.where(aasm_state: "failed", failed_at: RECENT_FAILURE_WINDOW.ago..).count
 
-          # `started_at` rather than `created_at`: an import can sit queued for a
-          # while before it runs, and that wait is not the job hanging.
-          @dashboard[:stuck_imports_count] =
-            Import.where(aasm_state: "started")
-              .where(started_at: ...STUCK_IMPORT_AFTER.ago)
-              .count
+          @dashboard[:stuck_imports_count] = Import.stuck.count
         end
 
         private def add_rsi_figures

--- a/app/controllers/admin/api/v1/imports_controller.rb
+++ b/app/controllers/admin/api/v1/imports_controller.rb
@@ -4,7 +4,7 @@ module Admin
   module Api
     module V1
       class ImportsController < ::Admin::Api::BaseController
-        before_action :set_import, only: [:show]
+        before_action :set_import, only: %i[show cleanup]
 
         def index
           authorize! with: ::Admin::ImportPolicy
@@ -21,6 +21,42 @@ module Admin
         end
 
         def show
+        end
+
+        # Marking a `started` import failed is the only cleanup there is: the row
+        # is what makes the dashboard say something is running, and the job it
+        # describes is long gone.
+        def cleanup
+          unless @import.started?
+            return render json: {
+              code: "import.not_running",
+              message: I18n.t("messages.admin.imports.not_running")
+            }, status: :unprocessable_entity
+          end
+
+          @import.cleanup!(admin_user: current_user)
+
+          render :show
+        end
+
+        # The same thing for the rows an admin ticked in the table.
+        #
+        # Narrowed to the running ones rather than refused over them: a
+        # selection made minutes ago can hold a run that has since finished, and
+        # one of those must not take the whole batch down. The count that comes
+        # back is what actually changed.
+        #
+        # Per record rather than an `update_all` so each one gets its
+        # `failed_at` and its note.
+        def cleanup_bulk
+          authorize! with: ::Admin::ImportPolicy
+
+          @count = 0
+
+          authorized_scope(Import.where(id: params[:ids], aasm_state: "started")).find_each do |import|
+            import.cleanup!(admin_user: current_user)
+            @count += 1
+          end
         end
 
         private def imports_query_params

--- a/app/frontend/admin/pages/maintenance/imports.vue
+++ b/app/frontend/admin/pages/maintenance/imports.vue
@@ -5,7 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
-import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
 import FilteredList from "@/shared/components/FilteredList/index.vue";
@@ -18,6 +18,7 @@ import { usePagination } from "@/shared/composables/usePagination";
 import { useI18n } from "@/shared/composables/useI18n";
 import {
   useImports,
+  useCleanupBulkImports,
   useReloadModelsMatrix,
   useReloadModelsScData,
   useReloadPaints,
@@ -33,9 +34,13 @@ import FilterForm from "@/admin/components/Imports/FilterForm/index.vue";
 import { useFilters } from "@/shared/composables/useFilters";
 import type { ImportQuery } from "@/services/fyAdminApi";
 import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useQueryClient } from "@tanstack/vue-query";
 
 const { t, l } = useI18n();
 const router = useRouter();
+const queryClient = useQueryClient();
+const { displaySuccess, displayInfo, displayAlert } = useAppNotifications();
 
 const onRowClick = async (record: Import) => {
   await router.push({ name: "import", params: { id: record.id } });
@@ -91,6 +96,43 @@ const isReloadingModules = computed(
 const isReloadingLoaners = computed(
   () => reloadLoanersMutation.isPending.value,
 );
+
+/*
+ * A stuck import is not a state of its own -- the row still says `started`
+ * because the job died before anything could mark it. Nothing but an admin can
+ * tell the difference between that and a run that is simply slow, which is why
+ * the rows to write off are ticked rather than swept.
+ */
+const selected = ref<string[]>([]);
+
+const onSelectedChange = (ids: string[]) => {
+  selected.value = ids;
+};
+
+const cleanupMutation = useCleanupBulkImports();
+
+// The selection is spent once the action lands: the rows it named have moved
+// on, and leaving them ticked only invites a second run over them.
+const cleanupSelected = async () => {
+  try {
+    const { count } = await cleanupMutation.mutateAsync({
+      data: { ids: selected.value },
+    });
+
+    selected.value = [];
+    void queryClient.invalidateQueries({ queryKey: ["imports"] });
+
+    if (count === 0) {
+      displayInfo({ text: t("messages.admin.imports.noneRunning") });
+
+      return;
+    }
+
+    displaySuccess({ text: t("messages.admin.imports.cleanedUp", { count }) });
+  } catch {
+    displayAlert({ text: t("messages.admin.imports.cleanupError") });
+  }
+};
 
 const reloadModels = () => reloadMatrixMutation.mutateAsync();
 const reloadScData = () => reloadScDataMutation.mutateAsync();
@@ -251,8 +293,23 @@ const columns: BaseTableCol<Import>[] = [
         :empty-visible="emptyVisible"
         default-sort="created_at desc"
         row-clickable
+        selectable
+        :selected="selected"
         @row-click="onRowClick"
+        @selected-change="onSelectedChange"
       >
+        <template #selected-actions>
+          <Btn
+            v-tooltip="t('actions.admin.imports.cleanupSelected')"
+            :tone="BtnTonesEnum.DANGER"
+            :loading="cleanupMutation.isPending.value"
+            :confirm="t('messages.confirm.import.cleanupSelected')"
+            :aria-label="t('actions.admin.imports.cleanupSelected')"
+            @click="cleanupSelected"
+          >
+            <i class="fa-duotone fa-hourglass-end" />
+          </Btn>
+        </template>
         <template #col-type="{ record }">
           {{ formatType(record.type) }}
         </template>

--- a/app/frontend/admin/pages/maintenance/imports/[id].vue
+++ b/app/frontend/admin/pages/maintenance/imports/[id].vue
@@ -12,6 +12,7 @@ import AsyncData from "@/shared/components/AsyncData.vue";
 
 import {
   useImport,
+  useCleanupImport,
   type Import,
   ImportStatusEnum,
 } from "@/services/fyAdminApi";
@@ -19,11 +20,14 @@ import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import copyText from "@/shared/utils/CopyText";
 import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import { useQueryClient } from "@tanstack/vue-query";
 
 const route = useRoute();
 
 const { t, l } = useI18n();
-const { displayInfo, displayAlert } = useAppNotifications();
+const { displayInfo, displaySuccess, displayAlert } = useAppNotifications();
+const queryClient = useQueryClient();
 
 const copyPayload = (value: string | null) => {
   if (!value) return;
@@ -36,6 +40,33 @@ const copyPayload = (value: string | null) => {
 const { data: importRecord, ...asyncStatus } = useImport(
   route.params.id as string,
 );
+
+/*
+ * Only offered while the row still reads `started`. Whether that means a job
+ * that died an hour ago or one that is still working is the one thing this page
+ * cannot know, so the decision stays with the admin reading it.
+ */
+const cleanupMutation = useCleanupImport();
+
+const isRunning = computed(
+  () => importRecord.value?.status === ImportStatusEnum.STARTED,
+);
+
+const cleanup = async () => {
+  const id = importRecord.value?.id;
+
+  if (!id) return;
+
+  try {
+    await cleanupMutation.mutateAsync({ id });
+
+    void queryClient.invalidateQueries({ queryKey: ["imports"] });
+
+    displaySuccess({ text: t("messages.admin.imports.cleaned") });
+  } catch {
+    displayAlert({ text: t("messages.admin.imports.cleanupError") });
+  }
+};
 
 const formatType = (type: string): string =>
   type
@@ -142,6 +173,21 @@ const headlineTitle = (record: Import) => formatType(record.type);
         <Heading hero>
           {{ headlineTitle(importRecord) }}
         </Heading>
+
+        <Teleport to="#header-right">
+          <Btn
+            v-if="isRunning"
+            :size="BtnSizesEnum.MD"
+            :loading="cleanupMutation.isPending.value"
+            :confirm="t('messages.confirm.import.cleanup')"
+            :aria-label="t('actions.admin.imports.cleanup')"
+            mobile-icon-only
+            @click="cleanup"
+          >
+            <i class="fa fa-hourglass-end" />
+            {{ t("actions.admin.imports.cleanup") }}
+          </Btn>
+        </Teleport>
 
         <div class="import-detail">
           <div class="import-detail__meta">

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -11,6 +11,10 @@
         },
         "supporterContributions": {
           "syncFromPatreon": "Von Patreon synchronisieren"
+        },
+        "imports": {
+          "cleanup": "Als fehlgeschlagen markieren",
+          "cleanupSelected": "Auswahl als fehlgeschlagen markieren"
         }
       },
       "duplicate": "Duplizieren",

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -470,6 +470,10 @@
         },
         "unlistedModel": {
           "createModel": "Ein Schiff aus %{name} anlegen? Der nächste sc_data-Load ergänzt die Mechanik."
+        },
+        "import": {
+          "cleanup": "Diesen Import als fehlgeschlagen markieren? Nur wenn der Job wirklich weg ist — ein noch laufender Durchlauf bricht am Ende mit einem Fehler ab.",
+          "cleanupSelected": "Die ausgewählten Importe als fehlgeschlagen markieren? Betroffen sind nur die noch laufenden, und ein tatsächlich noch laufender Durchlauf bricht am Ende mit einem Fehler ab."
         }
       },
       "oauthAuthorize": {
@@ -512,6 +516,15 @@
       "admin": {
         "supporterContributions": {
           "patreonSyncStarted": "Patreon-Synchronisierung gestartet. Aktualisiere in einer Minute, um importierte Unterstützer zu sehen."
+        },
+        "imports": {
+          "cleaned": "Import als fehlgeschlagen markiert",
+          "cleanedUp": {
+            "one": "%{count} Import als fehlgeschlagen markiert",
+            "other": "%{count} Importe als fehlgeschlagen markiert"
+          },
+          "noneRunning": "In der Auswahl lief nichts mehr",
+          "cleanupError": "Der Import konnte nicht bereinigt werden"
         }
       },
       "logistics": {

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -11,6 +11,10 @@
         },
         "supporterContributions": {
           "syncFromPatreon": "Sync from Patreon"
+        },
+        "imports": {
+          "cleanup": "Mark as failed",
+          "cleanupSelected": "Mark selected as failed"
         }
       },
       "duplicate": "Duplicate",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -469,6 +469,10 @@
         },
         "unlistedModel": {
           "createModel": "Create a ship from %{name}? The next sc_data load fills in its mechanics."
+        },
+        "import": {
+          "cleanup": "Mark this import as failed? Do this only if the job is really gone — a run that is still working will error out when it finishes.",
+          "cleanupSelected": "Mark the selected imports as failed? Only the ones still running are affected, and a run that is genuinely still working will error out when it finishes."
         }
       },
       "oauthAuthorize": {
@@ -511,6 +515,15 @@
       "admin": {
         "supporterContributions": {
           "patreonSyncStarted": "Patreon sync started. Refresh in a minute to see imported supporters."
+        },
+        "imports": {
+          "cleaned": "Import marked as failed",
+          "cleanedUp": {
+            "one": "%{count} import marked as failed",
+            "other": "%{count} imports marked as failed"
+          },
+          "noneRunning": "Nothing in the selection was still running",
+          "cleanupError": "The import could not be cleaned up"
         }
       },
       "logistics": {

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -11,6 +11,10 @@
         },
         "supporterContributions": {
           "syncFromPatreon": "Sincronizar desde Patreon"
+        },
+        "imports": {
+          "cleanup": "Marcar como fallida",
+          "cleanupSelected": "Marcar la selección como fallida"
         }
       },
       "duplicate": "Duplicar",

--- a/app/frontend/translations/es/messages.json
+++ b/app/frontend/translations/es/messages.json
@@ -470,6 +470,10 @@
         },
         "unlistedModel": {
           "createModel": "¿Crear una nave a partir de %{name}? La próxima carga de sc_data rellenará su mecánica."
+        },
+        "import": {
+          "cleanup": "¿Marcar esta importación como fallida? Hazlo solo si el trabajo ya no existe: una ejecución que siga activa fallará al terminar.",
+          "cleanupSelected": "¿Marcar como fallidas las importaciones seleccionadas? Solo afecta a las que siguen en curso, y una ejecución que siga realmente activa fallará al terminar."
         }
       },
       "oauthAuthorize": {
@@ -512,6 +516,15 @@
       "admin": {
         "supporterContributions": {
           "patreonSyncStarted": "Sincronización con Patreon iniciada. Actualiza en un minuto para ver los patrocinadores importados."
+        },
+        "imports": {
+          "cleaned": "Importación marcada como fallida",
+          "cleanedUp": {
+            "one": "%{count} importación marcada como fallida",
+            "other": "%{count} importaciones marcadas como fallidas"
+          },
+          "noneRunning": "Nada de la selección seguía en curso",
+          "cleanupError": "No se pudo limpiar la importación"
         }
       },
       "logistics": {

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -11,6 +11,10 @@
         },
         "supporterContributions": {
           "syncFromPatreon": "Synchroniser depuis Patreon"
+        },
+        "imports": {
+          "cleanup": "Marquer comme échouée",
+          "cleanupSelected": "Marquer la sélection comme échouée"
         }
       },
       "duplicate": "Dupliquer",

--- a/app/frontend/translations/fr/messages.json
+++ b/app/frontend/translations/fr/messages.json
@@ -470,6 +470,10 @@
         },
         "unlistedModel": {
           "createModel": "Créer un vaisseau à partir de %{name} ? Le prochain chargement sc_data complétera ses caractéristiques."
+        },
+        "import": {
+          "cleanup": "Marquer cet import comme échoué ? À ne faire que si le job a vraiment disparu : une exécution encore active échouera à la fin.",
+          "cleanupSelected": "Marquer les imports sélectionnés comme échoués ? Seuls ceux encore en cours sont concernés, et une exécution réellement encore active échouera à la fin."
         }
       },
       "oauthAuthorize": {
@@ -512,6 +516,15 @@
       "admin": {
         "supporterContributions": {
           "patreonSyncStarted": "Synchronisation Patreon démarrée. Actualisez dans une minute pour voir les soutiens importés."
+        },
+        "imports": {
+          "cleaned": "Import marqué comme échoué",
+          "cleanedUp": {
+            "one": "%{count} import marqué comme échoué",
+            "other": "%{count} imports marqués comme échoués"
+          },
+          "noneRunning": "Rien dans la sélection n'était encore en cours",
+          "cleanupError": "L'import n'a pas pu être nettoyé"
         }
       },
       "logistics": {

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -11,6 +11,10 @@
         },
         "supporterContributions": {
           "syncFromPatreon": "Sincronizza da Patreon"
+        },
+        "imports": {
+          "cleanup": "Segna come fallita",
+          "cleanupSelected": "Segna la selezione come fallita"
         }
       },
       "duplicate": "Duplica",

--- a/app/frontend/translations/it/messages.json
+++ b/app/frontend/translations/it/messages.json
@@ -469,6 +469,10 @@
         },
         "unlistedModel": {
           "createModel": "Creare una nave da %{name}? Il prossimo caricamento sc_data completerà le sue meccaniche."
+        },
+        "import": {
+          "cleanup": "Segnare questa importazione come fallita? Fallo solo se il job è davvero sparito: un'esecuzione ancora attiva darà errore al termine.",
+          "cleanupSelected": "Segnare come fallite le importazioni selezionate? Riguarda solo quelle ancora in corso, e un'esecuzione davvero ancora attiva darà errore al termine."
         }
       },
       "oauthAuthorize": {
@@ -511,6 +515,15 @@
       "admin": {
         "supporterContributions": {
           "patreonSyncStarted": "Sincronizzazione con Patreon avviata. Aggiorna la pagina tra un minuto per vedere i sostenitori importati."
+        },
+        "imports": {
+          "cleaned": "Importazione segnata come fallita",
+          "cleanedUp": {
+            "one": "%{count} importazione segnata come fallita",
+            "other": "%{count} importazioni segnate come fallite"
+          },
+          "noneRunning": "Nella selezione non era più in corso nulla",
+          "cleanupError": "Non è stato possibile ripulire l'importazione"
         }
       },
       "logistics": {

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -11,6 +11,10 @@
         },
         "supporterContributions": {
           "syncFromPatreon": "从 Patreon 同步"
+        },
+        "imports": {
+          "cleanup": "标记为失败",
+          "cleanupSelected": "将所选标记为失败"
         }
       },
       "duplicate": "复制",

--- a/app/frontend/translations/zh-CN/messages.json
+++ b/app/frontend/translations/zh-CN/messages.json
@@ -469,6 +469,10 @@
         },
         "unlistedModel": {
           "createModel": "根据 %{name} 创建飞船？下次 sc_data 载入会补齐其数据。"
+        },
+        "import": {
+          "cleanup": "将此导入标记为失败？仅在任务确实已经消失时才这样做——仍在运行的任务会在结束时报错。",
+          "cleanupSelected": "将所选导入标记为失败？只影响仍在运行的那些，确实仍在运行的任务会在结束时报错。"
         }
       },
       "oauthAuthorize": {
@@ -511,6 +515,15 @@
       "admin": {
         "supporterContributions": {
           "patreonSyncStarted": "Patreon 同步已开始。请稍后刷新以查看导入的支持者。"
+        },
+        "imports": {
+          "cleaned": "导入已标记为失败",
+          "cleanedUp": {
+            "one": "已将 %{count} 个导入标记为失败",
+            "other": "已将 %{count} 个导入标记为失败"
+          },
+          "noneRunning": "所选内容中没有仍在运行的导入",
+          "cleanupError": "无法清理该导入"
         }
       },
       "logistics": {

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -11,6 +11,10 @@
         },
         "supporterContributions": {
           "syncFromPatreon": "從 Patreon 同步"
+        },
+        "imports": {
+          "cleanup": "標記為失敗",
+          "cleanupSelected": "將所選標記為失敗"
         }
       },
       "duplicate": "複製",

--- a/app/frontend/translations/zh-TW/messages.json
+++ b/app/frontend/translations/zh-TW/messages.json
@@ -469,6 +469,10 @@
         },
         "unlistedModel": {
           "createModel": "根據 %{name} 建立飛船？下次 sc_data 載入會補齊其資料。"
+        },
+        "import": {
+          "cleanup": "將此匯入標記為失敗？僅在工作確實已經消失時才這樣做——仍在執行的工作會在結束時報錯。",
+          "cleanupSelected": "將所選匯入標記為失敗？只影響仍在執行的那些，確實仍在執行的工作會在結束時報錯。"
         }
       },
       "oauthAuthorize": {
@@ -511,6 +515,15 @@
       "admin": {
         "supporterContributions": {
           "patreonSyncStarted": "Patreon 同步已開始。請在一分鐘後重新整理以查看匯入的支持者。"
+        },
+        "imports": {
+          "cleaned": "匯入已標記為失敗",
+          "cleanedUp": {
+            "one": "已將 %{count} 個匯入標記為失敗",
+            "other": "已將 %{count} 個匯入標記為失敗"
+          },
+          "noneRunning": "所選內容中沒有仍在執行的匯入",
+          "cleanupError": "無法清理該匯入"
         }
       },
       "logistics": {

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -38,6 +38,23 @@ class Import < ApplicationRecord
 
   validates :type, presence: true
 
+  # An import that entered `started` and is still there long after any run would
+  # have finished. Not a state of its own: the job died without ever reaching
+  # `fail`, so nothing marked it.
+  #
+  # `started_at` rather than `created_at`: an import can sit queued for a while
+  # before it runs, and that wait is not the job hanging.
+  STUCK_AFTER = 1.hour
+
+  scope :stuck, -> { where(aasm_state: "started").where(started_at: ...STUCK_AFTER.ago) }
+
+  # Set while an admin clears a stuck import by hand. Neither half of
+  # `notify_admin` belongs to that: the broadcast raises a red "import failed"
+  # toast on the page the admin is looking at, once per row they just cleared,
+  # and the notification would trade the dashboard's stuck tile for a larger
+  # notifications one.
+  attr_accessor :skip_admin_notice
+
   def self.ransackable_attributes(auth_object = nil)
     [
       "aasm_state", "admin_user_id", "created_at", "failed_at", "finished_at", "id", "id_value",
@@ -83,6 +100,8 @@ class Import < ApplicationRecord
   ].freeze
 
   def notify_admin
+    return if skip_admin_notice
+
     AdminUser.find_each do |admin_user|
       ::ImportsChannel.broadcast_to(admin_user, to_jbuilder_hash)
     end
@@ -92,6 +111,30 @@ class Import < ApplicationRecord
 
   def label
     type.to_s.demodulize.underscore.humanize
+  end
+
+  # Nothing here reaches the job. A Sidekiq process that turns out to be alive
+  # after all carries on working and then raises on its own `finish!`, because
+  # the transition it expects is no longer there -- which is why this is the
+  # admin's call and never a sweeper.
+  def cleanup!(admin_user: nil)
+    self.skip_admin_notice = true
+    self.info = [info.presence, cleanup_note(admin_user)].compact.join(" -- ")
+
+    # Validations belong to the run, not to the record of it: an abandoned
+    # `Imports::HangarImport` whose attached file has since gone is exactly the
+    # kind of row that gets stuck, and it must not be the one row that cannot
+    # be written off.
+    fail_without_validation!
+
+    # That path writes the state column with an `update_all` and nothing else,
+    # and `failed_at` is set by a transition callback that runs after it. Both
+    # the timestamp and the note need a save of their own.
+    save!(validate: false)
+  end
+
+  private def cleanup_note(admin_user)
+    "Marked as failed by #{admin_user&.username || "an admin"}: the job stopped reporting."
   end
 
   # The cable broadcast reaches whoever has the imports page open; this is for

--- a/app/views/admin/api/v1/imports/cleanup_bulk.jbuilder
+++ b/app/views/admin/api/v1/imports/cleanup_bulk.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.count @count

--- a/config/locales/de/messages.yml
+++ b/config/locales/de/messages.yml
@@ -6,6 +6,8 @@ de:
     background_enabled:
       success: "%{resource} als Hintergrund verwendet."
     admin:
+      imports:
+        not_running: Nur ein laufender Import kann bereinigt werden.
       fleet_members:
         invalid_role: Die ausgewählte Rolle gehört nicht zu dieser Flotte.
         cannot_demote_last_admin: Dies ist der letzte Admin der Flotte und kann nicht

--- a/config/locales/en/messages.yml
+++ b/config/locales/en/messages.yml
@@ -6,6 +6,8 @@ en:
     background_enabled:
       success: "%{resource} used for Background."
     admin:
+      imports:
+        not_running: Only a running import can be cleaned up.
       fleet_members:
         invalid_role: The selected role does not belong to this fleet.
         cannot_demote_last_admin: This is the fleet's last admin and cannot be demoted.

--- a/config/locales/es/messages.yml
+++ b/config/locales/es/messages.yml
@@ -6,6 +6,8 @@ es:
     background_enabled:
       success: "%{resource} usado como fondo."
     admin:
+      imports:
+        not_running: Solo se puede limpiar una importación en curso.
       fleet_members:
         invalid_role: El rol seleccionado no pertenece a esta flota.
         cannot_demote_last_admin: Este es el último administrador de la flota y no se

--- a/config/locales/fr/messages.yml
+++ b/config/locales/fr/messages.yml
@@ -6,6 +6,8 @@ fr:
     background_enabled:
       success: "%{resource} utilisé comme fond."
     admin:
+      imports:
+        not_running: Seul un import en cours peut être nettoyé.
       fleet_members:
         invalid_role: Le rôle sélectionné n'appartient pas à cette flotte.
         cannot_demote_last_admin: Il s'agit du dernier administrateur de la flotte

--- a/config/locales/it/messages.yml
+++ b/config/locales/it/messages.yml
@@ -6,6 +6,8 @@ it:
     background_enabled:
       success: "%{resource} usato come sfondo."
     admin:
+      imports:
+        not_running: Solo un'importazione in corso può essere ripulita.
       fleet_members:
         invalid_role: Il ruolo selezionato non appartiene a questa flotta.
         cannot_demote_last_admin: Questo è l'ultimo amministratore della flotta e non

--- a/config/locales/zh-CN/messages.yml
+++ b/config/locales/zh-CN/messages.yml
@@ -6,6 +6,8 @@ zh-CN:
     background_enabled:
       success: "%{resource} 已用作背景。"
     admin:
+      imports:
+        not_running: 只有正在运行的导入才能被清理。
       fleet_members:
         invalid_role: 所选角色不属于该舰队。
         cannot_demote_last_admin: 这是该舰队的最后一名管理员，无法降级。

--- a/config/locales/zh-TW/messages.yml
+++ b/config/locales/zh-TW/messages.yml
@@ -6,6 +6,8 @@ zh-TW:
     background_enabled:
       success: "%{resource} 已用作背景。"
     admin:
+      imports:
+        not_running: 只有正在執行的匯入才能被清理。
       fleet_members:
         invalid_role: 所選角色不屬於該艦隊。
         cannot_demote_last_admin: 這是該艦隊的最後一名管理員，無法降級。

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -173,7 +173,14 @@ v1_admin_api_routes = lambda do
     end
   end
 
-  resources :imports, only: %i[index show]
+  resources :imports, only: %i[index show] do
+    member do
+      put :cleanup
+    end
+    collection do
+      put "cleanup-bulk", to: "imports#cleanup_bulk"
+    end
+  end
 
   resources :funding_goals, path: "funding-goals", only: %i[index show create update destroy]
   resources :supporter_contributions, path: "supporter-contributions", only: %i[index show create update destroy] do

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -2856,6 +2856,40 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/imports/cleanup-bulk":
+    put:
+      summary: Clean up a selection of Imports
+      tags:
+      - Imports
+      operationId: cleanupBulkImports
+      description: Mark the running Imports among a selection as failed
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/ImportBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ImportCleanupResult"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/imports/{id}":
     parameters:
     - name: id
@@ -2877,6 +2911,55 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/Import"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/imports/{id}/cleanup":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      description: id
+      required: true
+    put:
+      summary: Clean up a stuck Import
+      tags:
+      - Imports
+      operationId: cleanupImport
+      description: Mark a running Import as failed, for a job that never reported
+        back
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Import"
+        '422':
+          description: unprocessable entity
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
         '404':
           description: not found
           content:
@@ -12011,6 +12094,27 @@ components:
       - createdAt
       - updatedAt
       title: Import
+    ImportBulkInput:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+      additionalProperties: false
+      required:
+      - ids
+      title: ImportBulkInput
+    ImportCleanupResult:
+      type: object
+      properties:
+        count:
+          type: integer
+      additionalProperties: false
+      required:
+      - count
+      title: ImportCleanupResult
     ImportQuery:
       type: object
       properties:

--- a/test/integration/admin/api/v1/imports_test.rb
+++ b/test/integration/admin/api/v1/imports_test.rb
@@ -59,6 +59,61 @@ class Admin::Api::V1::ImportsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  api_path "/imports/{id}/cleanup" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, description: "id", required: true
+
+    put("Clean up a stuck Import") do
+      operationId "cleanupImport"
+      description "Mark a running Import as failed, for a job that never reported back"
+      tags "Imports"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::Import
+      end
+
+      response(422, "unprocessable entity") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/imports/cleanup-bulk" do
+    put("Clean up a selection of Imports") do
+      operationId "cleanupBulkImports"
+      description "Mark the running Imports among a selection as failed"
+      tags "Imports"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::ImportBulkInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::ImportCleanupResult
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
   setup do
     @user = create(:admin_user, resource_access: [:imports])
   end
@@ -159,5 +214,116 @@ class Admin::Api::V1::ImportsTest < ActionDispatch::IntegrationTest
     sign_in create(:admin_user, resource_access: [])
 
     assert_api_response :get, 403, path_params: {id: import.id}
+  end
+
+  # PUT /imports/{id}/cleanup
+  test "PUT /imports/{id}/cleanup marks a running import as failed" do
+    import = create(:import, aasm_state: "started", started_at: 5.hours.ago)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/imports/{id}/cleanup", path_params: {id: import.id} do
+      assert_equal "failed", parsed_body["status"]
+      assert_includes parsed_body["info"], @user.username
+    end
+
+    assert_predicate import.reload, :failed?
+    assert_not_nil import.failed_at
+  end
+
+  test "PUT /imports/{id}/cleanup keeps the info the run had already reported" do
+    import = create(:import, aasm_state: "started", started_at: 5.hours.ago, info: "142 models read")
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/imports/{id}/cleanup", path_params: {id: import.id}
+
+    assert_includes import.reload.info, "142 models read"
+  end
+
+  test "PUT /imports/{id}/cleanup refuses an import that is not running" do
+    import = create(:import, aasm_state: "finished", finished_at: 1.hour.ago)
+    sign_in @user
+
+    assert_api_response :put, 422, api_path: "/imports/{id}/cleanup", path_params: {id: import.id}
+
+    assert_predicate import.reload, :finished?
+  end
+
+  test "PUT /imports/{id}/cleanup notifies nobody" do
+    import = create(:import, aasm_state: "started", started_at: 5.hours.ago)
+    sign_in @user
+
+    assert_no_difference -> { AdminNotification.count } do
+      assert_api_response :put, 200, api_path: "/imports/{id}/cleanup", path_params: {id: import.id}
+    end
+  end
+
+  test "PUT /imports/{id}/cleanup returns 404 for missing id" do
+    sign_in @user
+
+    assert_api_response :put, 404, api_path: "/imports/{id}/cleanup",
+      path_params: {id: "00000000-0000-0000-0000-000000000000"}
+  end
+
+  test "PUT /imports/{id}/cleanup returns 401 when not signed in" do
+    import = create(:import, aasm_state: "started", started_at: 5.hours.ago)
+
+    assert_api_response :put, 401, api_path: "/imports/{id}/cleanup", path_params: {id: import.id}
+  end
+
+  test "PUT /imports/{id}/cleanup returns 403 for admin without access" do
+    import = create(:import, aasm_state: "started", started_at: 5.hours.ago)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, api_path: "/imports/{id}/cleanup", path_params: {id: import.id}
+  end
+
+  # PUT /imports/cleanup-bulk
+  test "PUT /imports/cleanup-bulk fails the selected imports and counts them" do
+    selected = create_list(:import, 2, aasm_state: "started", started_at: 5.hours.ago)
+    untouched = create(:import, aasm_state: "started", started_at: 5.hours.ago)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/imports/cleanup-bulk",
+      body: {ids: selected.map(&:id)} do
+      assert_equal 2, parsed_body["count"]
+    end
+
+    assert_equal %w[failed failed], selected.map { |import| import.reload.aasm_state }
+    assert_predicate untouched.reload, :started?
+  end
+
+  # A selection made minutes ago can hold a run that has since finished, and one
+  # of those must not take the whole batch down.
+  test "PUT /imports/cleanup-bulk skips a selected import that is no longer running" do
+    running = create(:import, aasm_state: "started", started_at: 5.hours.ago)
+    finished = create(:import, aasm_state: "finished", finished_at: 1.minute.ago)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/imports/cleanup-bulk",
+      body: {ids: [running.id, finished.id]} do
+      assert_equal 1, parsed_body["count"]
+    end
+
+    assert_predicate running.reload, :failed?
+    assert_predicate finished.reload, :finished?
+  end
+
+  test "PUT /imports/cleanup-bulk reports zero when nothing in the selection was running" do
+    finished = create(:import, aasm_state: "finished", finished_at: 1.minute.ago)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/imports/cleanup-bulk", body: {ids: [finished.id]} do
+      assert_equal 0, parsed_body["count"]
+    end
+  end
+
+  test "PUT /imports/cleanup-bulk returns 401 when not signed in" do
+    assert_api_response :put, 401, api_path: "/imports/cleanup-bulk", body: {ids: []}
+  end
+
+  test "PUT /imports/cleanup-bulk returns 403 for admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, api_path: "/imports/cleanup-bulk", body: {ids: []}
   end
 end

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -153,4 +153,58 @@ class ImportTest < ActiveSupport::TestCase
     assert_equal record.id, payload["id"]
     assert_equal "Imports::ModulesImport", payload["type"]
   end
+
+  test "the stuck scope holds only runs that have been going for over an hour" do
+    stuck = create(:import, aasm_state: "started", started_at: 5.hours.ago)
+    create(:import, aasm_state: "started", started_at: 2.minutes.ago)
+    create(:import, aasm_state: "created", started_at: nil)
+    create(:import, aasm_state: "finished", started_at: 5.hours.ago, finished_at: 4.hours.ago)
+
+    assert_equal [stuck.id], Import.stuck.pluck(:id)
+  end
+
+  test "cleanup! records the timestamp and who did it" do
+    admin_user = create(:admin_user)
+    record = create(:import, :modules_import, aasm_state: "started", started_at: 5.hours.ago)
+
+    record.cleanup!(admin_user:)
+    record.reload
+
+    assert_predicate record, :failed?
+    assert_not_nil record.failed_at
+    assert_includes record.info, admin_user.username
+  end
+
+  test "cleanup! keeps whatever the run had already reported" do
+    record = create(:import, :modules_import, aasm_state: "started", started_at: 5.hours.ago,
+      info: "142 models read")
+
+    record.cleanup!
+
+    assert_includes record.reload.info, "142 models read"
+  end
+
+  # A hangar import whose attached file is long gone is exactly the row that
+  # gets stuck, and it must not be the one row that cannot be written off.
+  test "cleanup! clears a record that no longer validates" do
+    record = create(:import, type: "Imports::HangarImport", aasm_state: "started",
+      started_at: 5.hours.ago)
+
+    record.reload.cleanup!
+
+    assert_predicate record.reload, :failed?
+  end
+
+  # The admin is looking at the page that told them about it, and one error
+  # notification per row would trade the dashboard's stuck tile for a larger one.
+  test "cleanup! tells neither the notification center nor the channel" do
+    create(:admin_user, resource_access: [:imports])
+    ImportsChannel.expects(:broadcast_to).never
+
+    record = create(:import, :modules_import, aasm_state: "started", started_at: 5.hours.ago)
+
+    record.cleanup!
+
+    assert_equal 0, AdminNotification.where(notification_type: "import_run").count
+  end
 end


### PR DESCRIPTION
The dashboard has counted stuck imports since the rebuild, with nowhere to go and do anything about them. This adds the doing.

## What a stuck import is

Not a state of its own. A run that entered `started` and never reached `fail` leaves a row saying something is still running long after the job died — nothing marked it, because nothing was left alive to. Cleaning it up means recording that, so the row reads `failed` and keeps whatever the run had already reported, plus a note naming the admin who wrote it off.

## Changes

- `Import.stuck` names the window (1 hour past `started_at`) once, so the dashboard figure and anything acting on it cannot drift apart. The dashboard controller now reads the scope instead of building the same query itself.
- `Import#cleanup!` fires the `fail` transition.
- `PUT /imports/{id}/cleanup` for one row, 422 for anything that is not running. `PUT /imports/cleanup-bulk` for a selection.
- The imports table is selectable, with "Mark selected as failed" in the bulk bar. The detail page carries the same action for a single run.

## Two decisions worth a look

**Ticking rows, not sweeping the threshold.** Whether an hour-old run is dead or merely slow is the one thing neither the page nor the server can know, and a real `ScData::AllImport` can legitimately pass an hour. Marking a live one failed does not kill the job — it carries on and then raises on its own `finish!`, because the transition it expects is gone. So the admin picks the rows. Both confirm dialogs say as much.

The bulk endpoint narrows a selection to its running rows rather than refusing over them: a selection made minutes ago can hold a run that has since finished, and one of those must not take the whole batch down. The count that comes back is what actually changed, so the toast is honest — nothing running in the selection reports that rather than a false success.

**Cleanup stays quiet.** `notify_admin` is suppressed for a hand-cleanup. The broadcast raises a red "import failed" toast on the page the admin is looking at, once per row they just cleared, and one notification per row would trade the dashboard's stuck tile for a larger notifications one.

## A gotcha, in case it bites elsewhere

`cleanup!` skips validations, because an abandoned `Imports::HangarImport` whose attached file has since gone is exactly the row that gets stuck, and it must not be the one row that cannot be cleared. AASM's `<event>_without_validation!` writes the state column with `unscoped.update_all` and nothing else, and `timestamps: true` sets `failed_at` from an `after_all_transitions` callback that runs *after* that write — so both the timestamp and the note need a save of their own. Plain `fail!` never shows this, because it goes through `save`.

## Testing

42 tests (13 model, 23 imports integration, 6 dashboard), all green. `standardrb`, `pnpm lint:fix` and `pnpm lint:ts` clean. Schema and Orval clients regenerated; the schema diff is additions only.

🤖
