### PR TITLE
feat(sc_data): keep the size range and types a port declares

### DIFF
--- a/app/lib/hangar_sync.rb
+++ b/app/lib/hangar_sync.rb
@@ -547,7 +547,8 @@ class HangarSync < HangarImporter
       "Retaliator Bomber" => "Retaliator",
       "Crusader A1 Spirit" => "A1 Spirit",
       "Crusader C1 Spirit" => "C1 Spirit",
-      "Crusader E1 Spirit" => "E1 Spirit"
+      "Crusader E1 Spirit" => "E1 Spirit",
+      "Gladius Dunlevy" => "Dunlevy"
     }
 
     return name if mapping[name.strip].nil?

--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -305,7 +305,7 @@ module ScData
       # rows match it -- two jobs that used to be one recursive method that wrote
       # as it walked, which is why the rules could not be exercised without a
       # database and why the destructive cleanup sat in the middle of them.
-      Slot = Struct.new(:name, :component, :children, :retain_only)
+      Slot = Struct.new(:name, :component, :children, :retain_only, :min_size, :max_size, :types)
 
       private def update_loadout(parent, loadout, cleanup: true)
         # The module-key derivation below only applies to a ship. A module's own
@@ -335,7 +335,16 @@ module ScData
 
         return flatten_hidden(item, component) if component&.hidden?
 
-        [Slot.new(name: item["name"].downcase, component:, children: nested_slots(item))]
+        [
+          Slot.new(
+            name: item["name"].downcase,
+            component:,
+            children: nested_slots(item),
+            min_size: item["min_size"],
+            max_size: item["max_size"],
+            types: item["types"]
+          )
+        ]
       end
 
       # A hidden component is a container the game files ship as an item -- a
@@ -437,17 +446,32 @@ module ScData
         return hardpoint.persisted? ? hardpoint.id : nil if slot.retain_only
 
         update_params = {source: :game_files, component: slot.component}
-
-        if slot.component.present?
-          update_params[:min_size] = slot.component.size
-          update_params[:max_size] = slot.component.size
-        end
+        update_params[:types] = slot.types if slot.types.present?
+        update_params.merge!(slot_sizes(slot))
 
         apply(hardpoint, update_params)
 
         persist_loadout(hardpoint, slot.children) if slot.children.present?
 
         hardpoint.id
+      end
+
+      # What is installed still sets the size the port is shown as, because the
+      # declared bounds are not trustworthy enough to display -- the files carry
+      # ports declared 0-0 with an S1 door sitting in them. The declaration is
+      # only allowed to say what the installed item cannot: the floor a smaller
+      # item would satisfy, and both bounds when nothing is installed at all.
+      private def slot_sizes(slot)
+        declared_min = slot.min_size.presence&.to_i
+        declared_max = slot.max_size.presence&.to_i
+        installed_size = slot.component&.size.presence&.to_i
+
+        return {} if installed_size.blank? && declared_min.blank? && declared_max.blank?
+        return {min_size: declared_min, max_size: declared_max} if installed_size.blank?
+
+        floor = (declared_min if declared_min.present? && declared_min < installed_size)
+
+        {min_size: floor || installed_size, max_size: installed_size}
       end
 
       private def loadout_name_blacklisted?(name, default_loadout = nil)

--- a/app/lib/sc_data/parser/models_parser.rb
+++ b/app/lib/sc_data/parser/models_parser.rb
@@ -23,7 +23,7 @@ module ScData
             extract_loadout(item)
           end
 
-          loadout = merge_module_ports(values, loadout)
+          loadout = merge_port_defs(values, loadout)
 
           {
             key:,
@@ -73,7 +73,7 @@ module ScData
             extract_loadout(item)
           end
 
-          loadout = merge_module_ports(values, loadout)
+          loadout = merge_port_defs(values, loadout)
 
           insurance = values.dig("StaticEntityClassData", "SEntityInsuranceProperties")
 
@@ -135,7 +135,7 @@ module ScData
             extract_loadout(entry)
           end
 
-          loadout = merge_module_ports(values, loadout)
+          loadout = merge_port_defs(values, loadout)
 
           insurance_params = values.dig("StaticEntityClassData", "SEntityInsuranceProperties", "shipInsuranceParams")
 
@@ -163,7 +163,45 @@ module ScData
         save_items(powersuits, folder: "models")
       end
 
-      private def merge_module_ports(values, loadout)
+      # A port declares what may sit in it -- the item types it accepts and the
+      # size range it takes -- and none of that is derivable from whatever the
+      # default loadout happens to have installed. The Retaliator's ordnance bay
+      # takes an S3-S9 missile, bomb or gun launcher; all the loadout says is
+      # that an S9 torpedo rack is in it today.
+      #
+      # A port that accepts a module is also appended when the loadout leaves it
+      # empty, since an empty module slot is still a slot.
+      private def merge_port_defs(values, loadout)
+        record_port_defs = extract_port_defs(values)
+        port_defs = extract_definition_port_defs(values.dig("Components", "VehicleComponentParams"))
+          .merge(record_port_defs)
+
+        return loadout if port_defs.blank?
+
+        merged = loadout.map do |entry|
+          port_def = port_defs[entry[:name]]
+
+          port_def.present? ? entry.merge(port_def) : entry
+        end
+
+        merged_names = merged.map { |entry| entry[:name] }.to_set
+
+        # Appended from the entity record alone, which is the set that was
+        # appended before reading the definition at all. The definition also
+        # calls the Hornet's configurable centre mount module-capable, and
+        # appending that would hand the Super Hornet a module slot it has never
+        # had -- a change to what the ship offers, not to what a port declares.
+        record_port_defs.each do |name, port_def|
+          next if merged_names.include?(name)
+          next unless port_def[:types].include?("Module")
+
+          merged << {name:, ref: nil, key: nil, **port_def}
+        end
+
+        merged
+      end
+
+      private def extract_port_defs(values)
         port_defs = values.dig(
           "Components",
           "SItemPortContainerComponentParams",
@@ -171,28 +209,84 @@ module ScData
           "SItemPortDef"
         )
 
-        return loadout if port_defs.blank?
+        return {} if port_defs.blank?
 
         port_defs = [port_defs] unless port_defs.is_a?(Array)
-        loadout_names = loadout.map { |entry| entry[:name] }.to_set
 
-        port_defs.each do |port|
+        port_defs.each_with_object({}) do |port, index|
           name = port["Name"]
           next if name.blank?
-          next if loadout_names.include?(name)
 
-          types = port.dig("Types", "SItemPortDefTypes")
-          types = [types] unless types.is_a?(Array)
-          next unless types.compact.any? { |t| t["Type"] == "Module" }
-
-          loadout << {
-            name:,
-            ref: nil,
-            key: nil
+          index[name] ||= {
+            min_size: port["MinSize"],
+            max_size: port["MaxSize"],
+            types: extract_port_def_types(port)
           }
         end
+      end
 
-        loadout
+      private def extract_port_def_types(port)
+        types = port.dig("Types", "SItemPortDefTypes")
+        types = [types] unless types.is_a?(Array)
+
+        types.compact.filter_map { |type| type["Type"] }
+      end
+
+      # A ship's item ports are declared in its vehicle implementation XML. The
+      # entity record's own `Ports` block only adds a handful of late ones (life
+      # support, the relay), so both are needed: the Eclipse's torpedo rack port
+      # -- the one that takes a bomb rack just as happily -- exists only here.
+      private def extract_definition_port_defs(component_params)
+        definition_file_path = component_params&.dig("vehicleDefinition")
+
+        return {} if definition_file_path.blank?
+
+        definition_file = "#{definition_path}/#{definition_file_path}"
+
+        return {} unless File.exist?(definition_file)
+
+        definition_data = extract_modification_definition(
+          Hash.from_xml(File.read(definition_file)),
+          component_params.dig("modification")
+        )
+
+        collect_item_ports(definition_data.dig("Vehicle", "Parts", "Part"))
+      end
+
+      # The same nested part tree `collect_hull_parts` walks, keeping exactly the
+      # parts it throws away.
+      private def collect_item_ports(node, ports = {})
+        case node
+        when Array
+          node.each { |value| collect_item_ports(value, ports) }
+        when Hash
+          item_port = node["ItemPort"]
+
+          if node["name"].present? && node["class"] == "ItemPort" && item_port.is_a?(Hash)
+            ports[node["name"]] ||= {
+              min_size: item_port["minSize"],
+              max_size: item_port["maxSize"],
+              types: extract_item_port_types(item_port)
+            }
+          end
+
+          collect_item_ports(node.dig("Parts", "Part"), ports)
+        end
+
+        ports
+      end
+
+      # A handful of ports carry junk where their types should be -- the
+      # Reclaimer's shield mounts hold a stray backtick -- so the block is only
+      # read when it came through as one.
+      private def extract_item_port_types(item_port)
+        types = item_port["Types"]
+
+        return [] unless types.is_a?(Hash)
+
+        Array.wrap(types["Type"]).filter_map do |type|
+          type["type"] if type.is_a?(Hash)
+        end
       end
 
       private def extract_loadout(item)

--- a/app/models/hardpoint.rb
+++ b/app/models/hardpoint.rb
@@ -35,6 +35,12 @@ class Hardpoint < ApplicationRecord
     radar computers fuel_intakes
   ].freeze
 
+  # The column is a string holding what an array serialised into it, which the
+  # API has always declared -- and the generated client has always typed -- as
+  # an array of strings. Read back as one, so the two agree. Every value ever
+  # written is already valid JSON, so nothing needs rewriting.
+  serialize :types, type: Array, coder: JSON
+
   belongs_to :parent, polymorphic: true, touch: true
   belongs_to :component, optional: true
   has_many :hardpoints, as: :parent, dependent: :destroy, autosave: true

--- a/test/loaders/hangar_sync_test.rb
+++ b/test/loaders/hangar_sync_test.rb
@@ -99,6 +99,23 @@ class HangarSyncTest < ActiveSupport::TestCase
     end
   end
 
+  class WithPaintOnlyPledgeTest < HangarSyncTest
+    test "matches a paint the RSI hangar names after its ship" do
+      gladius = Model.find_by!(slug: "aegs-gladius")
+      paint = create(:model_paint, model: gladius, name: "Dunlevy")
+
+      input = @input + [{"id" => "99999", "type" => "ship", "name" => "Gladius Dunlevy"}]
+
+      result = ::HangarSync.new(input).run(@user.id)
+
+      assert_equal [], result[:missing_models]
+
+      vehicle = Vehicle.where(id: result[:imported_vehicles]).find_by(model_paint_id: paint.id)
+      assert vehicle.present?
+      assert_equal gladius.id, vehicle.model_id
+    end
+  end
+
   class NotificationTest < HangarSyncTest
     test "summarises the sync in the notification body" do
       result = ::HangarSync.new(@input).run(@user.id)

--- a/test/loaders/sc_data/base_loader_loadout_test.rb
+++ b/test/loaders/sc_data/base_loader_loadout_test.rb
@@ -63,6 +63,75 @@ module ScData
         assert_equal 3, hardpoint.max_size
       end
 
+      # A port declares what it accepts, which is what a swap has to satisfy. The
+      # Retaliator's ordnance bay is the case that needs it: S3-S9, and a bomb
+      # launcher is as welcome in it as the S9 torpedo rack sitting there.
+      test "persists the types a port declares it accepts" do
+        create(:component, sc_key: "torpedo_rack_s9", size: "9")
+
+        update_loadout(@model, {"loadout" => [{
+          "name" => "hardpoint_torpedo_launcher_fore",
+          "key" => "torpedo_rack_s9",
+          "min_size" => "3",
+          "max_size" => "9",
+          "types" => ["MissileLauncher", "BombLauncher", "WeaponGun"]
+        }]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        assert_equal ["MissileLauncher", "BombLauncher", "WeaponGun"], hardpoint.types
+        assert_equal 3, hardpoint.min_size
+        assert_equal 9, hardpoint.max_size
+      end
+
+      # The size shown for a port stays the size of what is in it: the files
+      # carry ports declared 0-0 holding an S1 door, so the declaration only
+      # gets to lower the floor.
+      test "keeps the installed size as max_size when the declaration disagrees" do
+        create(:component, sc_key: "cargo_door_s1", size: "1")
+
+        update_loadout(@model, {"loadout" => [{
+          "name" => "hardpoint_cargo_pod",
+          "key" => "cargo_door_s1",
+          "min_size" => "0",
+          "max_size" => "0"
+        }]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        assert_equal 1, hardpoint.max_size
+      end
+
+      test "ignores a declared floor above the installed size" do
+        create(:component, sc_key: "cooler_s3", size: "3")
+
+        update_loadout(@model, {"loadout" => [{
+          "name" => "hardpoint_cooler",
+          "key" => "cooler_s3",
+          "min_size" => "5",
+          "max_size" => "9"
+        }]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        assert_equal 3, hardpoint.min_size
+        assert_equal 3, hardpoint.max_size
+      end
+
+      # An empty port has no installed size to fall back on, and used to get no
+      # size at all -- so an empty module slot could not say what fits it.
+      test "takes both bounds from the declaration when the port is empty" do
+        update_loadout(@model, {"loadout" => [{
+          "name" => "hardpoint_ordnance_bay",
+          "min_size" => "3",
+          "max_size" => "5",
+          "types" => ["BombLauncher"]
+        }]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        assert_nil hardpoint.component
+        assert_equal 3, hardpoint.min_size
+        assert_equal 5, hardpoint.max_size
+        assert_equal ["BombLauncher"], hardpoint.types
+      end
+
       test "resolves by ref when the entry carries no key" do
         component = create(:component, sc_ref: "a1b2c3", sc_key: "cooler_s1")
 

--- a/test/models/hardpoint_types_test.rb
+++ b/test/models/hardpoint_types_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# `types` is the list of item types a port accepts. It is stored in a string
+# column that arrays were written into for years, while the API -- and the
+# client generated from it -- have always called it an array of strings.
+class HardpointTypesTest < ActiveSupport::TestCase
+  setup do
+    @model = create(:model)
+  end
+
+  private def hardpoint(**attributes)
+    Hardpoint.create!(parent: @model, sc_name: "hardpoint_ordnance_bay", source: :game_files, **attributes)
+  end
+
+  test "reads an assigned list back as a list" do
+    record = hardpoint(types: ["MissileLauncher", "BombLauncher"])
+
+    assert_equal ["MissileLauncher", "BombLauncher"], record.reload.types
+  end
+
+  # What every row written before the column was serialised looks like: an
+  # array put through `to_s`, which is the same JSON it is read back as. Written
+  # through raw SQL because every path Rails offers now casts on the way in.
+  test "reads a value written as a bare string back as a list" do
+    record = hardpoint
+    connection = Hardpoint.connection
+
+    connection.update(<<~SQL.squish)
+      UPDATE hardpoints
+      SET types = #{connection.quote(["WeaponAttachment"].to_s)}
+      WHERE id = #{connection.quote(record.id)}
+    SQL
+
+    assert_equal ["WeaponAttachment"], record.reload.types
+  end
+
+  test "answers an empty list for a port that declares nothing" do
+    assert_equal [], hardpoint.reload.types
+  end
+end

--- a/test/parsers/sc_data/models_parser_test.rb
+++ b/test/parsers/sc_data/models_parser_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tmpdir"
+
+# A port declares what may sit in it. The default loadout only says what is in
+# it today, so neither the sizes a swap may be nor the item types it must be are
+# derivable from the loadout alone -- and the two declarations live in different
+# files, in different shapes.
+module ScData
+  module Parser
+    class ModelsParserTest < ActiveSupport::TestCase
+      DEFINITION_PATH = "scripts/entities/vehicles/implementations/xml/test_bomber.xml"
+
+      setup do
+        @base_folder = Dir.mktmpdir
+        @raw_path = "#{@base_folder}/raw/1.0.0"
+
+        FileUtils.mkdir_p("#{@raw_path}/Data/Localization/english")
+        File.write("#{@raw_path}/Data/Localization/english/global.ini", "")
+
+        write_ship
+        write_definition
+
+        @parser = ::ScData::Parser::ModelsParser.new(
+          base_folder: @base_folder, sc_version: "1.0.0", sc_environment: "test"
+        )
+      end
+
+      teardown do
+        FileUtils.remove_entry(@base_folder)
+      end
+
+      private def ports
+        @parser.all
+
+        parsed = JSON.parse(File.read("#{@base_folder}/parsed/test/models/test_bomber.json"))
+
+        parsed["loadout"].index_by { |entry| entry["name"] }
+      end
+
+      # The port that motivated all of this: an ordnance bay holding an S9
+      # torpedo rack, which the files say takes anything from S3 up and is as
+      # happy with a bomb rack as with the rack in it.
+      test "carries the size range and types a ship's own definition declares" do
+        port = ports.fetch("hardpoint_torpedorack")
+
+        assert_equal "3", port["min_size"]
+        assert_equal "10", port["max_size"]
+        assert_equal ["MissileLauncher", "BombLauncher"], port["types"]
+      end
+
+      # The entity record declares a handful of ports of its own rather than in
+      # the vehicle definition, so both sources have to be read.
+      test "carries what the entity record declares for its own ports" do
+        port = ports.fetch("hardpoint_relay")
+
+        assert_equal "0", port["min_size"]
+        assert_equal "1", port["max_size"]
+        assert_equal ["Relay"], port["types"]
+      end
+
+      test "still appends a module port the default loadout leaves empty" do
+        port = ports.fetch("hardpoint_front_module")
+
+        assert_nil port["key"]
+        assert_equal "3", port["max_size"]
+        assert_equal ["Module"], port["types"]
+      end
+
+      private def write_ship
+        FileUtils.mkdir_p("#{@raw_path}/#{::ScData::Parser::BaseParser::FOUNDRY_PATH}/entities/spaceships")
+
+        File.write("#{@raw_path}/#{::ScData::Parser::BaseParser::FOUNDRY_PATH}/entities/spaceships/test_bomber.xml", <<~XML)
+          <EntityClassDefinition.TEST_Bomber>
+            <Components>
+              <VehicleComponentParams vehicleName="@vehicle_NameTEST_Bomber" vehicleDefinition="#{DEFINITION_PATH}" />
+              <SItemPortContainerComponentParams>
+                <Ports>
+                  <SItemPortDef Name="hardpoint_relay" MinSize="0" MaxSize="1">
+                    <Types>
+                      <SItemPortDefTypes Type="Relay" />
+                    </Types>
+                  </SItemPortDef>
+                  <SItemPortDef Name="hardpoint_front_module" MinSize="3" MaxSize="3">
+                    <Types>
+                      <SItemPortDefTypes Type="Module" />
+                    </Types>
+                  </SItemPortDef>
+                </Ports>
+              </SItemPortContainerComponentParams>
+              <SEntityComponentDefaultLoadoutParams>
+                <loadout>
+                  <SItemPortLoadoutManualParams>
+                    <entries>
+                      <SItemPortLoadoutEntryParams itemPortName="hardpoint_torpedorack" entityClassName="TEST_Torpedo_Rack" />
+                      <SItemPortLoadoutEntryParams itemPortName="hardpoint_relay" entityClassName="TEST_Relay" />
+                    </entries>
+                  </SItemPortLoadoutManualParams>
+                </loadout>
+              </SEntityComponentDefaultLoadoutParams>
+            </Components>
+          </EntityClassDefinition.TEST_Bomber>
+        XML
+      end
+
+      # The ports sit one level down in the part tree, which is where a real
+      # ship keeps them.
+      private def write_definition
+        FileUtils.mkdir_p("#{@raw_path}/Data/#{File.dirname(DEFINITION_PATH)}")
+
+        File.write("#{@raw_path}/Data/#{DEFINITION_PATH}", <<~XML)
+          <Vehicle>
+            <Parts>
+              <Part name="body" class="Animated" damageMax="1000">
+                <Parts>
+                  <Part name="hardpoint_torpedorack" class="ItemPort">
+                    <ItemPort minSize="3" maxSize="10" flags="editable $swaponly">
+                      <Types>
+                        <Type type="MissileLauncher" subtypes="MissileRack" />
+                        <Type type="BombLauncher" subtypes="BombRack" />
+                      </Types>
+                    </ItemPort>
+                  </Part>
+                  <Part name="hardpoint_wing" class="Animated" damageMax="500" />
+                </Parts>
+              </Part>
+            </Parts>
+          </Vehicle>
+        XML
+      end
+    end
+  end
+end


### PR DESCRIPTION
Two reports from a user: the Gladius Dunlevy was not recognised on a hangar sync, and the Retaliator, Eclipse and Gladiator offer no bomb racks.

## The Dunlevy

RSI lists the paint as "Gladius Dunlevy", the catalogue stores it as "Dunlevy", and the sync's name table had no pairing for it — so a hangar holding one reported it under "Ships not found". One entry, plus a test that fails with exactly that warning when the entry is removed.

## The bomb racks

All nine exist as components already (Retaliator front/rear S3+S5, Eclipse 1×S10/4×S5/20×S3, Gladiator S3+S5) and are attached to nothing, because a ship's loadout is built from what the game installs by default and none of those three ship with a rack fitted. Nothing recorded that their ordnance ports *accept* one, so the question could not be answered at all.

This PR keeps that declaration. It does not surface the racks anywhere yet — the UI half is a separate decision.

| Port | Now declares |
| --- | --- |
| Eclipse `hardpoint_torpedorack` | S3–S10, `MissileLauncher` + `BombLauncher` |
| Gladiator `hardpoint_ordnance_bay` | S3–S5, `BombLauncher` + `MissileLauncher` |
| Gladiator wing racks | S3–S4, both |
| Retaliator `hardpoint_torpedo_launcher_fore` | S3–S9, incl. `BombLauncher` |

The Gladiator's S3–S5 matches its two racks exactly. The Retaliator's port was already exported; only the loader was discarding it, so that ship needs a load rather than a re-parse.

**Ships declare their real ports in the vehicle implementation XML**, not on the entity record — the record only adds a handful of late ones (life support, the relay). Reading only the record annotated none of the three ships, which is what sent me to the definition. Both are read now: 83,878 of the 85,191 loadout entries in 4.10 come back with a declaration.

### What deliberately did not change

- **The size a port is shown as.** It stays the size of what is installed. The declared bounds are not trustworthy enough to display: 126 ports declare a maximum that disagrees with the item in them, one being a Carrack cargo pod declared 0-0 with an S1 door in it. The declaration only lowers the floor, and fills both bounds for the 4,202 empty ports that had no size at all — an empty bay now shows its size instead of none.
- **Which module slots a ship offers.** The definition also calls the Hornet's configurable centre mount module-capable, and the Super Hornet's loadout omits it, so reading the definition would have handed the Super Hornet a module slot it has never had. Appending stays restricted to the entity record: verified as the same three Aurora Mk II slots before and after. Worth deciding separately — that mount looks like a real slot we are missing.

### Types serialisation

`types` is stored in a string column that arrays were written into, so the endpoint served `"[\"BombLauncher\"]"` for a field the schema and the generated client have always called an array of strings. It was a quiet inconsistency across 3,789 item ports; this PR makes it ~84k, so it is fixed here. Every value ever written is already valid JSON — all 3,789 existing rows read back as lists, so there is nothing to rewrite, and no schema change.

## Before this ships

The ship half needs a re-parse; loader tests read the pushed tree, so this lands green either way. The new read costs ~24ms/ship (~25s per build) — and the parser already parses that same definition XML three other times per ship, so memoising it would save more than this addition costs. I left that out: `extract_modification_definition` mutates the hash it is handed, so a shared memo wants its own change rather than a bundled one.

## Testing

New `models_parser_test` covering both declaration sources, four loader tests, and a model test pinning the legacy string shape. 190 tests green across `test/parsers/sc_data`, `test/loaders/sc_data` and the hangar sync file, plus the hardpoint API tests. Every figure above measured against the full 4.10 raw tree.

🤖
