### PR TITLE
feat(gallery): bring the image viewer in line with the design system

### DIFF
--- a/app/frontend/frontend/pages/visual-tests/media.vue
+++ b/app/frontend/frontend/pages/visual-tests/media.vue
@@ -15,6 +15,7 @@ import BaseText from "@/shared/components/base/Text/index.vue";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
 import { LazyImageVariantsEnum } from "@/shared/components/LazyImage/types";
 import { ViewImageSizeEnum } from "@/shared/components/ViewImage/types";
+import { useGallery } from "@/shared/composables/useGallery";
 import { useCookiesStore } from "@/frontend/stores/cookies";
 import { VideoTypeEnum, type MediaFile } from "@/services/fyApi";
 import { storeToRefs } from "pinia";
@@ -70,6 +71,16 @@ const { youtubeAccepted } = storeToRefs(cookiesStore);
 const toggleYoutube = () => {
   cookiesStore.cookies.youtube = !cookiesStore.cookies.youtube;
 };
+
+/*
+ * The lightbox is the one piece of this page that cannot be shown standing
+ * still: its chrome only exists once PhotoSwipe opens, so reviewing it means
+ * clicking a tile. The real dimensions of the bundled image are passed through
+ * because they are what pswp sizes the slide from.
+ */
+const storeImageSize = { width: 1200, height: 420 };
+
+useGallery(".vt-gallery");
 
 const video = {
   id: "vt-video",
@@ -238,6 +249,58 @@ const video = {
     <div class="col-12 col-lg-4">
       <BaseText muted no-spacing>broken url</BaseText>
       <ViewImage :image="file(brokenSrc)" alt="Broken" />
+    </div>
+  </div>
+
+  <Heading :level="HeadingLevelEnum.H2">Gallery | Lightbox</Heading>
+  <p>
+    Click a tile to open PhotoSwipe. Its chrome wears the app's control language
+    — the same fill, edge, radius and end-cap as
+    <code>Btn</code>, lighting the cap on hover — and the caption is a panel
+    held to a reading measure rather than a full-bleed band. The three tiles
+    cover the caption cases: one short, one long enough to wrap, and one with
+    none at all, which hides the panel instead of leaving an empty box.
+  </p>
+  <div class="row vt-gallery">
+    <div class="col-12 col-lg-4">
+      <LazyImage
+        :src="storeImage"
+        :href="storeImage"
+        :width="storeImageSize.width"
+        :height="storeImageSize.height"
+        alt="Short caption"
+        title="Short caption"
+        caption="Aegis Idris P"
+        shadow
+        gallery
+      />
+    </div>
+    <div class="col-12 col-lg-4">
+      <LazyImage
+        :src="storeImage"
+        :href="storeImage"
+        :width="storeImageSize.width"
+        :height="storeImageSize.height"
+        alt="Long caption"
+        title="Long caption"
+        caption="The <b>Aegis Idris P</b> under escort over Yela — a caption long
+          enough to run past the measure the panel holds, so it wraps instead of
+          spanning the whole viewport the way the old full-bleed band did."
+        shadow
+        gallery
+      />
+    </div>
+    <div class="col-12 col-lg-4">
+      <LazyImage
+        :src="storeImage"
+        :href="storeImage"
+        :width="storeImageSize.width"
+        :height="storeImageSize.height"
+        alt="No caption"
+        title="No caption"
+        shadow
+        gallery
+      />
     </div>
   </div>
 

--- a/app/frontend/shared/components/AppNotifications/index.scss
+++ b/app/frontend/shared/components/AppNotifications/index.scss
@@ -1,8 +1,24 @@
+/*
+ * Above everything. A notification is the app's topmost transient layer - it
+ * reports on what just happened, so there is nothing it should sit behind.
+ *
+ * At 1100 it sat behind seven of them: the mobile navigation and NetworkStatus
+ * (2000), OffCanvas (2020), AppConfirm and HoloViewer (2050), BtnDropdown,
+ * Select and Fleetchart (2100) and Loader (3000) - and behind PhotoSwipe, whose
+ * vendor default is 100000. In the lightbox that was load-bearing: copying an
+ * image URL confirms only through this layer, so the confirmation was painted
+ * under the viewer and the button read as doing nothing at all.
+ *
+ * Ahead of Loader deliberately. A blocking spinner is the one thing most likely
+ * to be up when something worth reporting completes. The lightbox is the other,
+ * and it is now held below this rather than at its vendor default - see
+ * --pswp-root-z-index in stylesheets/shared/vendor/pswp.scss.
+ */
 .app-notifications {
   position: fixed;
   top: calc(20px + env(safe-area-inset-top));
   right: calc(20px + env(safe-area-inset-right));
-  z-index: 1100;
+  z-index: 3100;
 }
 
 /* transitions */

--- a/app/frontend/shared/composables/useGallery.ts
+++ b/app/frontend/shared/composables/useGallery.ts
@@ -13,8 +13,21 @@ export const useGallery = (
 
   const lightbox = ref<PhotoSwipeLightbox>();
 
-  const copy = (url: string) => {
-    copyText(url).then(
+  /*
+   * Pass an element inside the open lightbox as `container`. Optional only
+   * because copyText's own argument is - copying without one does not work
+   * from in here, it just fails quietly.
+   *
+   * copyText hands clipboard.js a throwaway textarea to select and copy from,
+   * and clipboard.js appends it to the container - document.body by default.
+   * PhotoSwipe traps focus inside its own root while it is open, so a textarea
+   * parked in body never takes the selection, and `execCommand("copy")` copies
+   * an empty one. It still returns true, so clipboard.js reports success and
+   * the notification below claimed the URL had been copied while the clipboard
+   * kept whatever was in it before.
+   */
+  const copy = (url: string, container?: HTMLElement) => {
+    copyText(url, container).then(
       () => {
         displaySuccess({
           text: t("messages.copyImageUrl.success"),
@@ -85,7 +98,7 @@ export const useGallery = (
             return;
           }
 
-          copy(url);
+          copy(url, pswp.element);
         },
       });
 

--- a/app/frontend/shared/composables/useGallery.ts
+++ b/app/frontend/shared/composables/useGallery.ts
@@ -123,7 +123,13 @@ export const useGallery = (
         order: 9,
         isButton: false,
         appendTo: "root",
-        html: "Caption text",
+        /*
+         * Empty, not placeholder copy. The caption is a panel now, and one that
+         * starts with text in it flashes that text before the first `change`
+         * swaps it - and stays a visible empty box on an uncaptioned image,
+         * which is what the `:empty` rule in pswp.scss keys off.
+         */
+        html: "",
         onInit: (el, pswp) => {
           pswp.on("change", () => {
             const currSlideElement = pswp.currSlide?.data.element;

--- a/app/frontend/shared/composables/useGallery.ts
+++ b/app/frontend/shared/composables/useGallery.ts
@@ -59,16 +59,31 @@ export const useGallery = (
       children,
       bgOpacity: 1,
       counter: false,
+      /*
+       * pswp's own chrome ships hardcoded English for its titles, which are
+       * both the tooltip and the accessible name of every button it draws.
+       */
+      closeTitle: t("actions.close"),
+      zoomTitle: t("actions.zoom"),
+      arrowPrevTitle: t("actions.previous"),
+      arrowNextTitle: t("actions.next"),
+      errorMsg: t("errors.imageNotLoaded"),
       pswpModule: () => import("photoswipe"),
     });
 
     lightbox.value.on("uiRegister", () => {
       const pswp = lightbox.value?.pswp;
+      /*
+       * These two sit at 8 and 9, after pswp's own preloader at 7. The copy
+       * button used to be a 7 as well, which left it and the preloader to
+       * settle their position in the bar by registration order.
+       */
       pswp?.ui?.registerElement({
         name: "download-button",
-        order: 8,
+        order: 9,
         isButton: true,
         tagName: "button",
+        title: t("actions.download"),
         html: '<i class="fa fa-download"></i>',
 
         onClick: (_event, _el, pswp) => {
@@ -87,9 +102,10 @@ export const useGallery = (
 
       pswp?.ui?.registerElement({
         name: "copy-button",
-        order: 7,
+        order: 8,
         isButton: true,
         tagName: "button",
+        title: t("actions.copy"),
         html: '<i class="fa fa-copy"></i>',
         onClick: (_event, _el, pswp) => {
           const url = pswp.currSlide?.data.src;

--- a/app/frontend/stylesheets/shared/vendor/pswp.scss
+++ b/app/frontend/stylesheets/shared/vendor/pswp.scss
@@ -1,4 +1,15 @@
 .pswp {
+  /*
+   * Into the app's z-index scale, from a vendor default of 100000 that sat far
+   * outside it. High enough to cover the page chrome it takes over from - the
+   * mobile navigation and NetworkStatus at 2000, OffCanvas at 2020, AppConfirm
+   * and HoloViewer at 2050, and the dropdown and Fleetchart layers at 2100 -
+   * and below Loader (3000) and AppNotifications (3100), which have to be able
+   * to report over it. The copy button confirms only through a notification, so
+   * at 100000 that confirmation was painted underneath the viewer.
+   */
+  --pswp-root-z-index: 2200;
+
   .pswp__button {
     transition: all ease 0.5s;
   }

--- a/app/frontend/stylesheets/shared/vendor/pswp.scss
+++ b/app/frontend/stylesheets/shared/vendor/pswp.scss
@@ -1,3 +1,16 @@
+/*
+ * PhotoSwipe, wearing the app's own control language.
+ *
+ * The lightbox shipped as stock vendor chrome: bare 50x60 hit areas with white
+ * glyphs outlined in grey, and a full-bleed black caption band. Nothing in it
+ * came from the design system, so the one surface that covers the whole page
+ * was the one surface that looked like a different product.
+ *
+ * Values are taken from Btn and Panel rather than designed fresh - a control in
+ * the viewer and a control on the page behind it are one motif. The var()
+ * fallbacks are spelled out throughout because this is a plain stylesheet, not
+ * a Tailwind-processed one: a bare var() gets no fallback inlined for it here.
+ */
 .pswp {
   /*
    * Into the app's z-index scale, from a vendor default of 100000 that sat far
@@ -10,19 +23,221 @@
    */
   --pswp-root-z-index: 2200;
 
+  /* --pswp-bg stays #000, which is already $background. */
+  --pswp-placeholder-bg: var(--color-gray-black, #222);
+
+  --pswp-icon-color: var(--color-text, #c8c8c8);
+
+  /*
+   * Only the zoom icon reads this, for the two bars that draw its plus and
+   * minus. They have to read as cut-outs in the magnifier glass, so this is the
+   * backdrop the unfilled button shows through to rather than the ink - at the
+   * ink colour the bars merge into the glass and the button loses the one thing
+   * that tells zoom-in from zoom-out.
+   */
+  --pswp-icon-color-secondary: var(--color-background, #000);
+
+  /*
+   * pswp outlines every glyph in grey so it survives a photo showing through
+   * the chrome. The backdrop is opaque and the glyphs now sit on a framed
+   * control, so the outline only thickens them.
+   */
+  --pswp-icon-stroke-width: 0;
+
+  --pswp-error-text-color: var(--color-text, #c8c8c8);
+  --pswp-preloader-color: var(--color-edge-soft, rgb(122 130 136 / 0.28));
+  --pswp-preloader-color-secondary: var(--color-primary, #428bca);
+
+  /* The inset the chrome keeps from the viewport edge, and the control size it
+     is built on - Btn's `sm`, so the viewer's buttons are the app's buttons. */
+  --viewer-gutter: 16px;
+  --viewer-btn: var(--field-h, 43px);
+
+  .pswp__top-bar {
+    height: auto;
+    padding: var(--viewer-gutter, 16px);
+    gap: 8px;
+    align-items: center;
+  }
+
+  /* pswp ships 6px here to part the close button from the zoom button. The bar
+     owns its spacing through `gap` now, so this would double one seam. */
+  .pswp__button--close {
+    margin-right: 0;
+  }
+
   .pswp__button {
-    transition: all ease 0.5s;
+    /*
+     * Deliberately no `display`. pswp hides the zoom button until zoom is
+     * allowed, and hides a disabled arrow, using `display: none` on a single
+     * class - which any rule nested in `.pswp` outranks. Centring is done by
+     * the absolutely positioned glyph instead, so pswp keeps control of what
+     * shows.
+     */
+    width: var(--viewer-btn, 43px);
+    height: var(--viewer-btn, 43px);
+
+    /* pswp ships .85 and lifts it to 1 on hover - a second hover channel on a
+       control whose wash already answers. */
+    opacity: 1;
+
+    /*
+     * Btn's `bare`: no fill, no drawn edge and no end-cap, so nothing frames
+     * the picture and the chrome is only the glyphs until you reach for one.
+     * The border stays declared but transparent, the way Btn does it, so the
+     * box does not resize on the states below.
+     */
+    background-color: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-control-bare, 6px);
+    color: var(--color-text, #c8c8c8);
+
+    /*
+     * Was `all ease 0.5s`. Half a second is what made the toolbar feel
+     * detached from the cursor, and `all` drags layout properties into the
+     * transition; 150ms on the painted properties is where Btn and Panel
+     * landed for the same reason.
+     */
+    transition:
+      background-color 150ms ease-in-out,
+      border-color 150ms ease-in-out,
+      color 150ms ease-in-out;
+
+    /*
+     * Position and size only. The ink stays on pswp's own --pswp-icon-color
+     * pair, which the states below re-point; setting `fill` and `color` here
+     * would take the zoom icon's bars with it and flatten it into a blob.
+     */
+    .pswp__icn {
+      position: absolute;
+      inset: 0;
+      margin: auto;
+      width: 32px;
+      height: 32px;
+    }
+
+    /*
+     * The download and copy buttons carry a Font Awesome glyph rather than
+     * pswp's SVG sprite. Pinned to 16px because the sprites draw their glyph
+     * 16px inside a 32px viewBox, and because Tailwind's preflight gives a
+     * button `font: inherit` - without this the two would take whatever size
+     * the page body happens to run at.
+     */
+    > .fa {
+      position: absolute;
+      inset: 0;
+      margin: auto;
+      width: 16px;
+      height: 16px;
+      font-size: 16px;
+      line-height: 1;
+    }
+
+    /*
+     * The whole state, which for `bare` is a faint wash and lifted ink rather
+     * than a cap - it has no cap to light. The wash is Btn's literal, which
+     * has no token of its own.
+     */
+    &:hover:not(:disabled),
+    &:focus-visible {
+      background-color: rgb(122 130 136 / 0.12);
+      /* `color` lifts the Font Awesome glyphs, the variable lifts the sprites. */
+      color: var(--color-lifted, #eee);
+      --pswp-icon-color: var(--color-lifted, #eee);
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: auto;
+    }
+  }
+
+  .pswp__button--arrow {
+    width: var(--viewer-btn, 43px);
+    height: var(--viewer-btn, 43px);
+    top: 50%;
+    margin-top: calc(var(--viewer-btn, 43px) / -2);
+  }
+
+  .pswp__button--arrow--prev {
+    left: var(--viewer-gutter, 16px);
+    right: auto;
+  }
+
+  .pswp__button--arrow--next {
+    right: var(--viewer-gutter, 16px);
+    left: auto;
+  }
+
+  /*
+   * The chevron is drawn inside a 60px viewBox rather than the 32px the top-bar
+   * sprites use, so it takes its own size to land on the same optical weight.
+   * Its path spans x 10-29 of that 60, which leaves the glyph 10.5 units - 17.5%
+   * of the box - left of centre. pswp absorbed that with a `right: 14px` tuned
+   * to its own 75px-wide arrow button; at this size the correction has to be
+   * proportional, and the flip makes it symmetrical for the next arrow.
+   */
+  .pswp__button--arrow .pswp__icn {
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 36px;
+    height: 36px;
+    margin: auto;
+    transform: translateX(17.5%);
+  }
+
+  .pswp__button--arrow--next .pswp__icn {
+    transform: scale(-1, 1) translateX(17.5%);
+  }
+
+  /* Dormant while `counter` is off in useGallery, but pswp owns the element and
+     it should not come back wearing vendor styling if it is ever turned on. */
+  .pswp__counter {
+    height: auto;
+    margin: 0 auto 0 0;
+    padding: 0 4px;
+    font-size: 15px;
+    line-height: var(--viewer-btn, 43px);
+    color: var(--color-text, #c8c8c8);
+    /* pswp shadows the counter to survive a photo behind it; ours is opaque. */
+    text-shadow: none;
+    opacity: 1;
   }
 
   .pswp__custom-caption {
-    font-size: 16px;
-    line-height: 1.5;
-    color: white;
-    text-align: center;
     position: absolute;
-    bottom: 0;
-    padding: 10px;
-    width: 100vw;
-    background-color: rgba(0, 0, 0, 0.5);
+    left: 50%;
+    bottom: calc(var(--viewer-gutter, 16px) + 8px);
+    transform: translateX(-50%);
+
+    /*
+     * Was a `width: 100vw` band flush against the bottom edge, which set no
+     * reading measure and read as a browser artefact rather than as part of the
+     * app. A panel held to a line length that can be read is what the rest of
+     * the app does with prose.
+     */
+    width: max-content;
+    max-width: min(72ch, calc(100% - (var(--viewer-gutter, 16px) * 2)));
+    padding: 10px 16px;
+
+    font-size: 15px;
+    line-height: 1.5;
+    text-align: center;
+    text-wrap: pretty;
+    /* Was #fff - the one place in the viewer that set pure white for body copy. */
+    color: var(--color-text, #c8c8c8);
+
+    background-color: var(--color-surface, rgb(39 43 48 / 0.9));
+    border: 1px solid var(--color-edge-soft, rgb(122 130 136 / 0.28));
+    border-radius: var(--radius-surface-slim, 12px);
+    box-shadow: var(--shadow-surface-slim, 0 6px 20px -14px rgb(0 0 0 / 0.9));
+
+    /* An uncaptioned image still gets the element, so without this it sits
+       there as a small empty box. */
+    &:empty {
+      display: none;
+    }
   }
 }

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -35,6 +35,8 @@
       "back": "Zurück",
       "open": "Öffnen",
       "copy": "Kopieren",
+      "download": "Herunterladen",
+      "zoom": "Zoom",
       "more": "Mehr...",
       "showMore": "Mehr anzeigen",
       "export": "Export",

--- a/app/frontend/translations/de/errors.json
+++ b/app/frontend/translations/de/errors.json
@@ -2,6 +2,7 @@
   "de": {
     "errors": {
       "generic": "Ein Fehler ist aufgetreten",
+      "imageNotLoaded": "Das Bild konnte nicht geladen werden.",
       "upload": {
         "oneFile": "Es kann nur eine Datei gleichzeitig hochgeladen werden.",
         "generic": "Beim Hochladen ist ein Fehler aufgetreten.",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -35,6 +35,8 @@
       "back": "Back",
       "open": "Open",
       "copy": "Copy",
+      "download": "Download",
+      "zoom": "Zoom",
       "more": "More...",
       "showMore": "Show more",
       "export": "Export",

--- a/app/frontend/translations/en/errors.json
+++ b/app/frontend/translations/en/errors.json
@@ -2,6 +2,7 @@
   "en": {
     "errors": {
       "generic": "An error occurred",
+      "imageNotLoaded": "The image could not be loaded.",
       "upload": {
         "oneFile": "Only one file can be uploaded at a time.",
         "generic": "An error occurred during the upload.",

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -35,6 +35,8 @@
       "back": "Atrás",
       "open": "Abrir",
       "copy": "Copiar",
+      "download": "Descargar",
+      "zoom": "Zoom",
       "more": "Más...",
       "showMore": "Mostrar más",
       "export": "Exportar",

--- a/app/frontend/translations/es/errors.json
+++ b/app/frontend/translations/es/errors.json
@@ -2,6 +2,7 @@
   "es": {
     "errors": {
       "generic": "Se produjo un error",
+      "imageNotLoaded": "No se pudo cargar la imagen.",
       "upload": {
         "oneFile": "Solo se puede subir un archivo a la vez.",
         "generic": "Se produjo un error durante la subida.",

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -35,6 +35,8 @@
       "back": "Précédent",
       "open": "Ouvrir",
       "copy": "Copier",
+      "download": "Télécharger",
+      "zoom": "Zoom",
       "more": "Détails...",
       "showMore": "Afficher plus",
       "export": "Exporter",

--- a/app/frontend/translations/fr/errors.json
+++ b/app/frontend/translations/fr/errors.json
@@ -2,6 +2,7 @@
   "fr": {
     "errors": {
       "generic": "Une erreur s'est produite",
+      "imageNotLoaded": "L'image n'a pas pu être chargée.",
       "upload": {
         "oneFile": "Un seul fichier peut être téléchargé à la fois.",
         "generic": "Une erreur s'est produite lors du téléchargement.",

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -35,6 +35,8 @@
       "back": "Indietro",
       "open": "Apri",
       "copy": "Copia",
+      "download": "Scarica",
+      "zoom": "Zoom",
       "more": "Di più...",
       "showMore": "Mostra altro",
       "export": "Esporta",

--- a/app/frontend/translations/it/errors.json
+++ b/app/frontend/translations/it/errors.json
@@ -2,6 +2,7 @@
   "it": {
     "errors": {
       "generic": "Si è verificato un errore",
+      "imageNotLoaded": "Impossibile caricare l'immagine.",
       "upload": {
         "oneFile": "È possibile caricare un solo file alla volta.",
         "generic": "Si è verificato un errore durante il caricamento.",

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -35,6 +35,8 @@
       "back": "返回",
       "open": "打开",
       "copy": "复制",
+      "download": "下载",
+      "zoom": "缩放",
       "more": "更多...",
       "showMore": "显示更多",
       "export": "导出",

--- a/app/frontend/translations/zh-CN/errors.json
+++ b/app/frontend/translations/zh-CN/errors.json
@@ -2,6 +2,7 @@
   "zh-CN": {
     "errors": {
       "generic": "发生了错误",
+      "imageNotLoaded": "无法加载图片。",
       "upload": {
         "oneFile": "一次只能上传一个文件。",
         "generic": "上传过程中发生了错误。",

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -35,6 +35,8 @@
       "back": "返回",
       "open": "開啟",
       "copy": "複製",
+      "download": "下載",
+      "zoom": "縮放",
       "more": "更多...",
       "showMore": "顯示更多",
       "export": "匯出",

--- a/app/frontend/translations/zh-TW/errors.json
+++ b/app/frontend/translations/zh-TW/errors.json
@@ -2,6 +2,7 @@
   "zh-TW": {
     "errors": {
       "generic": "發生了錯誤",
+      "imageNotLoaded": "無法載入圖片。",
       "upload": {
         "oneFile": "一次只能上傳一個檔案。",
         "generic": "上傳過程中發生了錯誤。",


### PR DESCRIPTION
The image viewer was stock PhotoSwipe under a 17-line override, so the one surface that covers the whole page was the one surface that didn't look like the app. Bringing it into line turned up two functional bugs on the way, which are the first two commits.

## The copy button never copied anything

`copyText` hands clipboard.js a throwaway textarea to select and copy from, and clipboard.js appends it to the container it is given — `document.body` by default. PhotoSwipe traps focus inside its own root while it is open, so a textarea parked in `body` never takes the selection and `execCommand("copy")` copies an empty one.

It still returns true, so clipboard.js emitted `success` and the promise resolved: the viewer cheerfully reported *"Image URL Copied!"* over an unchanged clipboard.

Measured against real PhotoSwipe and real clipboard.js, with a control to rule out a headless-browser artefact:

| | clipboard afterwards |
|---|---|
| control, no lightbox open | `CONTROL-VALUE` ✅ |
| in the lightbox, `container: document.body` | `SENTINEL` ❌ |
| in the lightbox, `container: pswp.element` | `a.png` ✅ |

`copyText` already accepts the container as its second argument — the call site just never passed one.

## Notifications were painted under the viewer

`AppNotifications` sat at `z-index: 1100`, below **seven** other layers — the mobile navigation and NetworkStatus (2000), OffCanvas (2020), AppConfirm and HoloViewer (2050), BtnDropdown, Select and Fleetchart (2100) and Loader (3000) — and below PhotoSwipe, which shipped at its vendor default of 100000, far outside the app's scale.

In the viewer that is load-bearing rather than untidy: copying an image URL confirms *only* through a notification, so even once the copy worked the button still read as doing nothing. Notifications move to the top of the scale, and PhotoSwipe comes into it at 2200 — above the page chrome it takes over from, below the two layers that have to be able to report over it.

## The restyle

The buttons take `Btn`'s `bare` variant: no fill, no drawn edge, no end-cap, the same radius, and a faint wash with lifted ink on hover and focus. The toolbar previously ran two icon systems side by side — copy and download as 16px Font Awesome glyphs in the body colour, close/zoom/arrows as 32px white SVG sprites outlined in grey — now pinned to one optical size, with pswp's glyph outline dropped since it exists for chrome sitting over a photo rather than over an opaque backdrop. The caption becomes a surface panel held to a reading measure instead of a full-bleed band the width of the viewport, and hides itself rather than standing as an empty box on an uncaptioned image. `transition: all ease 0.5s` becomes 150ms on the painted properties, the timing `Btn` and `Panel` moved to.

Two details worth a reviewer's attention:

- **Nothing sets `display` on a button.** pswp hides the zoom button until zoom is allowed, and hides a disabled arrow, with `display: none` on a single class — which any rule nested in `.pswp` would outrank. The glyph is centred by position instead, and all five of pswp's show/hide states were checked to still hold.
- **The arrow chevron is drawn 17.5% off-centre in its own viewBox.** pswp corrected that with an offset tuned to its 75px-wide arrow button, so at this size the correction has to be proportional.

## Accessibility and i18n

The copy and download buttons were registered with no `title`, so they had no tooltip and no accessible name — a screen reader announced two empty buttons. pswp's own close, zoom and arrow titles, and the message shown when an image fails to load, default to hardcoded English, so the rest of the chrome was untranslated in a six-language app. Adds `actions.download`, `actions.zoom` and `errors.imageNotLoaded` across all seven locales.

The copy button also moves off `order: 7`, which is where PhotoSwipe puts its own preloader — the two shared a slot and settled it by registration order.

## Coverage

The viewer had none of any kind: no visual-tests page, and `Images.spec.ts` only asserts the grid loads without ever opening the lightbox. That is how it drifted this far, so this adds a *Gallery | Lightbox* section to `visual-tests/media` covering the short, wrapping and absent caption cases.

## Not included

`stylesheets/frontend/base.scss:1` reads `bas:root {` — a stray `bas` prefix that makes the selector match nothing, so `color-scheme: light dark` is dead on the frontend. Admin and docs have `:root` correctly. Fixing it changes native control and scrollbar rendering app-wide, so it wants its own PR rather than riding along here.

`counter: false` is left as it is — a deliberate call, though a 48-image gallery currently gives no position cue. The stylesheet is ready if we ever flip it.

🤖
