### PR TITLE
feat(sc_data): keep the tags a port and an item match on

### DIFF
--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -305,7 +305,10 @@ module ScData
       # rows match it -- two jobs that used to be one recursive method that wrote
       # as it walked, which is why the rules could not be exercised without a
       # database and why the destructive cleanup sat in the middle of them.
-      Slot = Struct.new(:name, :component, :children, :retain_only, :min_size, :max_size, :types)
+      Slot = Struct.new(
+        :name, :component, :children, :retain_only,
+        :min_size, :max_size, :types, :port_tags, :required_tags, :flags
+      )
 
       private def update_loadout(parent, loadout, cleanup: true)
         # The module-key derivation below only applies to a ship. A module's own
@@ -342,7 +345,10 @@ module ScData
             children: nested_slots(item),
             min_size: item["min_size"],
             max_size: item["max_size"],
-            types: item["types"]
+            types: item["types"],
+            port_tags: item["port_tags"],
+            required_tags: item["required_tags"],
+            flags: item["flags"]
           )
         ]
       end
@@ -447,6 +453,9 @@ module ScData
 
         update_params = {source: :game_files, component: slot.component}
         update_params[:types] = slot.types if slot.types.present?
+        update_params[:port_tags] = slot.port_tags if slot.port_tags.present?
+        update_params[:required_tags] = slot.required_tags if slot.required_tags.present?
+        update_params[:flags] = slot.flags if slot.flags.present?
         update_params.merge!(slot_sizes(slot))
 
         apply(hardpoint, update_params)

--- a/app/lib/sc_data/loader/items_loader.rb
+++ b/app/lib/sc_data/loader/items_loader.rb
@@ -21,6 +21,8 @@ module ScData
             category: item["category"],
             component_type: item["type"],
             component_sub_type: item["sub_type"],
+            tags: item["tags"],
+            required_tags: item["required_tags"],
             size: item["size"],
             grade: item["grade"],
             description: item["description"]
@@ -152,7 +154,10 @@ module ScData
             source: :game_files,
             min_size: loadout["min_size"],
             max_size: loadout["max_size"],
-            types: loadout["types"]
+            types: loadout["types"],
+            port_tags: loadout["port_tags"],
+            required_tags: loadout["required_tags"],
+            flags: loadout["flags"]
           }
 
           if default_loadout.present?

--- a/app/lib/sc_data/parser/base_parser.rb
+++ b/app/lib/sc_data/parser/base_parser.rb
@@ -263,6 +263,16 @@ module ScData
         data
       end
 
+      # A port and the item that fits it name the same tag, but not in the same
+      # spelling: the Retaliator's front rack carries `$Retaliator_BombRack_Front`
+      # and requires `Retaliator_BombRack_Front`, while the port it fits is the
+      # other way round. The `$` marks a tag as taking part in matching rather
+      # than being part of the tag, so it is dropped -- left on, the two sides
+      # never compare equal. Flags are the same shape (`$uneditable`).
+      private def normalize_tags(value)
+        value.to_s.split.map { |tag| tag.delete_prefix("$") }.uniq
+      end
+
       private def value_or_nil(value)
         if value == "<= PLACEHOLDER =>" ||
             value == "UNDEFINED" ||

--- a/app/lib/sc_data/parser/items_parser.rb
+++ b/app/lib/sc_data/parser/items_parser.rb
@@ -106,6 +106,8 @@ module ScData
           ref: value_or_nil(values.dig("__ref")),
           category: category,
           type: type,
+          tags: normalize_tags(tags),
+          required_tags: normalize_tags(values.dig("Components", "SAttachableComponentParams", "AttachDef", "RequiredTags")),
           sub_type: value_or_nil(values.dig("Components", "SAttachableComponentParams", "AttachDef", "SubType")),
           size: values.dig("Components", "SAttachableComponentParams", "AttachDef", "Size"),
           grade: values.dig("Components", "SAttachableComponentParams", "AttachDef", "Grade"),
@@ -681,6 +683,9 @@ module ScData
             name:,
             min_size: item.dig("MinSize"),
             max_size: item.dig("MaxSize"),
+            port_tags: normalize_tags(item.dig("PortTags")),
+            required_tags: normalize_tags(item.dig("RequiredPortTags")),
+            flags: normalize_tags(item.dig("Flags")),
             types: types.map do |type|
               type.dig("Type")
             end

--- a/app/lib/sc_data/parser/models_parser.rb
+++ b/app/lib/sc_data/parser/models_parser.rb
@@ -220,6 +220,9 @@ module ScData
           index[name] ||= {
             min_size: port["MinSize"],
             max_size: port["MaxSize"],
+            port_tags: normalize_tags(port["PortTags"]),
+            required_tags: normalize_tags(port["RequiredPortTags"]),
+            flags: normalize_tags(port["Flags"]),
             types: extract_port_def_types(port)
           }
         end
@@ -266,6 +269,9 @@ module ScData
             ports[node["name"]] ||= {
               min_size: item_port["minSize"],
               max_size: item_port["maxSize"],
+              port_tags: normalize_tags(item_port["portTags"]),
+              required_tags: normalize_tags(item_port["requiredTags"]),
+              flags: normalize_tags(item_port["flags"]),
               types: extract_item_port_types(item_port)
             }
           end

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -20,10 +20,12 @@
 #  item_type             :string
 #  name                  :string(255)
 #  power_connection      :string
+#  required_tags         :string
 #  sc_key                :string
 #  sc_ref                :string
 #  size                  :string(255)
 #  slug                  :string
+#  tags                  :string
 #  tracking_signal       :integer
 #  type_data             :string
 #  version               :string
@@ -72,6 +74,13 @@ class Component < ApplicationRecord
       reason: :update_reason,
       reason_description: :update_reason_description
     }
+
+  # The tags an item carries and the tags it demands of the port it goes into.
+  # A port and the item that fits it name a shared tag -- how the Eclipse's
+  # ordnance port takes its own bomb racks and not the Gladiator's. Stored as a
+  # serialised array, the way `Hardpoint#types` is.
+  serialize :tags, type: Array, coder: JSON
+  serialize :required_tags, type: Array, coder: JSON
 
   belongs_to :manufacturer, optional: true
 

--- a/app/models/component_build.rb
+++ b/app/models/component_build.rb
@@ -21,7 +21,9 @@
 #  item_type             :string
 #  name                  :string
 #  power_connection      :string
+#  required_tags         :string
 #  size                  :string
+#  tags                  :string
 #  tracking_signal       :integer
 #  type_data             :string
 #  version               :string           not null
@@ -103,6 +105,11 @@ class ComponentBuild < ApplicationRecord
   serialize :heat_connection, coder: YAML
   serialize :ammunition, coder: YAML
   serialize :inventory_consumption, coder: YAML
+
+  # JSON rather than YAML, matching Component: these two are lists of tags, and
+  # a build has to read back the same shape the column does.
+  serialize :tags, type: Array, coder: JSON
+  serialize :required_tags, type: Array, coder: JSON
 
   enum :item_class,
     {stealth: 0, civilian: 1, industrial: 2, military: 3, competition: 4}

--- a/app/models/hardpoint.rb
+++ b/app/models/hardpoint.rb
@@ -2,22 +2,25 @@
 #
 # Table name: hardpoints
 #
-#  id           :uuid             not null, primary key
-#  category     :integer
-#  details      :string
-#  group        :integer
-#  group_key    :string
-#  matrix_key   :string
-#  max_size     :integer
-#  min_size     :integer
-#  parent_type  :string           not null
-#  sc_name      :string
-#  source       :integer
-#  types        :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  component_id :uuid
-#  parent_id    :uuid             not null
+#  id            :uuid             not null, primary key
+#  category      :integer
+#  details       :string
+#  flags         :string
+#  group         :integer
+#  group_key     :string
+#  matrix_key    :string
+#  max_size      :integer
+#  min_size      :integer
+#  parent_type   :string           not null
+#  port_tags     :string
+#  required_tags :string
+#  sc_name       :string
+#  source        :integer
+#  types         :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  component_id  :uuid
+#  parent_id     :uuid             not null
 #
 # Indexes
 #
@@ -40,6 +43,12 @@ class Hardpoint < ApplicationRecord
   # an array of strings. Read back as one, so the two agree. Every value ever
   # written is already valid JSON, so nothing needs rewriting.
   serialize :types, type: Array, coder: JSON
+
+  # What the port carries, what it demands of whatever is put in it, and whether
+  # it may be changed at all. Same storage as `types` above.
+  serialize :port_tags, type: Array, coder: JSON
+  serialize :required_tags, type: Array, coder: JSON
+  serialize :flags, type: Array, coder: JSON
 
   belongs_to :parent, polymorphic: true, touch: true
   belongs_to :component, optional: true

--- a/db/migrate/20260907132814_add_port_tags_to_hardpoints_and_components.rb
+++ b/db/migrate/20260907132814_add_port_tags_to_hardpoints_and_components.rb
@@ -1,0 +1,23 @@
+class AddPortTagsToHardpointsAndComponents < ActiveRecord::Migration[8.1]
+  # What a port accepts is not only a type and a size. A port and the item that
+  # fits it name a shared tag -- the Eclipse's ordnance port and its three bomb
+  # racks all name `Eclipse_BombRack` -- and without those, a port that takes an
+  # S3-S10 bomb launcher matches the Gladiator's and the Retaliator's racks just
+  # as well as its own.
+  #
+  # Strings holding a serialised array, which is how `types` already stores the
+  # same shape.
+  def change
+    add_column :hardpoints, :port_tags, :string
+    add_column :hardpoints, :required_tags, :string
+    add_column :hardpoints, :flags, :string
+
+    add_column :components, :tags, :string
+    add_column :components, :required_tags, :string
+
+    # The items loader writes every component attribute to the build as well as
+    # to the row, so a column the loader sets has to exist on both.
+    add_column :component_builds, :tags, :string
+    add_column :component_builds, :required_tags, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_03_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_07_132814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -247,7 +247,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_200000) do
     t.uuid "manufacturer_id"
     t.string "name"
     t.string "power_connection"
+    t.string "required_tags"
     t.string "size"
+    t.string "tags"
     t.integer "tracking_signal"
     t.string "type_data"
     t.datetime "updated_at", null: false
@@ -278,10 +280,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_200000) do
     t.uuid "manufacturer_id"
     t.string "name", limit: 255
     t.string "power_connection"
+    t.string "required_tags"
     t.string "sc_key"
     t.string "sc_ref"
     t.string "size", limit: 255
     t.string "slug"
+    t.string "tags"
     t.integer "tracking_signal"
     t.string "type_data"
     t.datetime "updated_at", precision: nil
@@ -768,6 +772,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_200000) do
     t.uuid "component_id"
     t.datetime "created_at", null: false
     t.string "details"
+    t.string "flags"
     t.integer "group"
     t.string "group_key"
     t.string "matrix_key"
@@ -775,6 +780,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_03_200000) do
     t.integer "min_size"
     t.uuid "parent_id", null: false
     t.string "parent_type", null: false
+    t.string "port_tags"
+    t.string "required_tags"
     t.string "sc_name"
     t.integer "source"
     t.string "types"

--- a/test/factories/component_builds.rb
+++ b/test/factories/component_builds.rb
@@ -19,7 +19,9 @@
 #  item_type             :string
 #  name                  :string
 #  power_connection      :string
+#  required_tags         :string
 #  size                  :string
+#  tags                  :string
 #  tracking_signal       :integer
 #  type_data             :string
 #  version               :string           not null

--- a/test/factories/components.rb
+++ b/test/factories/components.rb
@@ -18,10 +18,12 @@
 #  item_type             :string
 #  name                  :string(255)
 #  power_connection      :string
+#  required_tags         :string
 #  sc_key                :string
 #  sc_ref                :string
 #  size                  :string(255)
 #  slug                  :string
+#  tags                  :string
 #  tracking_signal       :integer
 #  type_data             :string
 #  version               :string

--- a/test/factories/hardpoints.rb
+++ b/test/factories/hardpoints.rb
@@ -2,22 +2,25 @@
 #
 # Table name: hardpoints
 #
-#  id           :uuid             not null, primary key
-#  category     :integer
-#  details      :string
-#  group        :integer
-#  group_key    :string
-#  matrix_key   :string
-#  max_size     :integer
-#  min_size     :integer
-#  parent_type  :string           not null
-#  sc_name      :string
-#  source       :integer
-#  types        :string
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  component_id :uuid
-#  parent_id    :uuid             not null
+#  id            :uuid             not null, primary key
+#  category      :integer
+#  details       :string
+#  flags         :string
+#  group         :integer
+#  group_key     :string
+#  matrix_key    :string
+#  max_size      :integer
+#  min_size      :integer
+#  parent_type   :string           not null
+#  port_tags     :string
+#  required_tags :string
+#  sc_name       :string
+#  source        :integer
+#  types         :string
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  component_id  :uuid
+#  parent_id     :uuid             not null
 #
 # Indexes
 #

--- a/test/loaders/sc_data/base_loader_loadout_test.rb
+++ b/test/loaders/sc_data/base_loader_loadout_test.rb
@@ -83,6 +83,35 @@ module ScData
         assert_equal 9, hardpoint.max_size
       end
 
+      # Which of the nine bomb racks a port takes is decided by a tag, not by
+      # the type and size it shares with the other eight.
+      test "persists the tags a port names and whether it may be changed" do
+        create(:component, sc_key: "torpedo_rack_s9", size: "9")
+
+        update_loadout(@model, {"loadout" => [{
+          "name" => "hardpoint_torpedorack",
+          "key" => "torpedo_rack_s9",
+          "port_tags" => ["Eclipse_BombRack"],
+          "required_tags" => ["Eclipse_BombRack"],
+          "flags" => ["editable", "swaponly"]
+        }]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        assert_equal ["Eclipse_BombRack"], hardpoint.port_tags
+        assert_equal ["Eclipse_BombRack"], hardpoint.required_tags
+        assert_equal ["editable", "swaponly"], hardpoint.flags
+      end
+
+      test "leaves the tags alone for a port that names none" do
+        create(:component, sc_key: "cooler_s1", size: "1")
+
+        update_loadout(@model, {"loadout" => [{"name" => "hardpoint_cooler", "key" => "cooler_s1"}]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        assert_equal [], hardpoint.port_tags
+        assert_equal [], hardpoint.flags
+      end
+
       # The size shown for a port stays the size of what is in it: the files
       # carry ports declared 0-0 holding an S1 door, so the declaration only
       # gets to lower the floor.

--- a/test/models/component_build_test.rb
+++ b/test/models/component_build_test.rb
@@ -23,7 +23,9 @@ require "test_helper"
 #  item_type             :string
 #  name                  :string
 #  power_connection      :string
+#  required_tags         :string
 #  size                  :string
+#  tags                  :string
 #  tracking_signal       :integer
 #  type_data             :string
 #  version               :string           not null

--- a/test/models/component_test.rb
+++ b/test/models/component_test.rb
@@ -22,10 +22,12 @@ require "test_helper"
 #  item_type             :string
 #  name                  :string(255)
 #  power_connection      :string
+#  required_tags         :string
 #  sc_key                :string
 #  sc_ref                :string
 #  size                  :string(255)
 #  slug                  :string
+#  tags                  :string
 #  tracking_signal       :integer
 #  type_data             :string
 #  version               :string

--- a/test/parsers/sc_data/base_parser_test.rb
+++ b/test/parsers/sc_data/base_parser_test.rb
@@ -141,6 +141,26 @@ module ScData
         assert_nil @parser.send(:save_icon, "ui/logos/acme_256.tif")
       end
 
+      # A port and the item that fits it name the same tag in different
+      # spellings -- one side marks it with a `$`, the other does not -- and the
+      # whole point of the tag is that the two sides compare equal.
+      test "#normalize_tags drops the marker the files put on a matched tag" do
+        assert_equal ["Eclipse_BombRack"], @parser.send(:normalize_tags, "$Eclipse_BombRack")
+        assert_equal ["Eclipse_BombRack"], @parser.send(:normalize_tags, "Eclipse_BombRack")
+      end
+
+      test "#normalize_tags splits a list and keeps each tag once" do
+        assert_equal(
+          ["flightReady", "Retaliator_BombRack_Front"],
+          @parser.send(:normalize_tags, "flightReady $Retaliator_BombRack_Front flightReady")
+        )
+      end
+
+      test "#normalize_tags answers an empty list for a port that names none" do
+        assert_equal [], @parser.send(:normalize_tags, nil)
+        assert_equal [], @parser.send(:normalize_tags, "")
+      end
+
       private def write_asset(path, contents)
         target = "#{@base_folder}/raw/1.0.0/Data/#{path}"
 

--- a/test/parsers/sc_data/models_parser_test.rb
+++ b/test/parsers/sc_data/models_parser_test.rb
@@ -50,6 +50,25 @@ module ScData
         assert_equal ["MissileLauncher", "BombLauncher"], port["types"]
       end
 
+      # A type and a size are not enough to tell the Eclipse's racks from the
+      # Gladiator's -- both are S3-S5 bomb launchers. The shared tag is, and the
+      # flags say whether the port may be changed at all.
+      test "carries the tags and flags a ship's own definition declares" do
+        port = ports.fetch("hardpoint_torpedorack")
+
+        assert_equal ["Eclipse_BombRack"], port["port_tags"]
+        assert_equal ["Eclipse_BombRack"], port["required_tags"]
+        assert_equal ["editable", "swaponly"], port["flags"]
+      end
+
+      test "carries the tags and flags the entity record declares" do
+        port = ports.fetch("hardpoint_relay")
+
+        assert_equal ["Relay_Bay"], port["port_tags"]
+        assert_equal ["Relay_Bay"], port["required_tags"]
+        assert_equal ["uneditable"], port["flags"]
+      end
+
       # The entity record declares a handful of ports of its own rather than in
       # the vehicle definition, so both sources have to be read.
       test "carries what the entity record declares for its own ports" do
@@ -77,7 +96,7 @@ module ScData
               <VehicleComponentParams vehicleName="@vehicle_NameTEST_Bomber" vehicleDefinition="#{DEFINITION_PATH}" />
               <SItemPortContainerComponentParams>
                 <Ports>
-                  <SItemPortDef Name="hardpoint_relay" MinSize="0" MaxSize="1">
+                  <SItemPortDef Name="hardpoint_relay" MinSize="0" MaxSize="1" PortTags="Relay_Bay" RequiredPortTags="$Relay_Bay" Flags="$uneditable">
                     <Types>
                       <SItemPortDefTypes Type="Relay" />
                     </Types>
@@ -115,7 +134,7 @@ module ScData
               <Part name="body" class="Animated" damageMax="1000">
                 <Parts>
                   <Part name="hardpoint_torpedorack" class="ItemPort">
-                    <ItemPort minSize="3" maxSize="10" flags="editable $swaponly">
+                    <ItemPort minSize="3" maxSize="10" flags="editable $swaponly" portTags="Eclipse_BombRack" requiredTags="$Eclipse_BombRack">
                       <Types>
                         <Type type="MissileLauncher" subtypes="MissileRack" />
                         <Type type="BombLauncher" subtypes="BombRack" />


### PR DESCRIPTION
The other half of what a port declares. #4740 kept the type and the size range; those turn out not to say which item fits.

## The numbers

The Eclipse's ordnance port takes an S3–S10 missile or bomb launcher — and so do the Gladiator's and the Retaliator's. Measured against all 165 racks in the 4.10 files:

| Port | By type and size | With tags |
| --- | --- | --- |
| Eclipse `hardpoint_torpedorack` (S3–S10) | 130 candidates | **4** |
| Gladiator `hardpoint_ordnance_bay` (S3–S5) | 95 candidates | **3** |

The four are the Eclipse's own S3/S5/S10 bomb racks plus its torpedo rack; the three are the Gladiator's two bomb racks plus its quad missile rack. Exactly what each ship takes. Without tags a picker would have offered the Eclipse 130 options, most of them other ships' hardware — wrong rather than merely incomplete.

## How the matching works

Both sides declare, in both directions:

- the port demands a tag of the item (`requiredTags`) and carries one for the item to demand (`portTags`)
- the item mirrors that in `Tags` and `RequiredTags`

The Eclipse's port and its racks all name `Eclipse_BombRack`; the Gladiator's name `Gladiator_BombRack`; the Retaliator's front and rear bays name separate tags so a rear rack cannot go in the front bay. One generic BEHR rack carries no ship tag at all, which is how it stays out of all three.

The two sides spell the same tag differently — one marks it with a `$` — so the marker is dropped on the way in. Left on, the sides never compare equal, and that is the whole point of the tag.

## Flags

A port also says whether it may be changed at all (`editable`, `$uneditable`). That is the difference between a slot worth offering a choice for and one that only looks like it, so it comes along in the same pass rather than costing a second re-parse.

## Where the attributes live

Three sources, three spellings, all three read:

- a ship's ports — its vehicle implementation XML (`portTags`, `requiredTags`, `flags`)
- an item's ports — the Foundry record (`PortTags`, `RequiredPortTags`, `Flags`)
- an item's own tags — its `AttachDef` (`Tags`, `RequiredTags`)

## Testing

189 sc_data loader and parser tests pass; standardrb clean. New coverage for both port-def sources, the loader write, and the `$`-marker normalisation. Every figure above measured against the full 4.10 raw tree.

The loader tests earned their keep here: adding the two columns to `components` alone broke five of them, because the items loader dual-writes every component attribute to `component_builds` — so the columns and the serialisation had to land on both.

## After this merges

One `parse` + `push` covers #4740 and this PR together, then a `load`. No `sync` needed — the raw 4.10 export is already local.

🤖
