### PR TITLE
feat(sc_data): add hardpoint_builds and enforce the slot's natural key

### DIFF
--- a/app/models/hardpoint.rb
+++ b/app/models/hardpoint.rb
@@ -24,8 +24,9 @@
 #
 # Indexes
 #
-#  index_hardpoints_on_component_id  (component_id)
-#  index_hardpoints_on_parent        (parent_type,parent_id)
+#  index_hardpoints_on_component_id        (component_id)
+#  index_hardpoints_on_parent              (parent_type,parent_id)
+#  index_hardpoints_on_parent_and_sc_name  (parent_type,parent_id,sc_name) UNIQUE WHERE (source = 1)
 #
 # Foreign Keys
 #
@@ -55,36 +56,48 @@ class Hardpoint < ApplicationRecord
   has_many :hardpoints, as: :parent, dependent: :destroy, autosave: true
   has_many :model_positions, dependent: :nullify
 
+  # What each build of the game says about this slot. Written alongside the
+  # columns for now, so the reads can move over in their own step -- and only
+  # for `game_files` slots, since the matrix comes from no build.
+  has_many :builds, class_name: "HardpointBuild", dependent: :destroy
+  has_one :build, -> { current }, class_name: "HardpointBuild", inverse_of: :hardpoint
+
   enum :source,
     {ship_matrix: 0, game_files: 1}
 
-  enum :group,
-    {
-      avionic: 0, system: 1, propulsion: 2, thruster: 3, weapon: 4, defense: 5, auxiliary: 6,
-      seat: 7, relay: 8,
-      other: 9,
-      external_fuel_tank: 10,
-      refuel_boom: 11,
-      unknown: 99
-    },
-    suffix: true
+  # Named constants rather than inline maps, because `HardpointBuild` declares
+  # the same two: `group` and `category` are derived from the installed
+  # component, so they move to the build row, and a build holding `40` has to
+  # read as `weapons` there as well. Two copies of a 30-entry map is one copy
+  # too many.
+  GROUPS = {
+    avionic: 0, system: 1, propulsion: 2, thruster: 3, weapon: 4, defense: 5, auxiliary: 6,
+    seat: 7, relay: 8,
+    other: 9,
+    external_fuel_tank: 10,
+    refuel_boom: 11,
+    unknown: 99
+  }.freeze
 
-  enum :category,
-    {
-      radar: 1, computers: 2, scanners: 3,
-      powerplant: 10, cooler: 11, shieldgenerator: 12, module: 13, salvagefillerstation: 14,
-      fueltanks: 20, fuel_intakes: 21, quantumdrive: 22, jumpdrive: 23, external_fuel_tanks: 24,
-      refuel_boom: 25,
-      main_thrusters: 30, retro_thrusters: 31, vtol_thrusters: 32, maneuvering_thrusters: 33,
-      weapons: 40, weapon_mounts: 41, turret: 42, missile_racks: 43, bombcompartments: 44,
-      quantumenforcementdevice: 45, emp: 46, salvagemunching: 47,
-      armor: 50, countermeasures: 51,
-      selfdestruct: 60, lifesupport: 61, batteries: 62, utility: 63,
-      seat: 70,
-      relay: 80,
-      paints: 90, doors: 91, cargogrid: 92, inventory: 93, controller: 94,
-      unknown: 999
-    }, suffix: true
+  CATEGORIES = {
+    radar: 1, computers: 2, scanners: 3,
+    powerplant: 10, cooler: 11, shieldgenerator: 12, module: 13, salvagefillerstation: 14,
+    fueltanks: 20, fuel_intakes: 21, quantumdrive: 22, jumpdrive: 23, external_fuel_tanks: 24,
+    refuel_boom: 25,
+    main_thrusters: 30, retro_thrusters: 31, vtol_thrusters: 32, maneuvering_thrusters: 33,
+    weapons: 40, weapon_mounts: 41, turret: 42, missile_racks: 43, bombcompartments: 44,
+    quantumenforcementdevice: 45, emp: 46, salvagemunching: 47,
+    armor: 50, countermeasures: 51,
+    selfdestruct: 60, lifesupport: 61, batteries: 62, utility: 63,
+    seat: 70,
+    relay: 80,
+    paints: 90, doors: 91, cargogrid: 92, inventory: 93, controller: 94,
+    unknown: 999
+  }.freeze
+
+  enum :group, GROUPS, suffix: true
+
+  enum :category, CATEGORIES, suffix: true
 
   def self.ransackable_attributes(auth_object = nil)
     ["category", "component_id", "created_at", "group", "id", "parent_id", "parent_type",

--- a/app/models/hardpoint_build.rb
+++ b/app/models/hardpoint_build.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a hardpoint slot.
+#
+# The four catalogues each hold their facts in a `*_build` row; the loadout never
+# did, which is why loading a second environment replaced the first one's
+# hardpoints instead of sitting beside them. This is that row, one layer deeper:
+# the slot on `hardpoints` is stable across builds, and everything a build has an
+# opinion about lives here.
+#
+# Only the `game_files` half gets rows. The ship matrix comes from no build and
+# has no version, so if "has a build row" were the test for "is in this build",
+# every matrix hardpoint would read as retired from every build -- the same
+# conflation `in_game` was rejected for on the model catalogue.
+# == Schema Information
+#
+# Table name: hardpoint_builds
+#
+#  id            :uuid             not null, primary key
+#  category      :integer
+#  environment   :string           not null
+#  flags         :string
+#  group         :integer
+#  group_key     :string
+#  max_size      :integer
+#  min_size      :integer
+#  port_tags     :string
+#  required_tags :string
+#  types         :string
+#  version       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  component_id  :uuid
+#  hardpoint_id  :uuid             not null
+#
+# Indexes
+#
+#  index_hardpoint_builds_on_component_id             (component_id)
+#  index_hardpoint_builds_on_environment_and_version  (environment,version)
+#  index_hardpoint_builds_on_hardpoint_and_build      (hardpoint_id,environment,version) UNIQUE
+#  index_hardpoint_builds_on_hardpoint_id             (hardpoint_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (hardpoint_id => hardpoints.id) ON DELETE => cascade
+#
+class HardpointBuild < ApplicationRecord
+  belongs_to :hardpoint
+  belongs_to :component, optional: true
+
+  # How many builds of one environment are kept, matching the catalogues: enough
+  # to diff a patch against the one before it without the table growing forever.
+  BUILDS_RETAINED = 3
+
+  # Everything a build says, as opposed to what identifies the slot. `parent`,
+  # `sc_name` and `source` are the identity and stay on the row; `matrix_key` and
+  # `details` stay too -- neither is written by a load.
+  #
+  # `group`, `category` and `group_key` are here because Hardpoint derives all
+  # three from the installed component in a `before_validation`, so they move
+  # wherever the component does.
+  FACTS = %i[
+    component_id min_size max_size types port_tags required_tags flags
+    group category group_key
+  ].freeze
+
+  # The same serialization and enums Hardpoint declares, so a build row holding
+  # `3` reads as `thruster` here too and a JSON string comes back as the array it
+  # encodes. Getting this wrong is how a reader ends up calling `dig` on a raw
+  # serialized string, since the fallback fires only on nil.
+  serialize :types, type: Array, coder: JSON
+  serialize :port_tags, type: Array, coder: JSON
+  serialize :required_tags, type: Array, coder: JSON
+  serialize :flags, type: Array, coder: JSON
+
+  # Taken from Hardpoint rather than restated: a build row holding `40` has to
+  # read as `weapons` exactly as the slot's own column does, and a second copy
+  # of a 30-entry map is a drift waiting to happen.
+  enum :group, ::Hardpoint::GROUPS, suffix: true
+
+  enum :category, ::Hardpoint::CATEGORIES, suffix: true
+
+  validates :environment, presence: true
+  validates :version, presence: true
+  validates :hardpoint_id, uniqueness: {scope: [:environment, :version]}
+
+  # Every build this environment still has.
+  scope :for_source, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment)
+  }
+
+  # The one build the environment is on. `ScData::Source` names the version
+  # exactly, so this needs no ordering or subselect.
+  scope :current, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment, version: source.version)
+  }
+
+  # The versions worth keeping for one environment, ordered by when they first
+  # appeared. Re-loading a build updates its rows in place, so `created_at` is
+  # when that build first landed rather than when it was last touched.
+  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+    where(environment:)
+      .group(:version)
+      .minimum(:created_at)
+      .sort_by { |_version, first_seen| first_seen }
+      .last(keep)
+      .map(&:first)
+  end
+end

--- a/app/tasks/maintenance/backfill_hardpoint_builds_task.rb
+++ b/app/tasks/maintenance/backfill_hardpoint_builds_task.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Seeds a `HardpointBuild` from what each game-file slot already says, so the
+  # table is populated before anything reads it rather than staying empty until
+  # the next sc_data load.
+  #
+  # A task rather than a data migration: 22,561 slots at one lookup and one
+  # insert each took two minutes when this was measured, and `bin/deploy-release`
+  # runs `data:migrate` inside the Kamal pre-deploy hook -- so as a migration it
+  # would block every deploy behind it, and a hook that retries three times would
+  # re-scan the whole table each attempt. Here it is triggered once, watched, and
+  # resumable.
+  #
+  # Only the `game_files` half. The ship matrix comes from no build and has no
+  # version, so giving it rows would make "has a build row" stop meaning "this
+  # build describes it".
+  #
+  # Which build do the current columns describe? Whichever load ran last, which
+  # is the configured source: `persist_loadout` destroys every game-file row a
+  # run did not touch, so what survives on the table is what the last load wrote.
+  # That premise holds only while nothing can load a second environment, which is
+  # item 3 of docs/exec-plans/sc-data-live-and-ptu.md -- and item 3 is gated on
+  # this work, so the two cannot cross.
+  #
+  # Re-runnable and additive: it creates or updates the row for the source in
+  # force and deletes nothing. No `dry_run` attribute on purpose -- one that
+  # defaults to true makes a console run roll back silently while still reporting
+  # "succeeded", and there is nothing here to rehearse.
+  class BackfillHardpointBuildsTask < MaintenanceTasks::Task
+    def collection
+      Hardpoint.where(source: :game_files)
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(hardpoint)
+      build = hardpoint.builds.find_or_initialize_by(
+        environment: source.environment, version: source.version
+      )
+
+      # Assigned through the model rather than written raw, because the enums and
+      # the serialized arrays have to go back through the build's own casters:
+      # `hardpoint.group` hands back "weapons" and the build stores 40.
+      build.assign_attributes(
+        HardpointBuild::FACTS.index_with { |fact| hardpoint.public_send(fact) }
+      )
+
+      return unless build.changed?
+
+      # Validation is skipped because the uniqueness check it would run is the
+      # unique index's job here, and 22k extra selects buy nothing.
+      build.save!(validate: false)
+    end
+
+    # Read once for the run rather than per slot: `ScData::Source.current` is a
+    # config read on every call, deliberately unmemoized there.
+    private def source
+      @source ||= ::ScData::Source.current
+    end
+  end
+end

--- a/db/migrate/20260907200000_create_hardpoint_builds.rb
+++ b/db/migrate/20260907200000_create_hardpoint_builds.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a hardpoint, following the shape the four
+# catalogue build tables established.
+#
+# The loadout is the one thing the row-per-build work never covered. `hardpoints`
+# carries no environment, and `persist_loadout` destroys every game-file row the
+# loaded build does not name -- so loading PTU replaces live's loadouts in place.
+# See item 2 of docs/exec-plans/sc-data-live-and-ptu.md.
+#
+# The split is one layer deeper than the catalogues need, because a loadout
+# differs between builds in *structure* and not only in facts: the slot -- parent
+# plus `sc_name` -- stays on `hardpoints` and is what `ModelPosition` already
+# points at, while what a build says is in it moves here. A slot the build does
+# not describe simply has no row here, which is what replaces the destroy.
+#
+# Nothing reads this yet.
+class CreateHardpointBuilds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :hardpoint_builds, id: :uuid do |t|
+      # Cascade: a build says something about a slot, and says nothing at all
+      # once the slot is gone.
+      t.references :hardpoint, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+
+      t.string :environment, null: false
+      t.string :version, null: false
+
+      # What is installed is the loadout. No foreign key constraint, matching
+      # `hardpoints.component_id`, which has one -- but here a build may name a
+      # component a later load retires, and the row still has to describe the
+      # build it belongs to.
+      t.uuid :component_id
+
+      t.integer :min_size
+      t.integer :max_size
+
+      # Serialized as JSON arrays on the model, the same as on `hardpoints`.
+      t.string :types
+      t.string :port_tags
+      t.string :required_tags
+      t.string :flags
+
+      # Derived from the component by Hardpoint's `before_validation`, so they
+      # move with it rather than staying on the slot.
+      t.integer :group
+      t.integer :category
+      t.string :group_key
+
+      t.timestamps
+    end
+
+    # One row per slot per build. Re-loading the same build updates it in place;
+    # a new build adds a row beside it.
+    add_index :hardpoint_builds, [:hardpoint_id, :environment, :version],
+      unique: true, name: "index_hardpoint_builds_on_hardpoint_and_build"
+
+    # Every read names an environment and a version, because that pair is what
+    # `ScData::Source` hands out.
+    add_index :hardpoint_builds, [:environment, :version]
+    add_index :hardpoint_builds, :component_id
+
+    # The slot's natural key, and only on the game-files side. Unique in fact
+    # there already -- 0 duplicates over the 22,561 rows -- but nothing enforced
+    # it except `find_or_initialize_by` in the loader, and that is not enough
+    # once a slot is the thing build rows hang off.
+    #
+    # Scoped to `source = 1` (`game_files`) because the matrix side is not a set
+    # of named ports at all: it repeats names by design, and a ship carries 32
+    # rows called "Maneuvering Thruster". Measured before writing this --
+    # unscoped, the index is impossible: 1,222 duplicate groups and 2,406 excess
+    # rows, every one of them `ship_matrix`.
+    #
+    # So "the slot called X on this parent" is a well-defined thing for
+    # game-files rows and meaningless for matrix ones, which is the same
+    # asymmetry that keeps build rows off the matrix half.
+    add_index :hardpoints, [:parent_type, :parent_id, :sc_name],
+      unique: true, where: "source = 1",
+      name: "index_hardpoints_on_parent_and_sc_name"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_07_132814) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -767,6 +767,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_132814) do
     t.index ["user_id", "name"], name: "index_hangar_groups_on_user_id_and_name", unique: true
   end
 
+  create_table "hardpoint_builds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.integer "category"
+    t.uuid "component_id"
+    t.datetime "created_at", null: false
+    t.string "environment", null: false
+    t.string "flags"
+    t.integer "group"
+    t.string "group_key"
+    t.uuid "hardpoint_id", null: false
+    t.integer "max_size"
+    t.integer "min_size"
+    t.string "port_tags"
+    t.string "required_tags"
+    t.string "types"
+    t.datetime "updated_at", null: false
+    t.string "version", null: false
+    t.index ["component_id"], name: "index_hardpoint_builds_on_component_id"
+    t.index ["environment", "version"], name: "index_hardpoint_builds_on_environment_and_version"
+    t.index ["hardpoint_id", "environment", "version"], name: "index_hardpoint_builds_on_hardpoint_and_build", unique: true
+    t.index ["hardpoint_id"], name: "index_hardpoint_builds_on_hardpoint_id"
+  end
+
   create_table "hardpoints", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.integer "category"
     t.uuid "component_id"
@@ -787,6 +809,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_132814) do
     t.string "types"
     t.datetime "updated_at", null: false
     t.index ["component_id"], name: "index_hardpoints_on_component_id"
+    t.index ["parent_type", "parent_id", "sc_name"], name: "index_hardpoints_on_parent_and_sc_name", unique: true, where: "(source = 1)"
     t.index ["parent_type", "parent_id"], name: "index_hardpoints_on_parent"
   end
 
@@ -1734,6 +1757,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_132814) do
   add_foreign_key "fleet_memberships", "fleet_roles"
   add_foreign_key "fleet_notification_settings", "fleets"
   add_foreign_key "fleet_roles", "fleets"
+  add_foreign_key "hardpoint_builds", "hardpoints", on_delete: :cascade
   add_foreign_key "hardpoints", "components"
   add_foreign_key "imports", "admin_users"
   add_foreign_key "inventories", "vehicles", on_delete: :nullify

--- a/docs/exec-plans/sc-data-hardpoints-per-build.md
+++ b/docs/exec-plans/sc-data-hardpoints-per-build.md
@@ -100,11 +100,33 @@ separate and unblocked.
    `retained_versions` mirroring `ComponentBuild`, and a backfill writing the
    current live build from the columns already on the row. Nothing reads it yet.
 
-   Add a unique index on `(parent_type, parent_id, sc_name)` in the same PR.
-   The slot's natural key is already unique in fact — 0 duplicates over the
-   22,561 game-file rows — but nothing enforces it except
-   `find_or_initialize_by` in the loader, and once a slot is the thing other
-   records point at, that is not enough.
+   The backfill is a **maintenance task**, not a data migration.
+   `bin/deploy-release` runs `data:migrate` inside the Kamal pre-deploy hook, so
+   as a migration it would block every deploy behind two minutes of work --
+   22,561 slots at one lookup and one insert each, measured -- and the hook
+   retries three times, re-scanning the table on each attempt. A leaked Kamal
+   lock from a failed deploy then kills the next one before it can run the fix.
+   As a task it is triggered once, watched and resumable.
+
+   No `dry_run` attribute on it: one that defaults to true makes a console run
+   roll back silently while still reporting "succeeded", and an additive
+   backfill has nothing to rehearse.
+
+   Add a unique index on `(parent_type, parent_id, sc_name)` in the same PR,
+   **scoped to `source = 1`**. The slot's natural key is unique in fact on the
+   game-files side — 0 duplicates over its 22,561 rows — but nothing enforces it
+   except `find_or_initialize_by` in the loader, and once a slot is the thing
+   build rows hang off, that is not enough.
+
+   An earlier version of this step said to add it unscoped. That is impossible,
+   measured before it was written: 1,222 duplicate groups and 2,406 excess rows,
+   every one of them `ship_matrix`. The matrix half is not a set of named ports
+   at all — it repeats names by design, and a ship carries 32 rows called
+   "Maneuvering Thruster". So "the slot called X on this parent" is a
+   well-defined thing on the game-files side and meaningless on the matrix side,
+   which is the same asymmetry that keeps build rows off the matrix half. It is
+   worth reading as a second, independent argument for that constraint rather
+   than as a detail of the index.
 2. **Dual-write.** `persist_slot` calls `apply_build` alongside `apply`, and
    `persist_loadout` stops destroying: `retire_absent_builds(HardpointBuild,
    :hardpoint_id, …)` takes its place for the `game_files` half. This is the PR

--- a/test/factories/hardpoint_builds.rb
+++ b/test/factories/hardpoint_builds.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :hardpoint_build do
+    # `game_files` explicitly rather than the hardpoint factory's random source:
+    # only that half carries build rows, and a matrix slot with one would be the
+    # very thing the design forbids.
+    association :hardpoint, factory: :hardpoint, source: :game_files
+    environment { ScData::Source.environment }
+    version { ScData::Source.version }
+    min_size { 2 }
+    max_size { 2 }
+  end
+end

--- a/test/factories/hardpoints.rb
+++ b/test/factories/hardpoints.rb
@@ -24,8 +24,9 @@
 #
 # Indexes
 #
-#  index_hardpoints_on_component_id  (component_id)
-#  index_hardpoints_on_parent        (parent_type,parent_id)
+#  index_hardpoints_on_component_id        (component_id)
+#  index_hardpoints_on_parent              (parent_type,parent_id)
+#  index_hardpoints_on_parent_and_sc_name  (parent_type,parent_id,sc_name) UNIQUE WHERE (source = 1)
 #
 # Foreign Keys
 #

--- a/test/models/hardpoint_build_test.rb
+++ b/test/models/hardpoint_build_test.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HardpointBuildTest < ActiveSupport::TestCase
+  setup do
+    @environment = ScData::Source.environment
+    @version = ScData::Source.version
+  end
+
+  test "a slot carries one row per build, not two" do
+    hardpoint = create(:hardpoint, source: :game_files)
+    create(:hardpoint_build, hardpoint:, environment: @environment, version: @version)
+
+    duplicate = build(:hardpoint_build, hardpoint:, environment: @environment, version: @version)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors.attribute_names, :hardpoint_id
+  end
+
+  test "a later build of the same environment sits beside the earlier one" do
+    hardpoint = create(:hardpoint, source: :game_files)
+    create(:hardpoint_build, hardpoint:, environment: @environment, version: "0.0.1-live.1")
+    create(:hardpoint_build, hardpoint:, environment: @environment, version: "0.0.2-live.2")
+
+    assert_equal 2, hardpoint.builds.count
+  end
+
+  test "the same slot can be described by more than one environment" do
+    hardpoint = create(:hardpoint, source: :game_files)
+    create(:hardpoint_build, hardpoint:, environment: "live", version: @version)
+    create(:hardpoint_build, hardpoint:, environment: "ptu", version: @version)
+
+    assert_equal 2, hardpoint.builds.count
+  end
+
+  test "requires the build it describes" do
+    build_row = build(:hardpoint_build, environment: nil, version: nil)
+
+    assert_not build_row.valid?
+    assert_includes build_row.errors.attribute_names, :environment
+    assert_includes build_row.errors.attribute_names, :version
+  end
+
+  # --- Which build is in force -----------------------------------------------
+
+  test "#build resolves the row for the source in force and nothing else" do
+    hardpoint = create(:hardpoint, source: :game_files)
+    live = create(:hardpoint_build, hardpoint:, environment: "live", version: "1.0.0-live.1")
+    ptu = create(:hardpoint_build, hardpoint:, environment: "ptu", version: "1.0.1-ptu.2")
+
+    ScData::Source.with(ScData::Source.new(environment: "live", version: "1.0.0-live.1")) do
+      assert_equal live, hardpoint.reload.build
+    end
+
+    ScData::Source.with(ScData::Source.new(environment: "ptu", version: "1.0.1-ptu.2")) do
+      assert_equal ptu, hardpoint.reload.build
+    end
+  end
+
+  # A slot the build does not describe has no row, which is what replaces the
+  # destroy in `persist_loadout`. So "no build" has to be a clean nil rather than
+  # some other environment's row.
+  test "#build is nil for a source that does not describe the slot" do
+    hardpoint = create(:hardpoint, source: :game_files)
+    create(:hardpoint_build, hardpoint:, environment: "live", version: "1.0.0-live.1")
+
+    ScData::Source.with(ScData::Source.new(environment: "ptu", version: "1.0.1-ptu.2")) do
+      assert_nil hardpoint.reload.build
+    end
+  end
+
+  test ".retained_versions keeps the newest builds of one environment, oldest first" do
+    hardpoint = create(:hardpoint, source: :game_files)
+
+    %w[0.0.1-live.1 0.0.2-live.2 0.0.3-live.3 0.0.4-live.4].each_with_index do |version, index|
+      create(:hardpoint_build, hardpoint:, environment: "live", version:,
+        created_at: index.days.ago(Time.zone.parse("2026-09-07")))
+    end
+
+    retained = HardpointBuild.retained_versions("live")
+
+    assert_equal 3, retained.size
+    assert_not_includes retained, "0.0.4-live.4", "the oldest by first appearance drops out"
+  end
+
+  # --- The enums are shared, not restated ------------------------------------
+
+  # `group` and `category` derive from the installed component, so they move to
+  # the build row -- and a build holding 40 has to read as the same thing the
+  # slot's own column does. Restating a 30-entry map is how that drifts, so both
+  # models take it from one constant and this is the guard.
+  test "reads the same group and category maps as the slot" do
+    assert_equal Hardpoint.groups, HardpointBuild.groups
+    assert_equal Hardpoint.categories, HardpointBuild.categories
+  end
+
+  test "round-trips a serialized tag list the way the slot does" do
+    build_row = create(:hardpoint_build,
+      types: ["MissileLauncher", "BombLauncher"],
+      port_tags: ["Eclipse_BombRack"],
+      required_tags: ["Eclipse_BombRack"],
+      flags: ["editable", "swaponly"])
+
+    build_row.reload
+
+    assert_equal ["MissileLauncher", "BombLauncher"], build_row.types
+    assert_equal ["Eclipse_BombRack"], build_row.port_tags
+    assert_equal ["Eclipse_BombRack"], build_row.required_tags
+    assert_equal ["editable", "swaponly"], build_row.flags
+  end
+
+  # --- The slot's natural key ------------------------------------------------
+
+  # Once build rows hang off a slot, "the slot called X on this parent" has to
+  # mean one row. The loader has always kept that with `find_or_initialize_by`
+  # and nothing enforced it.
+  test "refuses a second game_files slot of the same name on one parent" do
+    model = create(:model)
+    create(:hardpoint, parent: model, sc_name: "hardpoint_power", source: :game_files)
+
+    assert_raises(ActiveRecord::RecordNotUnique) do
+      create(:hardpoint, parent: model, sc_name: "hardpoint_power", source: :game_files)
+    end
+  end
+
+  # The matrix half is not a set of named ports: it repeats names by design, and
+  # a ship carries 32 rows called "Maneuvering Thruster". Measured on the real
+  # table before the index was written -- unscoped it is impossible, 1,222
+  # duplicate groups and 2,406 excess rows, every one of them ship_matrix.
+  test "allows a repeated ship_matrix slot name, which the matrix relies on" do
+    model = create(:model)
+    create(:hardpoint, parent: model, sc_name: "Maneuvering Thruster", source: :ship_matrix)
+
+    assert_nothing_raised do
+      create(:hardpoint, parent: model, sc_name: "Maneuvering Thruster", source: :ship_matrix)
+    end
+  end
+
+  test "does not collide a game_files slot with a matrix slot of the same name" do
+    model = create(:model)
+    create(:hardpoint, parent: model, sc_name: "shared_name", source: :ship_matrix)
+
+    assert_nothing_raised do
+      create(:hardpoint, parent: model, sc_name: "shared_name", source: :game_files)
+    end
+  end
+
+  test "goes away with the slot it describes" do
+    hardpoint = create(:hardpoint, source: :game_files)
+    build_row = create(:hardpoint_build, hardpoint:)
+
+    hardpoint.destroy!
+
+    assert_not HardpointBuild.exists?(build_row.id)
+  end
+end

--- a/test/tasks/maintenance/backfill_hardpoint_builds_task_test.rb
+++ b/test/tasks/maintenance/backfill_hardpoint_builds_task_test.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Maintenance
+  class BackfillHardpointBuildsTaskTest < ActiveSupport::TestCase
+    setup do
+      @task = ::Maintenance::BackfillHardpointBuildsTask.new
+      @source = ScData::Source.current
+    end
+
+    test "#collection is the game-file slots and not the matrix ones" do
+      game_files = create(:hardpoint, source: :game_files)
+      matrix = create(:hardpoint, source: :ship_matrix)
+
+      ids = @task.collection.pluck(:id)
+
+      assert_includes ids, game_files.id
+      assert_not_includes ids, matrix.id
+    end
+
+    test "#process writes what the slot says into a row for the source in force" do
+      component = create(:component)
+      hardpoint = create(:hardpoint,
+        source: :game_files, component:, min_size: 2, max_size: 4,
+        types: ["MissileLauncher"], port_tags: ["Eclipse_BombRack"],
+        required_tags: ["Eclipse_BombRack"], flags: ["editable"])
+
+      @task.process(hardpoint)
+
+      build = hardpoint.builds.sole
+      assert_equal @source.environment, build.environment
+      assert_equal @source.version, build.version
+      assert_equal component.id, build.component_id
+      assert_equal 2, build.min_size
+      assert_equal 4, build.max_size
+      assert_equal ["MissileLauncher"], build.types
+      assert_equal ["Eclipse_BombRack"], build.port_tags
+      assert_equal ["Eclipse_BombRack"], build.required_tags
+      assert_equal ["editable"], build.flags
+    end
+
+    # The three columns Hardpoint derives from the installed component in a
+    # `before_validation`. They have to survive the trip as the same enum value,
+    # which is what the shared constant on Hardpoint is for.
+    test "#process carries the derived group and category across as themselves" do
+      hardpoint = create(:hardpoint, source: :game_files,
+        component: create(:component, category: "weapons"))
+
+      @task.process(hardpoint)
+
+      build = hardpoint.builds.sole
+      assert_equal hardpoint.group, build.group
+      assert_equal hardpoint.category, build.category
+      assert_equal hardpoint.group_key, build.group_key
+    end
+
+    # Additive and re-runnable: the row for a source is updated in place rather
+    # than a second one landing beside it.
+    test "#process is idempotent for the same source" do
+      hardpoint = create(:hardpoint, source: :game_files, min_size: 2)
+
+      @task.process(hardpoint)
+      @task.process(hardpoint)
+
+      assert_equal 1, hardpoint.builds.count
+    end
+
+    test "#process picks up a slot whose facts changed since the last run" do
+      hardpoint = create(:hardpoint, source: :game_files, min_size: 2)
+      @task.process(hardpoint)
+
+      hardpoint.update!(min_size: 5, max_size: 5)
+      @task.process(hardpoint)
+
+      assert_equal 5, hardpoint.builds.sole.min_size
+    end
+
+    # Another environment's row is a separate row, not a rewrite of this one --
+    # the whole point of the table.
+    test "#process leaves another environment's row alone" do
+      hardpoint = create(:hardpoint, source: :game_files, min_size: 2)
+      other = create(:hardpoint_build, hardpoint:, environment: "ptu",
+        version: "9.9.9-ptu.1", min_size: 7)
+
+      @task.process(hardpoint)
+
+      assert_equal 2, hardpoint.builds.count
+      assert_equal 7, other.reload.min_size
+    end
+  end
+end


### PR DESCRIPTION
Step 1 of #4756. The table, the model and the associations, populated — and
**nothing reads it yet, no loader writes it yet either.** The behaviour change
is step 2.

## Why

The loadout is the one thing the row-per-build work never covered. `hardpoints`
carries no `environment`, and `persist_loadout` destroys every game-file row the
loaded build does not name, so loading PTU replaces live's loadouts in place.
#4758 pins that; both of its assertions invert when step 2 lands.

The split is one layer deeper than the catalogues need, because a loadout differs
between builds in *structure* and not only in facts: the slot — `parent` plus
`sc_name` — stays on `hardpoints` and is what `ModelPosition` already points at,
while what a build says is in it moves to the build row. A slot the build does
not describe gets no row, and that is what replaces the destroy.

## Two things worth a reviewer's eye

**The unique index is scoped to `game_files`, and it has to be.** #4756 said to
add it unscoped. That is impossible — measured on the real table before writing
it:

| | |
| --- | --- |
| duplicate groups, unscoped | **1,222** |
| excess rows | **2,406** |
| of those, `ship_matrix` | **all of them** |

The matrix half is not a set of named ports: it repeats names by design, and a
ship carries 32 rows called `Maneuvering Thruster`. So "the slot called X on this
parent" is well defined for game-file rows and meaningless for matrix ones —
the same asymmetry that keeps build rows off the matrix half. Three tests cover
it: the game-files duplicate is refused, the matrix duplicate is allowed, and a
name shared across the two sources does not collide. The third commit here
corrects step 1 of the plan, now that it is on `main` saying the wrong thing.

Worth reading as more than an index detail: it is a second, independent argument
for the constraint that keeps build rows off the matrix half. "The slot called X
on this parent" is well defined on one side and meaningless on the other, which
is the same reason the matrix cannot answer "is it in this build" by row
existence.

**The enum maps are shared rather than restated.** `group` and `category` derive
from the installed component, so they move to the build row, and a build holding
`40` has to read as `weapons` exactly as the slot's column does. I wrote a second
copy first and **got the category map wrong** — invented plausible values instead
of the real `fueltanks: 20` / `main_thrusters: 30` / `unknown: 999`. They are now
constants on `Hardpoint` that `HardpointBuild` reads, with a test asserting the
two stay equal.

## The backfill is a maintenance task, not a data migration

`bin/deploy-release` runs `bin/rails db:migrate data:migrate` inside the Kamal
pre-deploy hook. As a migration the backfill would put **two minutes of measured
work** in front of every deploy — 22,561 slots at one lookup and one insert each
— the hook retries three times and would re-scan the table on each attempt, and
a leaked Kamal lock from a failed deploy kills the next one before it can run
the fix.

`Maintenance::BackfillHardpointBuildsTask` is triggered once, watched and
resumable, and the deploy stays fast. No `dry_run` attribute on it: one that
defaults to true makes a console run roll back silently while still reporting
"succeeded", and an additive backfill that deletes nothing has nothing to
rehearse.

## The backfill, verified

On a database restored from a production dump, running the task after deleting
the rows the migration version had written:

| | |
| --- | --- |
| game-file slots | 22,561 |
| build rows written | **22,561** |
| carrying a component | 16,119 |
| rows against a matrix slot | **0** |
| slots differing from their build row | **0** of 22,561 |

That last one is compared *through the models*, which matters: a raw column
comparison reports 4 differences, and all four are storage formatting —
`["A", "A"]` against `["A","A"]`, and `"[]"` against `NULL`, which a
`type: Array` serializer reads back as `[]` either way.

The task records why the current columns are taken to describe the configured
source: `persist_loadout` destroys every game-file row a run did not
touch, so what survives is what the last load wrote. That premise holds only
while nothing can load a second environment — item 3 of the parent plan — and
item 3 is gated on this work, so the two cannot cross.

## Tests

`test/models/hardpoint_build_test.rb`, 13 cases. Plus the suites that could have
been broken by the index: **730** across `test/loaders/sc_data/` and
`test/models/`, and **65** hardpoint and loadout endpoint tests. All green.

🤖
