### PR TITLE
perf(sc_data): fetch a raw export in parallel rather than through s3cmd

### DIFF
--- a/app/lib/sc_data/object_store.rb
+++ b/app/lib/sc_data/object_store.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "aws-sdk-s3"
+
+module ScData
+  # What the sc_data stores have in common: where the bucket is, how to reach
+  # it, and how to move tens of thousands of small objects between it and a
+  # local tree without waiting out one round trip at a time.
+  #
+  # A subclass says which prefix it covers and where that tree lives on disk.
+  # `ParsedStore` mirrors the parsed tree in both directions; `RawStore` only
+  # ever fetches an export.
+  class ObjectStore
+    # Both trees are mostly small objects, so the wall clock is round-trip bound
+    # rather than bandwidth bound. Kept modest to stay well inside provider rate
+    # limits on the loaders container.
+    CONCURRENCY = 16
+
+    class NotConfigured < StandardError; end
+
+    class MissingTree < StandardError; end
+
+    # One object as a listing describes it.
+    #
+    # `etag` is the content MD5 only for a single-part upload. A multipart one is
+    # a digest of the part digests with the part count appended, which no local
+    # file can reproduce -- so anything comparing digests has to ask first.
+    RemoteObject = Struct.new(:etag, :size) do
+      def multipart?
+        etag.include?("-")
+      end
+    end
+
+    # The sc_data buckets sit on the same account and endpoint as
+    # ActiveStorage's, and object-storage keys here are project-scoped, so the
+    # pair already deployed for `config/storage.yml` reaches them too.
+    #
+    # Everything but the bucket therefore falls back to that existing config, so
+    # the only value production carries for this is the one that actually
+    # differs. Each `sc_data_s3` key stays an override, for a separate account
+    # later or for running the CLI outside 1Password.
+    def self.settings
+      creds = Rails.application.credentials
+
+      {
+        endpoint: Rails.app.creds.option(:sc_data_s3, :endpoint) || storage_endpoint(creds),
+        access_key_id: Rails.app.creds.option(:sc_data_s3, :access_key_id) || creds.s3_access_key,
+        secret_access_key: Rails.app.creds.option(:sc_data_s3, :secret_access_key) || creds.s3_secret_key,
+        bucket: Rails.app.creds.option(:sc_data_s3, :bucket)
+      }
+    end
+
+    # `config/storage.yml` stores the scheme apart from the host, so it has to be
+    # rejoined here. Nil rather than a bare "://" when either half is missing, so
+    # `configured?` reports it as absent instead of building a broken client.
+    def self.storage_endpoint(creds)
+      return if creds.s3_protocol.blank? || creds.s3_endpoint.blank?
+
+      "#{creds.s3_protocol}://#{creds.s3_endpoint}"
+    end
+
+    def self.configured?(settings = self.settings)
+      settings.values.all?(&:present?)
+    end
+
+    def initialize(client: nil, settings: nil)
+      @client = client
+      @provided_settings = settings
+    end
+
+    # Where this store's tree lives on disk.
+    def local_root
+      raise NotImplementedError
+    end
+
+    # The key prefix this store covers, without a trailing slash.
+    private def prefix
+      raise NotImplementedError
+    end
+
+    private def key_for(path)
+      "#{prefix}/#{path}"
+    end
+
+    private def local_path(path)
+      File.join(local_root, path)
+    end
+
+    # Relative path => RemoteObject for everything under the prefix.
+    private def remote_objects
+      objects = {}
+
+      client.list_objects_v2(bucket:, prefix: "#{prefix}/").each do |page|
+        page.contents.each do |object|
+          objects[object.key.delete_prefix("#{prefix}/")] =
+            RemoteObject.new(object.etag.delete('"'), object.size)
+        end
+      end
+
+      objects
+    end
+
+    private def download(path)
+      target = local_path(path)
+      FileUtils.mkdir_p(File.dirname(target))
+
+      client.get_object(bucket:, key: key_for(path), response_target: target)
+    end
+
+    private def each_in_parallel(paths)
+      return 0 if paths.empty?
+
+      queue = Queue.new
+      paths.each { |path| queue << path }
+      queue.close # so a drained `pop` returns nil instead of blocking forever
+
+      errors = Queue.new
+
+      Array.new([CONCURRENCY, paths.size].min) do
+        Thread.new do
+          while (path = queue.pop)
+            begin
+              yield path
+            rescue => e
+              errors << "#{path}: #{e.message}"
+            end
+          end
+        end
+      end.each(&:join)
+
+      raise errors.pop unless errors.empty?
+
+      paths.size
+    end
+
+    private def bucket
+      settings.fetch(:bucket)
+    end
+
+    private def settings
+      @settings ||= begin
+        settings = @provided_settings || self.class.settings
+
+        unless self.class.configured?(settings)
+          missing = settings.select { |_, value| value.blank? }.keys
+
+          raise NotConfigured, "missing sc_data_s3 settings: #{missing.join(", ")}"
+        end
+
+        settings
+      end
+    end
+
+    private def client
+      @client ||= Aws::S3::Client.new(
+        endpoint: settings.fetch(:endpoint),
+        access_key_id: settings.fetch(:access_key_id),
+        secret_access_key: settings.fetch(:secret_access_key),
+        region: "unused"
+      )
+    end
+  end
+end

--- a/app/lib/sc_data/parsed_store.rb
+++ b/app/lib/sc_data/parsed_store.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "aws-sdk-s3"
-
 module ScData
   # Mirrors one parsed environment tree between `data/sc_data/parsed/<env>` and
   # object storage.
@@ -15,59 +13,17 @@ module ScData
   # carries is removed from the target. `ModelsLoader#update_in_game_flag` reads
   # a model's in-game-ness off file existence, so a leftover file from an
   # earlier build would keep a retired ship flying.
-  class ParsedStore
+  class ParsedStore < ObjectStore
     PREFIX = "parsed"
-
-    # Both trees are ~15k small objects, so the wall clock is round-trip bound
-    # rather than bandwidth bound. Kept modest to stay well inside provider
-    # rate limits on the loaders container.
-    CONCURRENCY = 16
-
-    class NotConfigured < StandardError; end
-
-    class MissingTree < StandardError; end
 
     class VersionMismatch < StandardError; end
 
     attr_reader :environment
 
-    # The parsed tree sits in a different bucket from ActiveStorage's, but on the
-    # same account and endpoint -- and object-storage keys here are
-    # project-scoped, so the pair already deployed for `config/storage.yml`
-    # reaches this bucket too.
-    #
-    # Everything but the bucket therefore falls back to that existing config, so
-    # the only value production carries for this is the one that actually
-    # differs. Each `sc_data_s3` key stays an override, for a separate account
-    # later or for running the CLI outside 1Password.
-    def self.settings
-      creds = Rails.application.credentials
-
-      {
-        endpoint: Rails.app.creds.option(:sc_data_s3, :endpoint) || storage_endpoint(creds),
-        access_key_id: Rails.app.creds.option(:sc_data_s3, :access_key_id) || creds.s3_access_key,
-        secret_access_key: Rails.app.creds.option(:sc_data_s3, :secret_access_key) || creds.s3_secret_key,
-        bucket: Rails.app.creds.option(:sc_data_s3, :bucket)
-      }
-    end
-
-    # `config/storage.yml` stores the scheme apart from the host, so it has to be
-    # rejoined here. Nil rather than a bare "://" when either half is missing, so
-    # `configured?` reports it as absent instead of building a broken client.
-    def self.storage_endpoint(creds)
-      return if creds.s3_protocol.blank? || creds.s3_endpoint.blank?
-
-      "#{creds.s3_protocol}://#{creds.s3_endpoint}"
-    end
-
-    def self.configured?(settings = self.settings)
-      settings.values.all?(&:present?)
-    end
-
     def initialize(environment, client: nil, settings: nil)
+      super(client:, settings:)
+
       @environment = environment.to_s
-      @client = client
-      @provided_settings = settings
     end
 
     # Local -> bucket. Returns the counts of what moved.
@@ -82,7 +38,7 @@ module ScData
 
       remote = remote_objects
 
-      uploaded = each_in_parallel(local.keys.reject { |path| remote[path] == local[path] }) do |path|
+      uploaded = each_in_parallel(local.keys.reject { |path| remote[path]&.etag == local[path] }) do |path|
         File.open(local_path(path), "rb") do |io|
           client.put_object(bucket:, key: key_for(path), body: io)
         end
@@ -106,10 +62,8 @@ module ScData
 
       local = local_files
 
-      downloaded = each_in_parallel(remote.keys.reject { |path| local[path] == remote[path] }) do |path|
-        target = local_path(path)
-        FileUtils.mkdir_p(File.dirname(target))
-        client.get_object(bucket:, key: key_for(path), response_target: target)
+      downloaded = each_in_parallel(remote.keys.reject { |path| local[path] == remote[path].etag }) do |path|
+        download(path)
       end
 
       removed = each_in_parallel(local.keys - remote.keys) do |path|
@@ -152,16 +106,9 @@ module ScData
       "#{PREFIX}/#{environment}"
     end
 
-    private def key_for(path)
-      "#{prefix}/#{path}"
-    end
-
-    private def local_path(path)
-      File.join(local_root, path)
-    end
-
-    # Relative path => MD5 hex, matching the shape of `remote_objects` so the
-    # two can be diffed directly.
+    # Relative path => MD5 hex. Every object in this tree is written
+    # single-part, so a listing's ETag is the plain MD5 of the content and the
+    # two sides can be diffed directly.
     private def local_files
       return {} unless File.directory?(local_root)
 
@@ -172,20 +119,6 @@ module ScData
 
         files[path] = Digest::MD5.file(full).hexdigest
       end
-    end
-
-    # Relative path => ETag. Every object here is written single-part, so the
-    # ETag is the plain MD5 of the content and comparable to a local digest.
-    private def remote_objects
-      objects = {}
-
-      client.list_objects_v2(bucket:, prefix: "#{prefix}/").each do |page|
-        page.contents.each do |object|
-          objects[object.key.delete_prefix("#{prefix}/")] = object.etag.delete('"')
-        end
-      end
-
-      objects
     end
 
     # A directory the mirror emptied is not an object anywhere, so nothing
@@ -201,59 +134,6 @@ module ScData
 
           Dir.rmdir(full) if File.directory?(full) && Dir.empty?(full)
         end
-    end
-
-    private def each_in_parallel(paths)
-      return 0 if paths.empty?
-
-      queue = Queue.new
-      paths.each { |path| queue << path }
-      queue.close # so a drained `pop` returns nil instead of blocking forever
-
-      errors = Queue.new
-
-      Array.new([CONCURRENCY, paths.size].min) do
-        Thread.new do
-          while (path = queue.pop)
-            begin
-              yield path
-            rescue => e
-              errors << "#{path}: #{e.message}"
-            end
-          end
-        end
-      end.each(&:join)
-
-      raise errors.pop unless errors.empty?
-
-      paths.size
-    end
-
-    private def bucket
-      settings.fetch(:bucket)
-    end
-
-    private def settings
-      @settings ||= begin
-        settings = @provided_settings || self.class.settings
-
-        unless self.class.configured?(settings)
-          missing = settings.select { |_, value| value.blank? }.keys
-
-          raise NotConfigured, "missing sc_data_s3 settings: #{missing.join(", ")}"
-        end
-
-        settings
-      end
-    end
-
-    private def client
-      @client ||= Aws::S3::Client.new(
-        endpoint: settings.fetch(:endpoint),
-        access_key_id: settings.fetch(:access_key_id),
-        secret_access_key: settings.fetch(:secret_access_key),
-        region: "unused"
-      )
     end
   end
 end

--- a/app/lib/sc_data/raw_store.rb
+++ b/app/lib/sc_data/raw_store.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module ScData
+  # Fetches one raw export -- the game's own files as the exporter uploaded
+  # them -- from object storage into `data/sc_data/raw/<version>`, which is what
+  # `ScData::Parser::*` reads.
+  #
+  # Download only, and never a mirror. An export is immutable once uploaded and
+  # nothing local is authoritative, so there is nothing to push back and no
+  # reason to delete: a version folder is input to a parse rather than a tree
+  # whose absences mean something. (`ParsedStore` removes what the source
+  # dropped because `update_in_game_flag` reads in-game-ness off file existence;
+  # nothing reads raw that way.)
+  class RawStore < ObjectStore
+    # A version folder as the exporter names it: the release, the environment it
+    # was published to, and the id of the build carrying it --
+    # `4.10.0-live.12519617`.
+    VERSION_PATTERN = /\A(?<release>.+)-(?<environment>[a-z]+)\.(?<build>\d+)\z/
+
+    def self.versions(client: nil, settings: nil)
+      new(nil, client:, settings:).versions
+    end
+
+    # The newest export published to an environment, or nil if it has none.
+    def self.latest(environment, client: nil, settings: nil)
+      versions(client:, settings:)
+        .rfind { |version| VERSION_PATTERN.match(version)[:environment] == environment.to_s }
+    end
+
+    attr_reader :version
+
+    def initialize(version, client: nil, settings: nil)
+      super(client:, settings:)
+
+      @version = version
+    end
+
+    # Every export the bucket carries, oldest build first. They sit at the root
+    # of the bucket, alongside the `parsed/` prefix.
+    #
+    # Ordered by build id alone rather than by release: the id is the game's own
+    # monotonic counter, so it settles both a release that sorts oddly and two
+    # environments sitting on the same release.
+    def versions
+      folders = []
+
+      client.list_objects_v2(bucket:, delimiter: "/").each do |page|
+        page.common_prefixes.each do |folder|
+          name = folder.prefix.delete_suffix("/")
+
+          folders << name if VERSION_PATTERN.match?(name)
+        end
+      end
+
+      folders.sort_by { |name| VERSION_PATTERN.match(name)[:build].to_i }
+    end
+
+    # Bucket -> local. Returns the counts of what moved.
+    def pull
+      remote = remote_objects
+
+      # An empty listing is a version that was never uploaded, or a typo in one.
+      # Silently parsing whatever half-tree is on disk would stamp the resulting
+      # rows with a build they do not describe.
+      raise MissingTree, "no export at s3://#{bucket}/#{prefix}" if remote.empty?
+
+      stale = remote.reject { |path, object| current?(path, object) }
+
+      downloaded = each_in_parallel(stale.keys) { |path| download(path) }
+
+      {downloaded:, unchanged: remote.size - downloaded}
+    end
+
+    def local_root
+      Rails.root.join("data/sc_data/raw", version)
+    end
+
+    # The export is its own prefix at the root of the bucket. Guarded because a
+    # blank one would list -- and start downloading -- the whole bucket.
+    private def prefix
+      raise ArgumentError, "no version given" if version.blank?
+
+      version
+    end
+
+    # Whether the local copy is already this object.
+    #
+    # A single-part ETag is the content MD5 and decides outright. A multipart
+    # one is a digest of digests that no local file can reproduce -- the export
+    # carries a handful of them, `Data/Game2.dcb` at 331 MB among them -- so
+    # comparing digests there would re-download the largest files in the export
+    # on every run, and the byte count stands in instead.
+    private def current?(path, object)
+      full = local_path(path)
+
+      return false unless File.file?(full)
+      return File.size(full) == object.size if object.multipart?
+
+      Digest::MD5.file(full).hexdigest == object.etag
+    end
+  end
+end

--- a/bin/scdata
+++ b/bin/scdata
@@ -39,7 +39,7 @@ end
 # Run bare, this falls back to reading 1Password directly, the way `sync` does,
 # so neither invocation needs the wrapper.
 def s3_settings
-  return ScData::ParsedStore.settings if ScData::ParsedStore.configured?
+  return ScData::ObjectStore.settings if ScData::ObjectStore.configured?
 
   {
     endpoint: "https://fsn1.your-objectstorage.com",

--- a/bin/scdata
+++ b/bin/scdata
@@ -11,11 +11,22 @@ COMMANDS = {
   "parse" => "Parse SC data for the given environment",
   "push" => "Upload the parsed tree for the given environment to S3",
   "pull" => "Download the parsed tree for the given environment from S3",
-  "load" => "Load all SC data (manufacturers, items, models, modules)",
-  "load:manufacturers" => "Load manufacturers from SC data",
-  "load:items" => "Load items from SC data",
-  "load:models" => "Load models (hardpoints) from SC data",
-  "load:modules" => "Load model modules from SC data"
+  "load" => "Load all SC data for the given environment (manufacturers, items, models, modules)",
+  "load:manufacturers" => "Load manufacturers for the given environment",
+  "load:items" => "Load items for the given environment",
+  "load:models" => "Load models (hardpoints) for the given environment",
+  "load:modules" => "Load model modules for the given environment"
+}.freeze
+
+# What each load command runs, and what to call it while it runs. Bodies are not
+# evaluated until the step is reached, so naming the loaders here does not need
+# Rails to be booted yet.
+LOAD_STEPS = {
+  "load" => ["all SC Data", -> { ScData::Loader::BaseLoader.all }],
+  "load:manufacturers" => ["manufacturers", -> { ScData::Loader::ManufacturersLoader.new.all }],
+  "load:items" => ["items", -> { ScData::Loader::ItemsLoader.new.all }],
+  "load:models" => ["models", -> { ScData::Loader::ModelsLoader.new.all }],
+  "load:modules" => ["model modules", -> { ScData::Loader::ModelModulesLoader.new.all }]
 }.freeze
 
 def usage
@@ -30,8 +41,18 @@ def boot_rails
   require_relative "../config/environment"
 end
 
-def config_info
-  "version: #{ScData::Source.current}"
+# The build a load is about to write. Naming an environment loads that one
+# without moving the default onto it -- `ScData::Source.with` is the same seam a
+# request goes through, so a loader resolves its build the way it always does
+# rather than reading the config a second way.
+def requested_source(environment)
+  return ScData::Source.current if environment.blank?
+
+  source = ScData::Source.find(environment)
+
+  abort "No build configured for environment: #{environment}" if source.blank?
+
+  source
 end
 
 # Under `bin/op` the settings are already in the environment, resolved from
@@ -188,58 +209,17 @@ when "push", "pull"
   moved = result[:uploaded] || result[:downloaded]
   puts "  #{(command == "push") ? "Uploaded" : "Downloaded"}: #{moved}, removed: #{result[:removed]}, unchanged: #{result[:unchanged]}"
 
-when "load"
+when *LOAD_STEPS.keys
   CliHelpers.run_step("Booting Rails") {
     boot_rails
     [true, ""]
   }
 
-  CliHelpers.run_step("Loading all SC Data #{config_info}") do
-    ScData::Loader::BaseLoader.all
-    [true, ""]
-  end
+  source = requested_source(args.shift)
+  label, load = LOAD_STEPS.fetch(command)
 
-when "load:manufacturers"
-  CliHelpers.run_step("Booting Rails") {
-    boot_rails
-    [true, ""]
-  }
-
-  CliHelpers.run_step("Loading manufacturers #{config_info}") do
-    ScData::Loader::ManufacturersLoader.new.all
-    [true, ""]
-  end
-
-when "load:items"
-  CliHelpers.run_step("Booting Rails") {
-    boot_rails
-    [true, ""]
-  }
-
-  CliHelpers.run_step("Loading items #{config_info}") do
-    ScData::Loader::ItemsLoader.new.all
-    [true, ""]
-  end
-
-when "load:models"
-  CliHelpers.run_step("Booting Rails") {
-    boot_rails
-    [true, ""]
-  }
-
-  CliHelpers.run_step("Loading models #{config_info}") do
-    ScData::Loader::ModelsLoader.new.all
-    [true, ""]
-  end
-
-when "load:modules"
-  CliHelpers.run_step("Booting Rails") {
-    boot_rails
-    [true, ""]
-  }
-
-  CliHelpers.run_step("Loading model modules #{config_info}") do
-    ScData::Loader::ModelModulesLoader.new.all
+  CliHelpers.run_step("Loading #{label} (#{source})") do
+    ScData::Source.with(source) { load.call }
     [true, ""]
   end
 

--- a/bin/scdata
+++ b/bin/scdata
@@ -7,7 +7,7 @@ require_relative "../lib/cli_helpers"
 EXPORT_FOLDER = "data/sc_data"
 
 COMMANDS = {
-  "sync" => "Sync raw SC data from Hetzner S3 (optionally specify version)",
+  "sync" => "Sync a raw SC data export from S3 (optionally specify an environment or version)",
   "parse" => "Parse SC data for the given environment",
   "push" => "Upload the parsed tree for the given environment to S3",
   "pull" => "Download the parsed tree for the given environment from S3",
@@ -36,8 +36,8 @@ end
 
 # Under `bin/op` the settings are already in the environment, resolved from
 # `.env.tpl` -- which is also how production supplies them to the loader jobs.
-# Run bare, this falls back to reading 1Password directly, the way `sync` does,
-# so neither invocation needs the wrapper.
+# Run bare, this falls back to reading 1Password directly, so neither
+# invocation needs the wrapper.
 def s3_settings
   return ScData::ObjectStore.settings if ScData::ObjectStore.configured?
 
@@ -79,41 +79,38 @@ usage if command.nil? || command == "--help" || command == "-h"
 
 case command
 when "sync"
-  require "open3"
+  CliHelpers.run_step("Booting Rails") {
+    boot_rails
+    [true, ""]
+  }
 
-  s3_bucket = "fltyrd-sc"
-  s3_endpoint = "fsn1.your-objectstorage.com"
-  s3_access_key = `op read "op://Fleetyards/HETZNER_S3/access_key_id"`.strip
-  s3_secret_key = `op read "op://Fleetyards/HETZNER_S3/secret_access_key"`.strip
-  s3cmd = "s3cmd --host=#{s3_endpoint} --host-bucket='%(bucket)s.#{s3_endpoint}' --access_key=#{s3_access_key} --secret_key=#{s3_secret_key}"
+  # Either an export folder or the environment to take the newest one from, so
+  # `sync ptu` reads the way `parse ptu` does. Bare, it follows the configured
+  # default rather than whatever build happens to be newest in the bucket --
+  # picking that up would sync a ptu export to someone who only ever asked
+  # about live.
+  target = args.shift || ScData::Source.environment
+  version = target
 
-  version = args.shift
-
-  if version.nil?
-    CliHelpers.run_step("Finding latest version in s3://#{s3_bucket}") do
-      output, status = Open3.capture2e("#{s3cmd} ls s3://#{s3_bucket}/")
-      abort "Failed to list bucket: #{output}" unless status.success?
-
-      folders = output.lines
-        .filter_map { |line| line[%r{s3://#{Regexp.escape(s3_bucket)}/([^/]+)/}, 1] }
-        .select { |name| name.match?(/\A.+\.\d+\z/) }
-        .sort_by { |name| name.match(/\.(\d+)\z/)[1].to_i }
-
-      abort "No versions found in s3://#{s3_bucket}" if folders.empty?
-
-      version = folders.last
-      [true, ""]
+  unless ScData::RawStore::VERSION_PATTERN.match?(target)
+    CliHelpers.run_step("Finding the newest #{target} export") do
+      version = ScData::RawStore.latest(target, settings: s3_settings)
+      [version.present?, version.present? ? "" : "no export found for environment: #{target}"]
     end
-    puts "  Latest version: #{version}"
+    abort if version.blank?
+
+    puts "  Newest #{target} export: #{version}"
   end
 
-  local_dir = File.join(EXPORT_FOLDER, "raw", version)
+  store = ScData::RawStore.new(version, settings: s3_settings)
+  result = nil
 
-  CliHelpers.run_step("Syncing s3://#{s3_bucket}/#{version} to #{local_dir}") do
-    FileUtils.mkdir_p(local_dir)
-    output, status = Open3.capture2e("#{s3cmd} sync --no-check-md5 s3://#{s3_bucket}/#{version}/ #{local_dir}/")
-    [status.success?, output]
+  CliHelpers.run_step("Syncing #{version} to #{store.local_root.relative_path_from(Rails.root)}") do
+    result = store.pull
+    [true, ""]
   end
+
+  puts "  Downloaded: #{result[:downloaded]}, unchanged: #{result[:unchanged]}"
 
 when "parse"
   CliHelpers.run_step("Booting Rails") {

--- a/test/lib/sc_data/raw_store_test.rb
+++ b/test/lib/sc_data/raw_store_test.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "aws-sdk-s3"
+
+module ScData
+  class RawStoreTest < ActiveSupport::TestCase
+    SETTINGS = {
+      endpoint: "https://example.invalid",
+      access_key_id: "key",
+      secret_access_key: "secret",
+      bucket: "fltyrd-sc"
+    }.freeze
+
+    VERSION = "4.10.1-ptu.12578875"
+
+    setup do
+      @root = Dir.mktmpdir
+      @client = Aws::S3::Client.new(stub_responses: true)
+    end
+
+    teardown do
+      FileUtils.remove_entry(@root)
+    end
+
+    # Settings and the client are both injected, so nothing here reaches the
+    # credential store or the network.
+    private def store(version: VERSION)
+      root = Pathname.new(@root)
+      store = ::ScData::RawStore.new(version, client: @client, settings: SETTINGS)
+      store.define_singleton_method(:local_root) { root }
+      store
+    end
+
+    private def write_local(path, content)
+      target = File.join(@root, path)
+      FileUtils.mkdir_p(File.dirname(target))
+      File.write(target, content)
+      target
+    end
+
+    private def digest(content)
+      Digest::MD5.hexdigest(content)
+    end
+
+    # Keyed the way the exporter uploads: the version folder sits at the root of
+    # the bucket, not under a prefix of ours.
+    private def stub_listing(entries)
+      @client.stub_responses(:list_objects_v2, {
+        contents: entries.map { |key, object|
+          etag, size = object.is_a?(Array) ? object : [digest(object), object.bytesize]
+          {key: "#{VERSION}/#{key}", etag: %("#{etag}"), size:}
+        }
+      })
+    end
+
+    private def requests(operation)
+      @client.api_requests
+        .select { |request| request[:operation_name] == operation }
+        .map { |request| request[:params] }
+    end
+
+    # --- Versions ---------------------------------------------------------
+
+    test ".versions lists the exports in the bucket, oldest build first" do
+      @client.stub_responses(:list_objects_v2, {
+        common_prefixes: [
+          {prefix: "4.10.1-ptu.12578875/"},
+          {prefix: "parsed/"},
+          {prefix: "4.9.0-live.12344265/"},
+          {prefix: "4.10.0-live.12519617/"}
+        ]
+      })
+
+      assert_equal ["4.9.0-live.12344265", "4.10.0-live.12519617", "4.10.1-ptu.12578875"],
+        ::ScData::RawStore.versions(client: @client, settings: SETTINGS)
+    end
+
+    # Ordered by build id rather than release, so a ptu export on the same
+    # release as live still resolves to the newer of the two.
+    test ".latest picks the newest export published to an environment" do
+      @client.stub_responses(:list_objects_v2, {
+        common_prefixes: [
+          {prefix: "4.10.0-live.12519617/"},
+          {prefix: "4.10.1-ptu.12578875/"},
+          {prefix: "4.10.0-ptu.12480000/"}
+        ]
+      })
+
+      assert_equal "4.10.1-ptu.12578875", ::ScData::RawStore.latest("ptu", client: @client, settings: SETTINGS)
+      assert_equal "4.10.0-live.12519617", ::ScData::RawStore.latest("live", client: @client, settings: SETTINGS)
+    end
+
+    test ".latest is nil for an environment the bucket carries no export for" do
+      @client.stub_responses(:list_objects_v2, {common_prefixes: [{prefix: "4.10.0-live.12519617/"}]})
+
+      assert_nil ::ScData::RawStore.latest("ptu", client: @client, settings: SETTINGS)
+    end
+
+    # --- Pull -------------------------------------------------------------
+
+    test "#pull downloads what differs and leaves matching files alone" do
+      write_local("Data/Libs/avenger.xml", "same")
+      stub_listing("Data/Libs/aurora.xml" => "fetched", "Data/Libs/avenger.xml" => "same")
+      @client.stub_responses(:get_object, {body: "fetched"})
+
+      result = store.pull
+
+      assert_equal "fetched", File.read(File.join(@root, "Data/Libs/aurora.xml"))
+      assert_equal ["#{VERSION}/Data/Libs/aurora.xml"], requests(:get_object).map { |r| r[:key] }
+      assert_equal 1, result[:downloaded]
+      assert_equal 1, result[:unchanged]
+    end
+
+    # A multipart ETag is a digest of the part digests with the count appended,
+    # so no local file can ever match it. `Data/Game2.dcb` is 331 MB and comes
+    # back as `...-40`: comparing digests there re-downloads the largest files
+    # in the export on every run.
+    test "#pull compares a multipart object by size rather than by digest" do
+      write_local("Data/Game2.dcb", "a" * 64)
+      stub_listing("Data/Game2.dcb" => ["d41d8cd98f00b204e9800998ecf8427e-40", 64])
+
+      result = store.pull
+
+      assert_empty requests(:get_object)
+      assert_equal 0, result[:downloaded]
+      assert_equal 1, result[:unchanged]
+    end
+
+    test "#pull fetches a multipart object again when the byte count differs" do
+      write_local("Data/Game2.dcb", "a" * 32)
+      stub_listing("Data/Game2.dcb" => ["d41d8cd98f00b204e9800998ecf8427e-40", 64])
+      @client.stub_responses(:get_object, {body: "b" * 64})
+
+      assert_equal 1, store.pull[:downloaded]
+    end
+
+    # An export is immutable and nothing local is authoritative, so there is
+    # nothing to mirror away -- unlike the parsed tree, whose absences say a
+    # ship left the build.
+    test "#pull leaves local files the export does not carry" do
+      write_local("Data/Libs/aurora.xml", "a")
+      write_local("scratch.txt", "mine")
+      stub_listing("Data/Libs/aurora.xml" => "a")
+
+      result = store.pull
+
+      assert File.exist?(File.join(@root, "scratch.txt"))
+      assert_empty requests(:delete_object)
+      assert_equal 0, result[:downloaded]
+    end
+
+    # An empty listing is a version that was never uploaded, or a typo in one.
+    # Parsing whatever is on disk would stamp the rows with a build they do not
+    # describe.
+    test "#pull refuses an empty export rather than reporting nothing to do" do
+      stub_listing({})
+
+      assert_raises(::ScData::RawStore::MissingTree) { store.pull }
+    end
+
+    # A blank prefix lists -- and would start downloading -- the whole bucket.
+    test "#pull without a version refuses before listing anything" do
+      assert_raises(ArgumentError) { store(version: nil).pull }
+
+      assert_empty requests(:list_objects_v2)
+    end
+
+    test "raises NotConfigured naming the missing settings" do
+      raw = ::ScData::RawStore.new(VERSION, client: @client, settings: SETTINGS.merge(bucket: nil))
+
+      error = assert_raises(::ScData::RawStore::NotConfigured) { raw.pull }
+
+      assert_match "bucket", error.message
+    end
+  end
+end


### PR DESCRIPTION
## Why

`bin/scdata sync` was the last piece of sc_data tooling shelling out to `s3cmd`,
which transfers strictly serially. A raw export is ~77k objects averaging 46 KB,
so the wall clock was round-trip bound: **52 files a minute**, about a day for one
export. That is the reason nobody had ever synced a second environment, and it is
what `docs/exec-plans/sc-data-live-and-ptu.md` names as the thing to fix before a
real PTU load.

## What

- `ScData::ObjectStore` — the settings, the client, the parallel transfer and the
  listing move out of `ParsedStore`, which keeps only the mirror semantics the
  parsed tree needs. Pure refactor, `parsed_store_test.rb` untouched and green.
- `ScData::RawStore` — download-only, no mirror delete, with a multipart-ETag
  guard.
- `bin/scdata sync [environment|version]` — `sync ptu` now reads the way
  `parse ptu` does.
- `bin/scdata load [environment]` — runs the load inside `ScData::Source.with`,
  the seam #4590 added. Before this there was no way to load a second
  environment from the CLI short of moving `default` and putting it back.

## Measured

Against `4.10.1-ptu.12578875` on Hetzner `fsn1`, and the live export as a
control:

| | s3cmd | this |
| --- | --- | --- |
| files/min | 52 | **8,729** |
| full export | ~24 h | **8m51s** |
| re-run, nothing to fetch | — | 24s, 0 downloads |

The whole export was then re-verified: 77,247 objects, every digest matching, 0
re-downloads.

## The two things a raw export needs that the parsed tree does not

**Nothing is deleted.** An export is immutable once uploaded and nothing local is
authoritative, so there is nothing to mirror away. `ParsedStore` removes what the
source dropped because `update_in_game_flag` reads in-game-ness off file
existence; nothing reads raw that way.

**A multipart ETag is not a digest.** `Data/Game2.dcb` is 331 MB and comes back
as an ETag ending `-40`, which is a digest of the part digests — no local file
can reproduce it, so comparing it re-downloads the largest files in the export on
every run. Those fall back to the byte count. This is what the 24s re-run proves.

## Tests

`test/lib/sc_data/raw_store_test.rb`, 10 cases: the version listing and its
ordering, download-only, the multipart comparison in both directions, the empty
listing, and the blank-version guard that would otherwise list the whole bucket.

`test/lib/sc_data/` 67 tests green, `test/loaders/sc_data/` 147 tests green.

🤖
