### PR TITLE
fix(dev): keep .env from shadowing vault secrets in bin/op

### DIFF
--- a/bin/op
+++ b/bin/op
@@ -13,8 +13,12 @@ if ! PATH="$clean_path" command -v op &> /dev/null; then
   exit 1
 fi
 
+# .env.local last so per-worktree overrides win. .env is deliberately absent:
+# op applies --env-file in order, so listing it here would let a stale .env
+# shadow a resolved vault value. dotenv-rails still loads it at boot, where it
+# fills gaps instead of clobbering.
 env_args=()
-for env_file in .env.tpl .env .env.local; do
+for env_file in .env.tpl .env.local; do
   if [ -f "$env_file" ]; then
     env_args+=(--env-file="$env_file")
   fi


### PR DESCRIPTION
`bin/op` listed `.env` between `.env.tpl` and `.env.local`. `op` applies
`--env-file` in order, later files winning:

```
$ op run --env-file=a.env --env-file=b.env -- printenv GREPTILE_TEST
from_dotenv
```

So a `.env` on disk overrode every value `.env.tpl` had just resolved from the
`Fleetyards` vault. Anyone still carrying a pre-1Password `.env` would silently
run on whatever it holds — the OAuth secrets, or `DOMAIN`, `DB_PORT` and
`REDIS_URL`, which is how you end up pointed at the wrong datastore without
noticing.

### Nothing is lost by dropping it

`.env` is still loaded — by `dotenv-rails` during boot — and dotenv does not
overwrite an already-set ENV value:

```
ALREADY_SET (vault already set it): "from_op"       # .env cannot clobber
NOT_SET     (gap in vault):         "from_dotenv"   # .env still fills gaps
```

That leaves a cleaner two-file model:

| source | role |
|---|---|
| `.env.tpl` | vault refs, committed |
| `.env` | loaded at boot — fills gaps only |
| `.env.local` | read last by `bin/op` — overrides everything |

No override capability is removed. `.env.local` is read last and beats both, so
it remains the channel for per-machine and per-worktree overrides. `.env` in
the middle was a strictly weaker second channel that duplicated it.

Added a comment recording the reasoning, since "why is `.env` missing from a
list that loads `.env.tpl` and `.env.local`" is not obvious from the code.

`bin/op true` still resolves clean against the vault on this branch.

### Context

Found while porting this setup to reckoning (reckoning/reckoning#990) — its
`bin/dev` had never been routed through `bin/op` at all. I copied this
env-file list across, greptile flagged it there, and it turned out to be worth
fixing at the source. The hazard is sharper in reckoning, whose pre-migration
`.env.example` held `SECRET_KEY_BASE` and the devise secrets, but the ordering
problem is the same one.

🤖
