### PR TITLE
ci(sc_data): refetch the parsed tree after re-parsing live

### DIFF
--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: data/sc_data/parsed
-          key: ${{ runner.os }}-sc-data-parsed-v1-${{ steps.sc-data.outputs.key }}
+          key: ${{ runner.os }}-sc-data-parsed-v2-${{ steps.sc-data.outputs.key }}
 
       - name: Fetch the parsed sc_data tree
         if: steps.parsed-tree.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Why

Found while loading a real PTU build for the first time. The parsed tree in the
bucket for `live` was produced by a parser **older than `main`**: #4746 added
`port_tags` and `required_tags` to loadout entries, and the slot `types`,
`min_size`, `max_size` and `flags` were not in it either.

| | pushed tree | re-parsed |
| --- | --- | --- |
| `models/aegs_gladius.json` | 14,130 bytes | 25,977 bytes |
| `models/` folder | 20 MB | 36 MB |

A loader reads the **pushed tree**, not the parser, so a parser change lands
green and nothing that runs ever sees it. This is
`docs/exec-plans/sc-data-live-and-ptu.md`'s own note — "a loader test reads the
*pushed* parsed tree, so a parser change lands green and the next version bump
inherits the failures".

Nothing user-facing was broken by it: `grep` finds only the `serialize`
declarations on `Component`, `ComponentBuild` and `Hardpoint` — no jbuilder and
no filter reads those columns yet. It was a trap waiting for whoever builds the
consumer, who would have found them empty in production.

## What was done outside this diff

`4.10.0-live.12519617` re-parsed and pushed to `s3://…/parsed/live`: **8,371 of
15,104 files updated, none added and none removed**. A second `push` reports
`0 uploaded, 15104 unchanged`, so the bucket and the tree agree.

Verified against the re-parsed tree *before* pushing it, since a re-parse is
exactly where a silent retirement would show up:

| | |
| --- | --- |
| `test/loaders/sc_data/` | 147 tests, 0 failures |
| `test/parsers/sc_data/` | 42 tests, 0 failures |
| `test/lib/sc_data/` + commodity matcher | 64 tests, 0 failures |
| `test/fixtures/sc_data/live/commodity_keys.json` | unchanged, 232 keys |

Loading it is non-destructive too — a full live load off the re-parsed tree
reported `Hardpoint created=0 updated=14024 unchanged=3686` with the loadout
fingerprint unchanged, so the 14,024 writes are the new tag and size fields
arriving and nothing was destroyed and recreated.

## The diff

The version pointer has not moved, so the cache key had to. `v1` → `v2`, which
is the case the comment on that step already describes: "re-parsing the same
dump can change the tree without moving the version".

🤖
