### PR TITLE
feat(sc_data): dual-write what a build says about a hardpoint

### DIFF
--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -460,6 +460,19 @@ module ScData
 
         apply(hardpoint, update_params)
 
+        # Dual-written from here: the row keeps the facts and the build row gets
+        # a copy, so the reads can move over in their own step. Read off the
+        # hardpoint rather than off `update_params`, because `group`, `category`
+        # and `group_key` are derived by Hardpoint's `before_validation` and are
+        # only correct once `apply` has saved.
+        #
+        # A `retain_only` slot returns above and gets no build row on purpose: it
+        # exists to keep a leftover row alive through the cleanup, and it
+        # describes a build where the component was not yet hidden. What that
+        # should mean once the cleanup retires build rows instead of destroying
+        # slots is a decision for that step, not this one.
+        apply_build(hardpoint, HardpointBuild.facts_from(hardpoint))
+
         persist_loadout(hardpoint, slot.children) if slot.children.present?
 
         hardpoint.id

--- a/app/models/hardpoint_build.rb
+++ b/app/models/hardpoint_build.rb
@@ -84,6 +84,17 @@ class HardpointBuild < ApplicationRecord
   validates :version, presence: true
   validates :hardpoint_id, uniqueness: {scope: [:environment, :version]}
 
+  # The facts a build row holds, read off a slot. Deliberately read from the
+  # record rather than from whatever params a caller has in hand: `group`,
+  # `category` and `group_key` are derived by Hardpoint's `before_validation`,
+  # so they are only correct once the slot itself has been saved.
+  #
+  # One method because both writers need exactly this -- the loader's dual-write
+  # and the backfill task -- and a second copy of the list would drift.
+  def self.facts_from(hardpoint)
+    FACTS.index_with { |fact| hardpoint.public_send(fact) }
+  end
+
   # Every build this environment still has.
   scope :for_source, ->(source = ::ScData::Source.current) {
     where(environment: source.environment)

--- a/app/tasks/maintenance/backfill_hardpoint_builds_task.rb
+++ b/app/tasks/maintenance/backfill_hardpoint_builds_task.rb
@@ -44,9 +44,7 @@ module Maintenance
       # Assigned through the model rather than written raw, because the enums and
       # the serialized arrays have to go back through the build's own casters:
       # `hardpoint.group` hands back "weapons" and the build stores 40.
-      build.assign_attributes(
-        HardpointBuild::FACTS.index_with { |fact| hardpoint.public_send(fact) }
-      )
+      build.assign_attributes(HardpointBuild.facts_from(hardpoint))
 
       return unless build.changed?
 

--- a/docs/exec-plans/sc-data-hardpoints-per-build.md
+++ b/docs/exec-plans/sc-data-hardpoints-per-build.md
@@ -127,16 +127,43 @@ separate and unblocked.
    which is the same asymmetry that keeps build rows off the matrix half. It is
    worth reading as a second, independent argument for that constraint rather
    than as a detail of the index.
-2. **Dual-write.** `persist_slot` calls `apply_build` alongside `apply`, and
-   `persist_loadout` stops destroying: `retire_absent_builds(HardpointBuild,
-   :hardpoint_id, …)` takes its place for the `game_files` half. This is the PR
-   that makes a second load non-destructive, and it is the one item 3 is gated
-   on.
+2. **Dual-write, cleanup untouched.** `persist_slot` calls `apply_build`
+   alongside `apply`. No behaviour change: build rows start existing, and a slot
+   still exists if and only if it has a row for the current build, because the
+   destroy is still there and takes the build row with it on the cascade.
 3. **Move the reads.** `api/v1/hardpoints/_base.jbuilder` and everything that
    embeds it resolve facts through the build, and the nested `json.hardpoints`
-   recursion filters to children the build describes.
-4. **Drop the columns**, after (3) has been on `main` long enough to trust —
-   and this folds into item 4 of the parent plan rather than standing alone.
+   recursion filters to children the build describes. Still no visible change,
+   for the same reason: with the destroy in place, "has a build row" and "exists"
+   are the same predicate.
+4. **Stop destroying.** `persist_loadout` retires build rows instead of
+   destroying slots, and *this* is the PR that fixes the bug and the one item 3
+   of the parent plan is gated on.
+5. **Drop the columns**, after (4) has been on `main` long enough to trust — and
+   this folds into item 4 of the parent plan rather than standing alone.
+
+**The order of (3) and (4) is not interchangeable, and an earlier version of
+this plan had them the other way round.** `Api::V1::ModelsController#hardpoints`
+serves `model.hardpoints.includes(:component)` filtered by nothing but `source`.
+Stop destroying while the reads are still column-based and every slot retired by
+every past build appears in that response at once — along with stale children in
+the `json.hardpoints` recursion and a changed `group_key`, since `group_keys`
+counts a slot's children. Moving the reads first makes (4) a pure improvement:
+a retired slot keeps its row, has no build row, and simply stops being offered.
+
+Two things (4) has to get right, noted while (2) was written:
+
+- **`retire_absent_builds` is global.** It does
+  `build_class.current(source).where.not(foreign_key => loaded)`, and
+  `persist_loadout` runs per parent and again per nested level — so used as-is,
+  the first call would retire every other ship's build rows. It needs scoping to
+  the parent's own slots.
+- **A `retain_only` slot has no build row**, deliberately: it exists to keep a
+  leftover alive through the cleanup and describes a build where the component
+  was not yet hidden. Once existence is decided by the build row, that row stops
+  being offered. That is probably right, and it changes a characterized
+  behaviour, so it has to be a decision rather than a side effect. Pinned in
+  `base_loader_loadout_test.rb`.
 
 ## Risks
 

--- a/test/loaders/sc_data/base_loader_loadout_test.rb
+++ b/test/loaders/sc_data/base_loader_loadout_test.rb
@@ -26,6 +26,16 @@ module ScData
         parent.hardpoints.reload.where(source: :game_files)
       end
 
+      # A loader reads its build from `ScData::Source` in the constructor, so
+      # wrapping a call in `ScData::Source.with` does not move it -- and
+      # `sc_environment` is an accessor precisely so a caller can point a loader
+      # it already has somewhere else. This is what a load of another
+      # environment actually looks like.
+      private def loading_as(environment, version)
+        @loader.sc_environment = environment
+        @loader.sc_version = version
+      end
+
       # --- Resolution by key ------------------------------------------------
 
       test "creates a game_files hardpoint per entry and resolves the component by key" do
@@ -403,35 +413,125 @@ module ScData
       end
 
       # The finding from the first real PTU load, pinned here because nothing in
-      # the suite covered it: `hardpoints` carries no `environment`, and nothing
-      # below `update_loadout` consults `ScData::Source`. The block around each
-      # load makes no difference to what is written, which is the point -- the
-      # two environments share one set of rows, and the second load to run
-      # destroys what the first wrote rather than sitting beside it.
+      # the suite covered it: `hardpoints` carries no `environment`, so the two
+      # environments share one set of rows and the second load to run destroys
+      # what the first wrote rather than sitting beside it.
       #
       # `4.10.1-ptu.12578875` did not expose this in the real load: it agrees
       # with `4.10.0-live.12519617` on every loadout, so there was nothing to
       # destroy. A build where they diverge rewrites live's ship pages.
       #
       # This is a bug, and it is item 2 of `docs/exec-plans/sc-data-live-and-ptu.md`.
-      # Once a slot carries builds, the live hardpoint has to survive with no
-      # build row for ptu, and both assertions here invert.
+      # Once the reads resolve through the build and the cleanup stops
+      # destroying, the live slot has to survive with no build row for ptu, and
+      # every assertion here inverts.
       test "a load for another environment destroys the loadout the first one wrote" do
         create(:component, sc_key: "live_component")
         create(:component, sc_key: "ptu_component")
 
-        ::ScData::Source.with(::ScData::Source.new(environment: "live", version: "1.0.0-live.1")) do
-          update_loadout(@model, {"loadout" => [{"name" => "live_only", "key" => "live_component"}]})
-        end
+        loading_as("live", "1.0.0-live.1")
+        update_loadout(@model, {"loadout" => [{"name" => "live_only", "key" => "live_component"}]})
 
         live_hardpoint = game_files_hardpoints(@model).sole
+        live_build = live_hardpoint.builds.sole
 
-        ::ScData::Source.with(::ScData::Source.new(environment: "ptu", version: "1.0.1-ptu.2")) do
-          update_loadout(@model, {"loadout" => [{"name" => "ptu_only", "key" => "ptu_component"}]})
-        end
+        loading_as("ptu", "1.0.1-ptu.2")
+        update_loadout(@model, {"loadout" => [{"name" => "ptu_only", "key" => "ptu_component"}]})
 
-        refute Hardpoint.exists?(live_hardpoint.id), "the live loadout is destroyed, not retired"
+        refute Hardpoint.exists?(live_hardpoint.id), "the live slot is destroyed, not retired"
         assert_equal ["ptu_only"], game_files_hardpoints(@model).pluck(:sc_name)
+
+        # And the build row goes with it, on the cascade. Writing build rows is
+        # not on its own enough: what live said is gone either way until the
+        # cleanup stops destroying slots.
+        refute HardpointBuild.exists?(live_build.id)
+      end
+
+      # --- Dual-write --------------------------------------------------------
+
+      test "writes a build row carrying what the slot says" do
+        component = create(:component, sc_key: "torpedo_rack_s9", size: "9")
+
+        loading_as("live", "1.0.0-live.1")
+        update_loadout(@model, {"loadout" => [{
+          "name" => "hardpoint_torpedo",
+          "key" => "torpedo_rack_s9",
+          "min_size" => "3",
+          "types" => ["MissileLauncher"],
+          "port_tags" => ["Eclipse_BombRack"],
+          "required_tags" => ["Eclipse_BombRack"],
+          "flags" => ["editable"]
+        }]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        build_row = hardpoint.builds.sole
+
+        assert_equal "live", build_row.environment
+        assert_equal "1.0.0-live.1", build_row.version
+        assert_equal component.id, build_row.component_id
+        assert_equal 3, build_row.min_size
+        assert_equal 9, build_row.max_size
+        assert_equal ["MissileLauncher"], build_row.types
+        assert_equal ["Eclipse_BombRack"], build_row.port_tags
+        assert_equal ["Eclipse_BombRack"], build_row.required_tags
+        assert_equal ["editable"], build_row.flags
+      end
+
+      # `group`, `category` and `group_key` are derived by Hardpoint's
+      # `before_validation`, so they are only correct once the slot has saved --
+      # which is why the build row is read off the record rather than off the
+      # params the walk had in hand.
+      test "carries the derived group and category onto the build row" do
+        create(:component, sc_key: "shield_s2", size: "2", category: "shieldgenerator")
+
+        update_loadout(@model, {"loadout" => [{"name" => "hardpoint_shield", "key" => "shield_s2"}]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        build_row = hardpoint.builds.sole
+
+        assert_equal hardpoint.group, build_row.group
+        assert_equal hardpoint.category, build_row.category
+        assert_equal hardpoint.group_key, build_row.group_key
+        assert_not_nil build_row.group
+      end
+
+      test "updates the build row in place when the same build is loaded again" do
+        create(:component, sc_key: "cooler_s1", size: "1")
+        create(:component, sc_key: "cooler_s3", size: "3")
+
+        loading_as("live", "1.0.0-live.1")
+        update_loadout(@model, {"loadout" => [{"name" => "hardpoint_cooler", "key" => "cooler_s1"}]})
+        update_loadout(@model, {"loadout" => [{"name" => "hardpoint_cooler", "key" => "cooler_s3"}]})
+
+        hardpoint = game_files_hardpoints(@model).sole
+        assert_equal 1, hardpoint.builds.count
+        assert_equal 3, hardpoint.builds.sole.min_size
+      end
+
+      # A `retain_only` slot exists to keep a leftover row alive through the
+      # cleanup, and it describes a build where the component was not yet hidden.
+      # It gets no build row, so once the cleanup retires build rows rather than
+      # destroying slots, this row stops being offered -- which is a decision for
+      # that step and is pinned here so it has to be made deliberately.
+      test "writes no build row for a slot the walk only retains" do
+        cargo_grid = create(:component, sc_key: "cargo_grid_s4")
+        door = create(:component, :hidden, sc_key: "cargo_door")
+        create(:hardpoint, parent: door, sc_name: "grid", component: cargo_grid, source: :game_files)
+
+        # The retained row has to pre-exist: `retain_only` protects a leftover
+        # from the cleanup and never creates one.
+        stale = create(:hardpoint, parent: @model, sc_name: "hardpoint_door",
+          component: create(:component, sc_key: "old_door_component"), source: :game_files)
+
+        update_loadout(@model, {"loadout" => [{"name" => "hardpoint_door", "key" => "cargo_door"}]})
+
+        assert Hardpoint.exists?(stale.id), "the leftover is still protected from cleanup"
+        assert_empty stale.reload.builds
+
+        # The slot the flattening promoted does get one -- it is part of this
+        # build's loadout.
+        promoted = game_files_hardpoints(@model).find_by(sc_name: "hardpoint_door-grid")
+        assert_not_nil promoted.builds.sole
       end
 
       # `cleanup: false` is what the hidden-component flattening recurses with,


### PR DESCRIPTION
Step 2 of `docs/exec-plans/sc-data-hardpoints-per-build.md`. `persist_slot`
writes the build row alongside the columns.

**No behaviour change.** The cleanup is untouched, so a slot still exists if and
only if it has a row for the current build — the destroy is still there and takes
the build row with it on the cascade. The two-environment test still asserts the
bug, and now asserts one more part of it.

## The plan had steps 3 and 4 the wrong way round

This is the finding of this PR, and the third commit fixes the plan.

`Api::V1::ModelsController#hardpoints` serves
`model.hardpoints.includes(:component)` filtered by nothing but `source`. Stop
destroying while the reads are still column-based and **every slot retired by
every past build appears in that response at once** — plus stale children in the
`json.hardpoints` recursion, and a changed `group_key`, because `group_keys`
counts a slot's children.

So the reads have to move first. Then stopping the destroy is a pure
improvement: a retired slot keeps its row, has no build row, and stops being
offered. The order is now 2 dual-write → 3 move the reads → 4 stop destroying →
5 drop the columns, and each step is independently safe.

Two things step 4 will have to get right, found while writing this one and
recorded in the plan:

- **`retire_absent_builds` is global.** It does
  `build_class.current(source).where.not(foreign_key => loaded)`, and
  `persist_loadout` runs per parent *and* again per nested level — so used as-is,
  the first call would retire every other ship's build rows.
- **A `retain_only` slot has no build row**, deliberately. Once existence is
  decided by the build row, that leftover stops being offered. That is probably
  right, and it changes a characterized behaviour, so it has to be a decision.
  Pinned in the test rather than left to happen.

## A correction to my own test from #4758

It wrapped its calls in `ScData::Source.with`, which **does not move the
loader** — a loader reads its build in the constructor, and `sc_environment` is
an accessor precisely so a caller can point one somewhere else. The destroy is
environment-blind, so the old assertions held anyway; with build rows in play the
test has to load as two real sources, and it now does. It also asserts the live
build row goes with the slot on the cascade, which is what shows that writing
build rows is not on its own enough.

## Also

`HardpointBuild.facts_from` (first commit) is what both writers need — the
backfill task and now the loader — and the reason the facts are read off the
record rather than off a caller's params belongs next to the list.

## Tests

Four new cases in the characterization file: the build row carries what the slot
says, the derived `group`/`category`/`group_key` come across as themselves,
re-loading the same build updates in place, and a `retain_only` slot gets none
while the slot the flattening promoted does.

**776 tests** across `test/loaders/sc_data/`, `test/models/` and
`test/tasks/maintenance/`, all green — the dual-write adds a write per slot, so
the loader stats assertions were the thing to check.

🤖
