### PR TITLE
fix(auth): stop remember-me invalidating itself across devices

### DIFF
--- a/app/frontend/admin/composables/useAxiosInterceptors.ts
+++ b/app/frontend/admin/composables/useAxiosInterceptors.ts
@@ -17,7 +17,7 @@ export const useAxiosInterceptors = () => {
     (response) => {
       return response;
     },
-    async (error) => {
+    (error) => {
       const sessionStore = useSessionStore();
 
       if (
@@ -25,7 +25,11 @@ export const useAxiosInterceptors = () => {
         error.response.status === 401 &&
         sessionStore.isAuthenticated
       ) {
-        await sessionStore.logout();
+        // Only drop the local state. Calling logout() here would send
+        // DELETE /sessions, which authenticates via the remember-me cookie before
+        // signing out -- so a single stray 401 would consume that cookie and take
+        // remember-me with it.
+        sessionStore.clearSession();
       }
 
       return Promise.reject(error as Error);

--- a/app/frontend/admin/stores/session.ts
+++ b/app/frontend/admin/stores/session.ts
@@ -48,9 +48,12 @@ export const useSessionStore = defineStore("session", {
       this.authenticated = true;
       this.currentUser = user;
     },
-    async logout() {
+    clearSession() {
       this.authenticated = false;
       this.currentUser = undefined;
+    },
+    async logout() {
+      this.clearSession();
 
       await destroySession().catch(() => {});
     },

--- a/app/frontend/frontend/composables/useAxiosInterceptors.spec.ts
+++ b/app/frontend/frontend/composables/useAxiosInterceptors.spec.ts
@@ -1,0 +1,70 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const destroySession = vi.fn(() => Promise.resolve());
+
+vi.mock("@/services/fyApi", () => ({
+  destroySession: () => destroySession(),
+  me: vi.fn(),
+}));
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({ currentLocale: () => "en" }),
+}));
+
+import { useAxiosInterceptors } from "./useAxiosInterceptors";
+import { useSessionStore } from "@/frontend/stores/session";
+import { AXIOS_INSTANCE } from "@/services/axiosClient";
+
+const respondWith = (status: number) => {
+  AXIOS_INSTANCE.defaults.adapter = () =>
+    Promise.reject({ response: { status } });
+};
+
+const signedIn = () => {
+  const sessionStore = useSessionStore();
+  sessionStore.login({ id: "user-1", username: "torlek" } as never);
+
+  return sessionStore;
+};
+
+describe("useAxiosInterceptors", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    destroySession.mockClear();
+    AXIOS_INSTANCE.interceptors.request.clear();
+    AXIOS_INSTANCE.interceptors.response.clear();
+    useAxiosInterceptors();
+  });
+
+  it("drops the local session on a 401 without signing out on the server", async () => {
+    const sessionStore = signedIn();
+    respondWith(401);
+
+    await expect(AXIOS_INSTANCE.get("/models")).rejects.toBeDefined();
+
+    expect(sessionStore.isAuthenticated).toBe(false);
+    expect(sessionStore.currentUser).toBeUndefined();
+    // Signing out here would spend the remember-me cookie: DELETE /sessions
+    // authenticates with it and then deletes it.
+    expect(destroySession).not.toHaveBeenCalled();
+  });
+
+  it("leaves the session alone for other errors", async () => {
+    const sessionStore = signedIn();
+    respondWith(500);
+
+    await expect(AXIOS_INSTANCE.get("/models")).rejects.toBeDefined();
+
+    expect(sessionStore.isAuthenticated).toBe(true);
+  });
+
+  it("still signs out on the server when the user asks to log out", async () => {
+    const sessionStore = signedIn();
+
+    await sessionStore.logout();
+
+    expect(sessionStore.isAuthenticated).toBe(false);
+    expect(destroySession).toHaveBeenCalledOnce();
+  });
+});

--- a/app/frontend/frontend/composables/useAxiosInterceptors.ts
+++ b/app/frontend/frontend/composables/useAxiosInterceptors.ts
@@ -17,7 +17,7 @@ export const useAxiosInterceptors = () => {
     (response) => {
       return response;
     },
-    async (error) => {
+    (error) => {
       const sessionStore = useSessionStore();
 
       if (
@@ -25,7 +25,11 @@ export const useAxiosInterceptors = () => {
         error.response.status === 401 &&
         sessionStore.isAuthenticated
       ) {
-        await sessionStore.logout();
+        // Only drop the local state. Calling logout() here would send
+        // DELETE /sessions, which authenticates via the remember-me cookie before
+        // signing out -- so a single stray 401 would consume that cookie and take
+        // remember-me with it.
+        sessionStore.clearSession();
       }
 
       return Promise.reject(error);

--- a/app/frontend/frontend/stores/session.ts
+++ b/app/frontend/frontend/stores/session.ts
@@ -47,11 +47,14 @@ export const useSessionStore = defineStore("session", {
       this.authenticated = true;
       this.currentUser = user;
     },
-    async logout() {
+    clearSession() {
       const hangarStore = useHangarStore();
       hangarStore.ships = [];
 
       this.$reset();
+    },
+    async logout() {
+      this.clearSession();
 
       await destroySession().catch(() => {});
     },

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -139,6 +139,13 @@ Devise.setup do |config|
   # If true, extends the user's remember period when remembered via cookie.
   config.extend_remember_period = true
 
+  # Devise defaults this to true, which nulls `remember_created_at` on sign out.
+  # That column backs every remember cookie the account has, so a sign out in one
+  # browser silently deauthorizes all the others -- they stay signed in only until
+  # their session hits `timeout_in`, then drop to the login screen. Signing out is
+  # per device here; the cookie for the device doing it is deleted either way.
+  config.expire_all_remember_me_on_sign_out = false
+
   # Options to be passed to the created cookie. For instance, you can set
   # :secure => true in order to force SSL only cookies.
   # Strip port from domain — cookie domains must not include ports

--- a/test/integration/api/v1/sessions_test.rb
+++ b/test/integration/api/v1/sessions_test.rb
@@ -66,4 +66,82 @@ class Api::V1::SessionsTest < ActionDispatch::IntegrationTest
   test "DELETE /sessions returns 401 when not signed in" do
     assert_api_response :delete, 401
   end
+
+  # ==> remember me
+  REMEMBER_COOKIE = "#{Rails.configuration.cookie_prefix}_USER_STORED_#{Rails.env.upcase}"
+
+  test "a remembered browser stays signed in once its session is gone" do
+    browser = sign_in_remembered(create(:user, password: "enterprise"))
+
+    browser.cookies.delete(Rails.configuration.cookie_prefix)
+    browser.get "/api/v1/users/me"
+
+    assert_equal 200, browser.response.status
+  end
+
+  test "DELETE /sessions leaves other remembered browsers signed in" do
+    user = create(:user, password: "enterprise")
+    browser = sign_in_remembered(user)
+
+    elsewhere = open_session
+    sign_in_json(elsewhere, user, remember: false)
+    elsewhere.delete "/api/v1/sessions"
+    assert_equal 200, elsewhere.response.status
+
+    browser.cookies.delete(Rails.configuration.cookie_prefix)
+    browser.get "/api/v1/users/me"
+
+    assert_equal 200, browser.response.status
+  end
+
+  test "signing in on one device does not unremember the other" do
+    user = create(:user, password: "enterprise")
+    phone = sign_in_remembered(user)
+
+    # the axios interceptor signs out on any 401, then the user logs back in
+    computer = sign_in_remembered(user)
+    computer.delete "/api/v1/sessions"
+    sign_in_json(computer, user, remember: true)
+
+    phone.cookies.delete(Rails.configuration.cookie_prefix)
+    phone.get "/api/v1/users/me"
+
+    assert_equal 200, phone.response.status
+  end
+
+  test "DELETE /sessions drops the remember cookie of the browser doing it" do
+    browser = sign_in_remembered(create(:user, password: "enterprise"))
+
+    browser.delete "/api/v1/sessions"
+
+    assert_predicate remember_cookie(browser).to_s, :empty?
+  end
+
+  private def sign_in_remembered(user)
+    browser = open_session
+    sign_in_json(browser, user, remember: true)
+
+    value = remember_cookie(browser)
+    assert value.present?, "expected a remember-me cookie"
+    browser.cookies[REMEMBER_COOKIE] = value
+
+    browser
+  end
+
+  private def sign_in_json(browser, user, remember:)
+    browser.post "/api/v1/sessions",
+      params: {login: user.username, password: "enterprise", rememberMe: remember}.to_json,
+      headers: {"CONTENT_TYPE" => "application/json"}
+
+    assert_equal 200, browser.response.status
+  end
+
+  # The remember cookie is scoped to the app's configured domain, which is not the
+  # host integration tests run on, so the test jar throws it away. Read it off the
+  # response instead, and put it back by hand where a real browser would have kept it.
+  private def remember_cookie(browser)
+    Array(browser.response.headers["Set-Cookie"])
+      .find { |cookie| cookie.start_with?(REMEMBER_COOKIE) }
+      &.then { |cookie| CGI.unescape(cookie[/#{REMEMBER_COOKIE}=([^;]*)/o, 1].to_s) }
+  end
 end


### PR DESCRIPTION
Fixes the "I get logged out several times a day even though remember me is ticked, and I never sign out" report.

## What was happening

`remember_created_at` is a single column on the user row shared by every device, and a remember cookie is only accepted while its `generated_at` is **newer** than that column.

Two defaults combined to make that column move:

1. `expire_all_remember_me_on_sign_out` was left at Devise's default `true`, so any sign out nulls the column — and the next remember-me login sets it forward to `Time.now`.
2. The axios error interceptor called `sessionStore.logout()` on any 401, which sends `DELETE /sessions`. That endpoint authenticates first, and the rememberable strategy answers it — so the request spent the remember-me cookie and then deleted it. A stray 401 became a sign out nobody asked for.

With two devices in regular use this never converges. Whichever device logs in last pushes the column past the other device's cookie timestamp and invalidates it. That device then 401s, auto signs out, nulls the column again — which kills the first device too, since a NULL column compares against `Time.now` and nothing can beat it — logs back in, and the cycle repeats. Once per session timeout, indefinitely.

Reproduced in an integration test. Phone signs in, then the computer takes an automatic sign out and logs back in:

```
expire_all_remember_me_on_sign_out = true
phone remembered.         remember_created_at=22:15:44.908877
computer auto signed out. remember_created_at=
computer logged in again. remember_created_at=22:15:44.990781
PHONE: 401
COMPUTER: 200
```

82ms of drift was enough. Same scenario on this branch:

```
expire_all_remember_me_on_sign_out = false
phone remembered.         remember_created_at=22:15:55.497799
computer auto signed out. remember_created_at=22:15:55.497799
computer logged in again. remember_created_at=22:15:55.497799
PHONE: 200
COMPUTER: 200
```

It only takes one sign out, ever, to enter the loop — which is why it has no apparent cause from the outside. 11% of users active in the last 90 days are currently sitting on `remember_created_at = NULL`.

## Changes

- `config/initializers/devise.rb` — `expire_all_remember_me_on_sign_out = false`. Sign out is per device; the cookie of the browser doing it is still deleted, so a deliberate logout is unchanged.
- Both `useAxiosInterceptors.ts` — a 401 now clears local state via a new `clearSession()` instead of calling `logout()`. Deliberate logout from the navigation and the account page still signs out on the server.

## Testing

- 4 new cases in `test/integration/api/v1/sessions_test.rb` (8 total, green). Both new ones were verified to fail against the old setting — 401 instead of 200.
- New `useAxiosInterceptors.spec.ts`: a 401 clears local state without calling `destroySession`, other statuses leave the session alone, and a deliberate logout still hits the server.

## Notes

- Everyone currently in the NULL state needs one more login per device to mint a fresh cookie. After that the column stops moving.
- A rejected remember cookie is never actually removed from the browser: the delete Devise emits carries no `domain`, so it cannot remove a `Domain=.fleetyards.net` cookie. It stays visible in devtools while being rejected on every request. Left alone here — it self-heals on the next login — but it is why this was hard to see.
- Not addressed: sessions live on a Redis running `--maxmemory-policy allkeys-lru` shared with the Rails cache, and that policy evicts across all databases, so session keys are dropped well before their 2h TTL. That is not what caused the logouts, but it is what kept handing the loop chances to fire. Sidekiq's queues are in the same eviction pool, which is the more serious version of the same problem.

🤖
