### PR TITLE
docs: a loadout manager is not why hardpoints need builds

### DIFF
--- a/docs/exec-plans/sc-data-live-and-ptu.md
+++ b/docs/exec-plans/sc-data-live-and-ptu.md
@@ -169,11 +169,12 @@ build, so it did not fire.
 ### 2. Hardpoints per build — before anything else
 
 The loadout has to stop being a single set of rows that the last load to run
-owns. The shape that fits both this and a loadout manager is the one the other
-four catalogues already use, split one layer further:
+owns. That is the whole reason, and it needs no other: the shape is the one the
+other four catalogues already use, split one layer further, because a loadout
+differs between builds in *structure* and not only in facts.
 
-- a **slot** — `parent` plus `sc_name` — stable across builds, which is what a
-  saved loadout or a named preset can safely point at;
+- a **slot** — `parent` plus `sc_name` — stable across builds, which is what
+  `ModelPosition` already points at;
 - a **`HardpointBuild`** carrying what the build says is in it: the component,
   `min_size`/`max_size`, `types`, `port_tags`, `required_tags`, `flags`;
 - a slot the build does not describe simply has no build row, so nothing is
@@ -209,10 +210,12 @@ there is no curated data on that table to preserve, and the slot identity is
 `hardpoints`.
 
 `vehicle_loadout_hardpoints` still points at `model_hardpoints` rather than at
-`hardpoints`, which is why a loadout manager cannot be built on it as it stands
-— but with 0 rows against 319 `vehicle_loadouts` there is nothing to migrate,
-only a foreign key to repoint. Deleting the legacy pair is a separate,
-unblocked piece of work.
+`hardpoints`, and it has never held a row. It is not a constraint on this work
+in either direction: the *live* vehicle-loadout feature is a bookmark — all 319
+`vehicle_loadouts` rows carry a URL to `spviewer.eu` or `erkul.games` and none
+carry anything else — so it reads no hardpoints and knows nothing about builds.
+The two share the word "loadout" and nothing else. Deleting the legacy pair,
+`vehicle_loadout_hardpoints` included, is separate and unblocked.
 
 ### 3. A production load path for a second environment
 


### PR DESCRIPTION
Follow-up to #4755, which I could not amend once it was queued.

Item 2 justified itself partly on serving a future loadout manager — "the shape
that fits both this and a loadout manager". I checked afterwards and it does
not fit both, because the second thing is not what I took it for:

- the **live** vehicle-loadout feature is a bookmark. All 319
  `vehicle_loadouts` rows carry a URL to `spviewer.eu` or `erkul.games`, and
  **zero** have a blank one. It reads no hardpoints, resolves no components and
  knows nothing about builds.
- `vehicle_loadout_hardpoints`, the internal half that would relate, has
  **never held a row**, `create_from_defaults!` sits behind a `from_defaults`
  parameter nobody has ever passed, and it seeds from `model_hardpoints` — the
  dead table whose game-files rows stopped being written in 2024.

They share the word "loadout" and nothing else. Item 2 stands entirely on the
loader destroying the other environment's loadouts, which is reason enough, and
the slot the split makes stable is what `ModelPosition` already points at today.

So this drops the speculative justification and states the measurement instead.
What an eventual editor would actually do with the split is in #4756, labelled
as a consequence rather than a driver.

Docs only, no code.

🤖
