### PR TITLE
fix(inventory): ask the build whether an item is still in the game

### DIFF
--- a/app/models/concerns/inventory_ledger_entry.rb
+++ b/app/models/concerns/inventory_ledger_entry.rb
@@ -119,14 +119,22 @@ module InventoryLedgerEntry
   # than leaving a player to work out why they cannot record more of something
   # they are holding.
   #
-  # `version` records the build an item was last seen in, which is the same
-  # question `current_version` asks of the catalogues. Entries naming a thing
-  # without pointing at one -- most of them -- have nothing to be missing from.
+  # Asked of the build describing the item rather than of the `version` column
+  # on its row. The column names whichever build was loaded last, across every
+  # environment, so a ptu load moves it off the live build for every row at
+  # once and leaves every live entry claiming to be missing. Measured on the
+  # first real ptu load: as a live request 0 of 10 entries reported available,
+  # as a ptu request 10 of 10, with each item's live build row sitting there
+  # untouched. The build row is the same thing `current_version` resolves
+  # against for all three catalogues an entry can name.
+  #
+  # Entries naming a thing without pointing at one -- most of them -- have
+  # nothing to be missing from.
   def item_available?
     return true unless referenced_item?
-    return true unless item.respond_to?(:version)
+    return true unless item.respond_to?(:build)
 
-    item.version == ScData::Source.version
+    item.build.present?
   end
 
   # What one piece costs a cargo grid, in SCU. Bulk cargo is already counted in

--- a/test/models/inventory_item_test.rb
+++ b/test/models/inventory_item_test.rb
@@ -152,6 +152,20 @@ class HangarInventoryItemTest < ActiveSupport::TestCase
     assert_predicate item, :item_available?
   end
 
+  # The column records whichever build was loaded last, across every
+  # environment, so loading ptu moves it off the live build for every row in the
+  # catalogue at once. Measured on the first real ptu load: as a live request 0
+  # of 10 entries reported available, while every one of them still had its live
+  # build row.
+  test "leaves an entry alone when another environment's load moved the version column" do
+    current = create(:component, version: ScData::Source.version)
+    current.update_column(:version, "4.10.1-ptu.12578875")
+
+    item = create(:inventory_item, inventory: @inventory, item: current)
+
+    assert_predicate item, :item_available?
+  end
+
   # Most entries name a thing without pointing at one, and a name has no build
   # to be missing from.
   test "leaves an entry that references nothing alone" do


### PR DESCRIPTION
## Why

Found by doing the thing `docs/exec-plans/sc-data-live-and-ptu.md` calls "the
only unknown": loading a real PTU build beside live for the first time.

`item_available?` compared the `version` column on the catalogue row against
`ScData::Source.version`. That column names whichever build was loaded **last,
across every environment** — every loader's `update_params` carries
`version: sc_version` into `apply`. So the first load of a second source moves
it off the live build for every row in the catalogue at once, and every live
entry starts reporting itself as missing through `available` on
`_inventory_item.jbuilder`, `_stock_item.jbuilder` and
`_base.jbuilder`.

## Measured

With `4.10.1-ptu.12578875` loaded beside `4.10.0-live.12519617` in a database
restored from a production dump:

| request as | available | unavailable |
| --- | --- | --- |
| `live` | **0** of 10 | 10 |
| `ptu` | 10 of 10 | 0 |

And per entry, on a live request:

```
Component  Crossfield M2C   column=4.10.1-ptu.12578875  build_row=true  item_available?=false
Component  Beacon M1C       column=4.10.1-ptu.12578875  build_row=true  item_available?=false
```

The live build row was sitting right there. The row knew the answer; the column
was the only thing that had moved.

## What

`item.build.present?` instead — the `has_one :build, -> { current }` that
`Commodity`, `Component` and `Equipment` all carry, which is what
`current_version` already resolves against for those three since #4522, #4557
and #4563.

## Tests

The two existing cases pass unchanged, and they were worth checking: the
component factory keys its build row on the row's own `version`, so
`create(:component, version: <older>)` has no current build either way. Added
the case this fixes — the column moved to another environment's build while the
current build row is still there.

`test/models/inventory_item_test.rb` 21, the inventory models 39, and the 178
inventory endpoint tests all green.

## Note

Exposure today is small — `fleet_inventory_items` has 24 rows, 10 pointing at a
catalogue item, and `inventory_items` is empty in the dump. This lands now
because it is a blocker for loading a second source at all, not because it is
breaking anything yet.

🤖
