### PR TITLE
fix(ships): open the module picker from anywhere on the slot

### DIFF
--- a/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/index.scss
+++ b/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/index.scss
@@ -1,4 +1,24 @@
+/*
+ * The whole row opens the picker, not just the label in it: the label is a few
+ * words wide in a row that is the width of the panel, so most of a slot looked
+ * inert. The label stays a button for the keyboard, and the row carries the
+ * cursor so the hit area is honest about how big it is.
+ */
+.module-slot {
+  cursor: pointer;
+
+  &:hover .module-select-btn {
+    color: $text-color;
+  }
+}
+
 .module-select-btn {
+  appearance: none;
+  padding: 0;
+  background: transparent;
+  border: none;
+  text-align: left;
+  font: inherit;
   cursor: pointer;
   color: color.scale($text-color, $lightness: -20%);
 

--- a/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/index.vue
+++ b/app/frontend/frontend/components/Models/Hardpoints/ModuleItem/index.vue
@@ -136,23 +136,28 @@ const hasExpandableContent = computed(
 </script>
 
 <template>
-  <HardpointItem :count="count">
+  <HardpointItem :count="count" class="module-slot" @click="openModuleModal">
     <template #default>
       <HardpointSize :size="hardpoint.maxSize" />
       <HardpointComponent>
-        <span
+        <!--
+          A button rather than the label it used to be, so the slot is reachable
+          from the keyboard. It needs no handler of its own: a click on it -- or
+          Enter, which fires one -- reaches the row.
+        -->
+        <button
+          type="button"
           class="module-select-btn"
           :class="{ 'module-select-btn-active': selectedModule }"
-          @click="openModuleModal"
         >
           <i class="fa-duotone fa-puzzle" />
           {{ selectedModule?.name || t("labels.hardpoint.moduleSlotEmpty") }}
-        </span>
+        </button>
       </HardpointComponent>
       <button
         v-if="selectedModule && hasExpandableContent"
         class="module-expand-toggle"
-        @click="toggleExpanded"
+        @click.stop="toggleExpanded"
       >
         <i
           class="fa-light"
@@ -161,9 +166,14 @@ const hasExpandableContent = computed(
       </button>
     </template>
     <template #loadout>
+      <!--
+        The expanded contents sit inside the row, so without this a click on one
+        of the module's own hardpoints would reach the row and reopen the picker.
+      -->
       <div
         v-if="expanded && selectedModule && hasExpandableContent"
         class="module-loadout"
+        @click.stop
       >
         <HardpointCategory
           v-for="(items, category) in moduleCategories"


### PR DESCRIPTION
Only the "— Select Module —" label opened the picker. That label is a few words wide in a row as wide as the panel, so most of a module slot looked inert — you had to hit the text.

The row carries the handler now, and the cursor with it, so the hit area is honest about how big it is.

Two details that came with it:

- **The label became a `<button>`**, so the slot is reachable from the keyboard. It needs no handler of its own — a click on it, or Enter, which fires one, reaches the row.
- **The chevron and the expanded contents stop their clicks.** Both sit inside the row, so without that, toggling a module's own hardpoint would reopen the picker.

Follows #4742, which rebuilt the picker the row opens.

## Testing

`lint:ts`, `lint:js` and `format` clean; 494 frontend unit tests pass. The hit area itself is a mouse behaviour I have not been able to exercise in the running app — this is a fresh worktree with no database — so the click paths are reasoned from the DOM rather than clicked.

🤖
