### PR TITLE
fix(ships): make a module choice move the metrics, and rebuild the picker

### DIFF
--- a/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.scss
@@ -1,34 +1,110 @@
-.module-item {
-  .module-image {
-    max-width: 100px;
-    flex: none;
+/*
+ * A list rather than the two-up grid of photographs this used to be. The
+ * photograph is the same for every module on a ship, so a grid of them asked
+ * the reader to choose between four identical pictures; in a row the fittings
+ * and the cargo figure line up down the modal and can actually be compared.
+ */
+.module-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.module-option {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+  padding: 10px 16px 10px 10px;
+  text-align: left;
+  cursor: pointer;
+  background-color: $panel-bg;
+  border: $panel-border-width solid transparent;
+  border-radius: $panel-border-radius;
+  transition:
+    border-color $transition-base-speed,
+    background-color $transition-base-speed;
+
+  &:hover,
+  &:focus-visible {
+    border-color: $panel-inner-border;
   }
 
-  .module-panel {
-    cursor: pointer;
+  &--selected {
+    border-color: $success;
+  }
+}
 
-    .module-panel-selected {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 40px;
-      height: 40px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      background-color: $success;
-      border-radius: 0 10px 0 $panelContentBorderRadius;
+.module-option__image {
+  flex: none;
+  width: 96px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: $panelContentBorderRadius;
 
-      i,
-      svg {
-        color: #fff;
-      }
+  &--stock {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba($gray-black, 0.6);
+
+    i,
+    svg {
+      font-size: 24px;
+      color: $gray-light;
     }
   }
 }
 
-@media (max-width: $desktop-breakpoint) {
-  .module-item {
-    margin: 0;
+.module-option__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.module-option__name {
+  color: $text-color;
+  font-size: 16px;
+}
+
+.module-option__contents {
+  color: $gray-lighter;
+  font-size: 13px;
+}
+
+.module-option__meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: none;
+}
+
+.module-option__cargo {
+  color: $text-color;
+  font-size: 14px;
+  white-space: nowrap;
+}
+
+/*
+ * The meta column drops under the name rather than squeezing it: at this width
+ * a cargo figure and two pills beside a name leave the name a few characters.
+ */
+@media (max-width: $tablet-breakpoint) {
+  .module-option {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .module-option__image {
+    width: 72px;
+    height: 48px;
+  }
+
+  .module-option__meta {
+    width: 100%;
+    padding-left: 88px;
   }
 }

--- a/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/Modal/index.vue
@@ -6,18 +6,17 @@ export default {
 
 <script lang="ts" setup>
 import Modal from "@/shared/components/AppModal/Inner/index.vue";
-import Panel from "@/shared/components/base/Panel/index.vue";
-import PanelImage from "@/shared/components/base/Panel/Image/index.vue";
-import PanelHeading from "@/shared/components/base/Panel/Heading/index.vue";
-import Btn from "@/shared/components/base/Btn/index.vue";
+import Pill from "@/shared/components/base/Pill/index.vue";
 import { useComlink } from "@/shared/composables/useComlink";
 import { useI18n } from "@/shared/composables/useI18n";
-import { type ModelModule } from "@/services/fyApi";
-import { PanelAlignmentsEnum } from "@/shared/components/base/Panel/types";
-import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
+import {
+  HardpointCategoryEnum,
+  type Hardpoint,
+  type ModelModule,
+} from "@/services/fyApi";
+import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
 
 import { useWebpCheck } from "@/shared/composables/useWebpCheck";
-import { useMobile } from "@/shared/composables/useMobile";
 import fallbackImageJpg from "@/images/fallback/store_image.jpg";
 import fallbackImage from "@/images/fallback/store_image.webp";
 
@@ -35,23 +34,53 @@ const comlink = useComlink();
 
 const { supported: webpSupported } = useWebpCheck();
 
-const mobile = useMobile();
+const storeImage = (mod: ModelModule) =>
+  mod.media.storeImage?.smallUrl ||
+  (webpSupported.value ? fallbackImage : fallbackImageJpg);
 
-const storeImage = (mod: ModelModule) => {
-  if (mobile.value && mod.media.storeImage?.mediumUrl) {
-    return mod.media.storeImage?.mediumUrl;
+// Ports that say nothing about what the module is for. The slot row drops the
+// same two from its own expansion.
+const UNINFORMATIVE: HardpointCategoryEnum[] = [
+  HardpointCategoryEnum.CONTROLLER,
+  HardpointCategoryEnum.UNKNOWN,
+];
+
+// What the module brings, which is the whole reason to pick one over another: a
+// torpedo bay and a cargo bay fill the same slot and ship the same photograph,
+// and only their fittings tell them apart. The count is dropped at one, because
+// every category label is already plural.
+const contents = (mod: ModelModule): string => {
+  const counts = new Map<string, number>();
+
+  (mod.hardpoints || []).forEach((hardpoint: Hardpoint) => {
+    const category = hardpoint.category;
+
+    if (!category || UNINFORMATIVE.includes(category)) {
+      return;
+    }
+
+    counts.set(category, (counts.get(category) || 0) + 1);
+  });
+
+  if (!counts.size) {
+    return t("labels.hardpoint.moduleContentsUnknown");
   }
 
-  if (mod.media.storeImage?.smallUrl) {
-    return mod.media.storeImage?.smallUrl;
-  }
+  return [...counts.entries()]
+    .map(([category, count]) => {
+      const label = t(`labels.hardpoint.categories.${category}`);
 
-  if (webpSupported) {
-    return fallbackImage;
-  }
-
-  return fallbackImageJpg;
+      return count > 1 ? `${count} × ${label}` : label;
+    })
+    .join(" · ");
 };
+
+const cargo = (mod: ModelModule): number => mod.metrics?.cargo || 0;
+
+// Only a status worth a warning is shown. Most modules are flight ready, and a
+// pill on every row would say nothing while crowding the figures that do.
+const upcoming = (mod: ModelModule): boolean =>
+  !!mod.productionStatus && mod.productionStatus !== "flight-ready";
 
 const selectModule = (mod: ModelModule) => {
   props.onSelect(mod);
@@ -68,46 +97,66 @@ const isSelected = (mod: ModelModule) => mod.slug === props.selectedModuleSlug;
 
 <template>
   <Modal :title="t('labels.hardpoint.selectModule')">
-    <div class="row">
-      <div
+    <div class="module-options">
+      <button
+        type="button"
+        class="module-option"
+        :class="{ 'module-option--selected': !selectedModuleSlug }"
+        data-test="module-option-stock"
+        @click="clearModule"
+      >
+        <span class="module-option__image module-option__image--stock">
+          <i class="fa-duotone fa-layer-minus" />
+        </span>
+        <span class="module-option__body">
+          <span class="module-option__name">
+            {{ t("labels.hardpoint.moduleStock") }}
+          </span>
+          <span class="module-option__contents">
+            {{ t("labels.hardpoint.moduleStockHint") }}
+          </span>
+        </span>
+        <span class="module-option__meta">
+          <Pill v-if="!selectedModuleSlug" :variant="PillVariantsEnum.SUCCESS">
+            <i class="fa fa-check" />
+            {{ t("labels.hardpoint.moduleFitted") }}
+          </Pill>
+        </span>
+      </button>
+
+      <button
         v-for="mod in modules"
         :key="mod.id"
-        class="col-12 col-md-6 module-item"
+        type="button"
+        class="module-option"
+        :class="{ 'module-option--selected': isSelected(mod) }"
+        data-test="module-option"
+        @click="selectModule(mod)"
       >
-        <Panel
-          :alignment="PanelAlignmentsEnum.LEFT"
-          class="module-panel"
-          @click="selectModule(mod)"
-        >
-          <PanelImage
-            :image="storeImage(mod)"
-            image-size="auto"
-            rounded="left"
-            class="module-image"
-            :alt="mod.name"
-          />
-          <div>
-            <PanelHeading :level="HeadingLevelEnum.H3">
-              {{ mod.name }}
-            </PanelHeading>
-            <div
-              v-if="isSelected(mod)"
-              v-tooltip="t('labels.selected')"
-              class="module-panel-selected"
-            >
-              <i class="fa fa-check" />
-            </div>
-          </div>
-        </Panel>
-      </div>
+        <img
+          :src="storeImage(mod)"
+          :alt="mod.name"
+          class="module-option__image"
+          loading="lazy"
+        />
+        <span class="module-option__body">
+          <span class="module-option__name">{{ mod.name }}</span>
+          <span class="module-option__contents">{{ contents(mod) }}</span>
+        </span>
+        <span class="module-option__meta">
+          <Pill v-if="isSelected(mod)" :variant="PillVariantsEnum.SUCCESS">
+            <i class="fa fa-check" />
+            {{ t("labels.hardpoint.moduleFitted") }}
+          </Pill>
+          <span v-if="cargo(mod)" class="module-option__cargo">
+            {{ t("labels.hardpoint.moduleCargo", { cargo: cargo(mod) }) }}
+          </span>
+          <Pill v-if="upcoming(mod)" :variant="PillVariantsEnum.WARNING">
+            {{ t(`labels.model.productionStatus.${mod.productionStatus}`) }}
+          </Pill>
+        </span>
+      </button>
     </div>
-    <template #footer>
-      <div class="modal-actions">
-        <Btn v-if="selectedModuleSlug" @click="clearModule">
-          {{ t("labels.hardpoint.clearModule") }}
-        </Btn>
-      </div>
-    </template>
   </Modal>
 </template>
 

--- a/app/frontend/frontend/components/Models/Hardpoints/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/index.vue
@@ -26,6 +26,10 @@ import {
 import type { FlightMode } from "@/frontend/composables/powerSim";
 import { useMetricsMasonry } from "@/frontend/composables/useMetricsMasonry";
 import {
+  useEquippedHardpoints,
+  type EquippedModules,
+} from "@/frontend/composables/useEquippedHardpoints";
+import {
   useModelHardpoints as useModelHardpointsQuery,
   HardpointGroupEnum,
   HardpointSourceEnum,
@@ -112,6 +116,19 @@ const {
 // in flight, so they never pop into the layout once the data lands.
 const loadingHardpoints = computed(() => isLoading.value || isFetching.value);
 
+// The module the reader picked per slot, chosen in the slot row and provided by
+// the ship page. Grafted onto the slot so every metric below answers for the
+// loadout on screen rather than the one the game ships.
+const equippedModules = inject<Ref<EquippedModules>>(
+  "equippedModules",
+  ref({}),
+);
+
+const loadoutHardpoints = useEquippedHardpoints(
+  () => hardpoints.value as Hardpoint[] | undefined,
+  equippedModules,
+);
+
 // User pip choices from the Power Distribution control; empty = auto (default).
 const powerOverrides = ref<PortOverrides>({});
 const flightMode = ref<FlightMode>("SCM");
@@ -122,7 +139,7 @@ watch([() => props.model.slug, source], () => {
 });
 
 const combatStats = useLoadoutStats(
-  () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
+  loadoutHardpoints,
   () => props.model.metrics?.weaponPoolSize,
   powerOverrides,
 );
@@ -138,7 +155,7 @@ provide("powerOverrides", powerOverrides);
 
 // Shield power allocation → Defense card scales shield HP/regen with the pips.
 const powerSim = useLoadoutSim(
-  () => (hardpoints.value as Hardpoint[] | undefined) ?? [],
+  loadoutHardpoints,
   () => props.model.metrics?.weaponPoolSize,
   flightMode,
   powerOverrides,
@@ -222,19 +239,19 @@ useMetricsMasonry(metricsGrid);
       </div>
       <div v-if="showMetrics" ref="metricsGrid" class="metrics-grid">
         <ModelCombatMetrics
-          :hardpoints="hardpoints as Hardpoint[]"
+          :hardpoints="loadoutHardpoints"
           :loading="loadingHardpoints"
         />
         <ModelPowerDistribution
           v-model="powerOverrides"
           v-model:mode="flightMode"
-          :hardpoints="hardpoints as Hardpoint[]"
+          :hardpoints="loadoutHardpoints"
           :weapon-pool-size="model.metrics?.weaponPoolSize"
           :cross-section="model.metrics?.signatureCrossSection"
           :loading="loadingHardpoints"
         />
         <ModelDefenseMetrics
-          :hardpoints="hardpoints as Hardpoint[]"
+          :hardpoints="loadoutHardpoints"
           :model-name="model.name"
           :loading="loadingHardpoints"
         />

--- a/app/frontend/frontend/composables/useEquippedHardpoints.spec.ts
+++ b/app/frontend/frontend/composables/useEquippedHardpoints.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  HardpointCategoryEnum,
+  type Hardpoint,
+  type ModelModule,
+} from "@/services/fyApi";
+import { graftEquippedModules } from "./useEquippedHardpoints";
+
+function hardpoint(
+  attributes: Partial<Hardpoint> & { id: string },
+  children: Hardpoint[] = [],
+): Hardpoint {
+  return {
+    name: attributes.id,
+    category: HardpointCategoryEnum.MODULE,
+    hardpoints: children,
+    createdAt: "",
+    updatedAt: "",
+    ...attributes,
+  } as Hardpoint;
+}
+
+function module(hardpoints: Hardpoint[]): ModelModule {
+  return { name: "Front Torpedo Bay", hardpoints } as ModelModule;
+}
+
+describe("graftEquippedModules", () => {
+  const torpedoBay = hardpoint({ id: "torpedo-launcher" });
+
+  it("hangs a chosen module's hardpoints off the slot holding it", () => {
+    const slot = hardpoint({ id: "front-module" });
+
+    const result = graftEquippedModules([slot], {
+      "front-module": module([torpedoBay]),
+    });
+
+    expect(result[0].hardpoints).toEqual([torpedoBay]);
+  });
+
+  it("keys the slot by its group when it has one", () => {
+    const slot = hardpoint({ id: "front-module", groupKey: "front-group" });
+
+    const result = graftEquippedModules([slot], {
+      "front-group": module([torpedoBay]),
+    });
+
+    expect(result[0].hardpoints).toEqual([torpedoBay]);
+  });
+
+  // The default module's contents would otherwise be counted alongside the
+  // contents of the module that replaced it.
+  it("replaces what the slot already held rather than adding to it", () => {
+    const slot = hardpoint({ id: "front-module" }, [
+      hardpoint({ id: "cargo-grid" }),
+    ]);
+
+    const result = graftEquippedModules([slot], {
+      "front-module": module([torpedoBay]),
+    });
+
+    expect(result[0].hardpoints).toEqual([torpedoBay]);
+  });
+
+  it("leaves a slot with no choice made alone", () => {
+    const slot = hardpoint({ id: "rear-module" }, [
+      hardpoint({ id: "cargo-grid" }),
+    ]);
+
+    const result = graftEquippedModules([slot], { "front-module": null });
+
+    expect(result[0]).toBe(slot);
+  });
+
+  it("returns the list untouched when nothing is equipped", () => {
+    const slots = [hardpoint({ id: "front-module" })];
+
+    expect(graftEquippedModules(slots, {})).toBe(slots);
+    expect(graftEquippedModules(slots, undefined)).toBe(slots);
+  });
+
+  it("survives a loadout that has not loaded yet", () => {
+    expect(graftEquippedModules(undefined, {})).toEqual([]);
+  });
+});

--- a/app/frontend/frontend/composables/useEquippedHardpoints.ts
+++ b/app/frontend/frontend/composables/useEquippedHardpoints.ts
@@ -1,0 +1,49 @@
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+import { type Hardpoint, type ModelModule } from "@/services/fyApi";
+
+export type EquippedModules = Record<string, ModelModule | null>;
+
+// The key a module slot is chosen under, matching how the slot row keys its own
+// selection.
+export function slotId(hardpoint: Hardpoint): string {
+  return hardpoint.groupKey || hardpoint.id;
+}
+
+// Every metric on a ship page walks the hardpoint tree, so a module the reader
+// picked has to hang off the slot holding it -- otherwise nothing but the cargo
+// card notices the choice, and swapping a torpedo bay for a cargo bay leaves
+// the combat figures answering for a ship nobody is looking at.
+//
+// Grafted onto the slot rather than appended to the list: a slot holds whatever
+// module is in it, so replacing its contents is what keeps a default module
+// from being counted alongside the one that replaced it. Ships currently ship
+// their bays unladen, which is why appending has looked the same so far.
+export function graftEquippedModules(
+  hardpoints: Hardpoint[] | undefined,
+  equipped: EquippedModules | undefined,
+): Hardpoint[] {
+  const base = hardpoints ?? [];
+
+  if (!equipped || !Object.keys(equipped).length) {
+    return base;
+  }
+
+  return base.map((hardpoint) => {
+    const module = equipped[slotId(hardpoint)];
+
+    if (!module) {
+      return hardpoint;
+    }
+
+    return { ...hardpoint, hardpoints: module.hardpoints ?? [] };
+  });
+}
+
+export function useEquippedHardpoints(
+  hardpoints: MaybeRefOrGetter<Hardpoint[] | undefined>,
+  equipped: MaybeRefOrGetter<EquippedModules | undefined>,
+) {
+  return computed(() =>
+    graftEquippedModules(toValue(hardpoints), toValue(equipped)),
+  );
+}

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1245,7 +1245,6 @@
         "moduleFitted": "Verbaut",
         "moduleCargo": "%{cargo} SCU",
         "moduleContentsUnknown": "Keine eigene Ausstattung",
-        "clearModule": "Auswahl löschen",
         "categories": {
           "radar": "Radar",
           "armor": "Panzerung",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1240,6 +1240,11 @@
         },
         "moduleSlotEmpty": "— Modul auswählen —",
         "selectModule": "Modul auswählen",
+        "moduleStock": "Wie ausgeliefert",
+        "moduleStockHint": "Slot bleibt, wie das Schiff geliefert wird",
+        "moduleFitted": "Verbaut",
+        "moduleCargo": "%{cargo} SCU",
+        "moduleContentsUnknown": "Keine eigene Ausstattung",
         "clearModule": "Auswahl löschen",
         "categories": {
           "radar": "Radar",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1236,7 +1236,6 @@
         },
         "moduleSlotEmpty": "— Select Module —",
         "selectModule": "Select Module",
-        "clearModule": "Clear Selection",
         "moduleStock": "As delivered",
         "moduleStockHint": "Slot left as the ship comes",
         "moduleFitted": "Fitted",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1237,6 +1237,11 @@
         "moduleSlotEmpty": "— Select Module —",
         "selectModule": "Select Module",
         "clearModule": "Clear Selection",
+        "moduleStock": "As delivered",
+        "moduleStockHint": "Slot left as the ship comes",
+        "moduleFitted": "Fitted",
+        "moduleCargo": "%{cargo} SCU",
+        "moduleContentsUnknown": "No fittings of its own",
         "categories": {
           "radar": "Radar",
           "armor": "Armor",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1245,7 +1245,6 @@
         "moduleFitted": "Instalado",
         "moduleCargo": "%{cargo} SCU",
         "moduleContentsUnknown": "Sin equipamiento propio",
-        "clearModule": "Borrar selección",
         "categories": {
           "radar": "Radar",
           "armor": "Blindaje",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1240,6 +1240,11 @@
         },
         "moduleSlotEmpty": "— Seleccionar módulo —",
         "selectModule": "Seleccionar módulo",
+        "moduleStock": "Tal como se entrega",
+        "moduleStockHint": "Ranura tal como viene la nave",
+        "moduleFitted": "Instalado",
+        "moduleCargo": "%{cargo} SCU",
+        "moduleContentsUnknown": "Sin equipamiento propio",
         "clearModule": "Borrar selección",
         "categories": {
           "radar": "Radar",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1245,7 +1245,6 @@
         "moduleFitted": "Installé",
         "moduleCargo": "%{cargo} SCU",
         "moduleContentsUnknown": "Aucun équipement propre",
-        "clearModule": "Effacer la sélection",
         "categories": {
           "radar": "Radar",
           "armor": "Blindage",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1240,6 +1240,11 @@
         },
         "moduleSlotEmpty": "— Sélectionner un module —",
         "selectModule": "Sélectionner un module",
+        "moduleStock": "Tel que livré",
+        "moduleStockHint": "Emplacement tel que le vaisseau est livré",
+        "moduleFitted": "Installé",
+        "moduleCargo": "%{cargo} SCU",
+        "moduleContentsUnknown": "Aucun équipement propre",
         "clearModule": "Effacer la sélection",
         "categories": {
           "radar": "Radar",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1240,6 +1240,11 @@
         },
         "moduleSlotEmpty": "— Seleziona modulo —",
         "selectModule": "Seleziona modulo",
+        "moduleStock": "Come consegnato",
+        "moduleStockHint": "Slot lasciato come arriva la nave",
+        "moduleFitted": "Installato",
+        "moduleCargo": "%{cargo} SCU",
+        "moduleContentsUnknown": "Nessun equipaggiamento proprio",
         "clearModule": "Cancella selezione",
         "categories": {
           "radar": "Radar",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1245,7 +1245,6 @@
         "moduleFitted": "Installato",
         "moduleCargo": "%{cargo} SCU",
         "moduleContentsUnknown": "Nessun equipaggiamento proprio",
-        "clearModule": "Cancella selezione",
         "categories": {
           "radar": "Radar",
           "armor": "Corazza",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1240,6 +1240,11 @@
         },
         "moduleSlotEmpty": "— 选择模块 —",
         "selectModule": "选择模块",
+        "moduleStock": "出厂状态",
+        "moduleStockHint": "插槽保持飞船出厂时的状态",
+        "moduleFitted": "已装配",
+        "moduleCargo": "%{cargo} SCU",
+        "moduleContentsUnknown": "无自带设备",
         "clearModule": "清除选择",
         "categories": {
           "radar": "雷达",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1245,7 +1245,6 @@
         "moduleFitted": "已装配",
         "moduleCargo": "%{cargo} SCU",
         "moduleContentsUnknown": "无自带设备",
-        "clearModule": "清除选择",
         "categories": {
           "radar": "雷达",
           "armor": "装甲",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1245,7 +1245,6 @@
         "moduleFitted": "已裝配",
         "moduleCargo": "%{cargo} SCU",
         "moduleContentsUnknown": "無自帶設備",
-        "clearModule": "清除選擇",
         "categories": {
           "radar": "雷達",
           "armor": "裝甲",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1240,6 +1240,11 @@
         },
         "moduleSlotEmpty": "— 選擇模組 —",
         "selectModule": "選擇模組",
+        "moduleStock": "出廠狀態",
+        "moduleStockHint": "插槽保持船艦出廠時的狀態",
+        "moduleFitted": "已裝配",
+        "moduleCargo": "%{cargo} SCU",
+        "moduleContentsUnknown": "無自帶設備",
         "clearModule": "清除選擇",
         "categories": {
           "radar": "雷達",


### PR DESCRIPTION
Groundwork for offering bomb racks on a port, both halves of which are worth having on their own.

## Picking a module now moves the metrics

It only ever moved the cargo card. The choice fed `moduleCargoHolds` and nothing else, while every other figure read the hardpoints query, which never changes:

| Card | Read from | Reacted to a choice |
| --- | --- | --- |
| Cargo | `combinedCargoHolds` | yes |
| Combat / Defense / Hull | the hardpoints query | no |
| Flight / Power | `useLoadoutStats` + `useLoadoutSim`, same query | no |

So swapping a torpedo bay for a cargo bay left every combat figure answering for a loadout nobody was looking at.

Every metric walks the hardpoint tree, so the chosen module's hardpoints now hang off the slot holding it (`useEquippedHardpoints`). Grafted onto the slot rather than appended to the list, because a slot holds whatever module is in it — that is what keeps a laden default module from being counted alongside the module that replaced it. Ships currently ship their bays unladen, which is why appending would have looked identical today and wrong later.

## The picker is a list rather than a grid of identical photographs

Every module on a ship ships the same store photograph, so a two-up grid of them asked the reader to choose between four identical pictures labelled only by name — and a torpedo bay and a cargo bay fill the same slot and look the same.

Each row now carries what the module brings, summarised from its own hardpoints, plus its cargo capacity and a warning where it is not flight ready. That last one matters: three of the Retaliator's five modules are still in concept and the old grid never said so. The figures line up down the modal, so they read against each other.

Also: "As delivered" is a row at the top instead of a footer button that appeared only once something was chosen, each option is a `<button>` so the list is keyboard reachable, and the selected row carries an edge and a pill rather than a check tucked into its bottom corner.

## Translations

All five new keys are written into every locale, not just `en` — `crowdin.yml` is still in the repo but no longer really in use, and `enableFallback` would have hidden the gap.

## Testing

`useEquippedHardpoints` has a spec covering the graft, the group keying, the replace-not-append rule and the untouched cases (6 tests). `lint:ts`, `lint:js` and `format` are clean.

The modal is verified by compiling its SCSS standalone and screenshotting the real markup at desktop and phone widths — rows, alignment, the wrap behaviour and the selected edge all check out. It has **not** been seen in the running app: this is a fresh worktree with no database, so that is the one thing left to eyeball before merging.

🤖
