### PR TITLE
chore(dev): drop the dead --docker flag

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -12,7 +12,6 @@ services=(web worker vite)
 
 for arg in "$@"; do
   case "$arg" in
-    --docker)      use_docker=1 ;;
     --rdbg)        use_rdbg=1 ;;
     --open)        open_browser=1 ;;
     --no-web)      no_web=1 ;;
@@ -26,7 +25,6 @@ Usage: bin/dev [OPTIONS]
 Start the development server (Rails, Sidekiq, Vite).
 
 Options:
-  --docker       Include Docker Compose services
   --rdbg         Attach Ruby debugger (rdbg) to the Rails server
   --open         Open browser when server is ready
 
@@ -83,10 +81,7 @@ else
   [ -n "$no_vite" ]   && run_vite=0
 fi
 
-run_docker=0
-[ -n "$use_docker" ] && run_docker=1
-
-formation="web=${run_web},worker=${run_worker},vite=${run_vite},docker-compose=${run_docker}"
+formation="web=${run_web},worker=${run_worker},vite=${run_vite}"
 
 if [ -n "$open_browser" ]; then
   (

--- a/bin/setup
+++ b/bin/setup
@@ -311,7 +311,7 @@ if ARGV.include?("--help") || ARGV.include?("-h")
       --port=N        Override the Rails port (default: derived from the slot)
       --vite-port=N   Override the Vite dev server port (default: derived from the slot)
       --dev           Start the development server after setup
-      --dev-<flag>    Forward --<flag> to bin/dev (e.g. --dev-docker, --dev-open)
+      --dev-<flag>    Forward --<flag> to bin/dev (e.g. --dev-open, --dev-rdbg)
       --verbose       Show full command output (default: concise status lines)
       --help          Show this help message
   HELP


### PR DESCRIPTION
`bin/dev --docker` has never done anything.

`foreman`'s `-m` formation only controls processes the Procfile declares, and
`Procfile` has never had a `docker-compose` entry — `git log -S"docker-compose"`
over that path comes back empty. So `docker-compose=1` was being matched against
a process that doesn't exist, silently, since the flag arrived with the Vue 3
migration (#2655).

Demonstration of the underlying mechanic — `-m` is an allowlist, and names not
in the Procfile are simply dropped:

```
$ foreman start -f Procfile.stub -m "web=1,worker=1"
web.1    | WEB_RAN
worker.1 | WORKER_RAN      # a third process named in -m never appears
```

### Why removing rather than wiring it up

Docker is deliberately managed outside foreman here, and better than foreman
could:

- `bin/setup` starts it with `docker compose up -d --wait --wait-timeout 30`,
  so setup blocks until postgres and redis are actually healthy.
- `AGENTS.md` documents `docker-compose up -d` as its own step.

A foreman-managed `docker compose up` would be attached, with no health gate,
and would duplicate state that's shared across worktrees. So there's nothing
here worth reinstating.

Also dropped `--dev-docker` from `bin/setup`'s help example. `bin/setup`
forwards `--dev-<flag>` to `bin/dev`, and `bin/dev` exits 1 on unknown options
— so that example advertised a flag that would have hard-failed once the flag
was gone.

After: `bin/dev --help` lists only real options, `foreman check -f Procfile`
reports `valid procfile detected (web, worker, vite)`, and `bin/dev --docker`
now fails loudly instead of being quietly ignored.

### Context

Found while porting this `bin/dev` to reckoning
(reckoning/reckoning#990). Reckoning's Procfile *does* declare a
`docker-compose` process, so the flag works there — it's getting the same
removal separately, for the same reason: `bin/setup` already handles Docker
properly.

🤖
