### PR TITLE
feat(sc_data): read a hardpoint's facts through its build

### DIFF
--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -135,7 +135,13 @@ module Api
         model = find_model_by_slug!
         return if performed?
 
-        scope = model.hardpoints.includes(:component)
+        # `in_build` narrows to what this build describes; the nested levels are
+        # narrowed by the partial. The build rows are preloaded to the depth the
+        # export actually nests -- measured at three, with 638 slots at the
+        # deepest level -- since the partial reads `facts` on every child.
+        scope = model.hardpoints.in_build.includes(
+          :component, :build, hardpoints: [:component, :build, {hardpoints: [:component, :build]}]
+        )
 
         scope = scope.where(source: params[:source]) if params[:source].present?
 

--- a/app/models/hardpoint.rb
+++ b/app/models/hardpoint.rb
@@ -65,6 +65,19 @@ class Hardpoint < ApplicationRecord
   enum :source,
     {ship_matrix: 0, game_files: 1}
 
+  # The slots a build describes: the game-files ones carrying a row for it, plus
+  # the whole matrix half, which comes from no build and whose facts live only on
+  # the row.
+  #
+  # A no-op today for the game-files half, because the cleanup still destroys
+  # every slot a load did not name -- so a slot exists if and only if it has a
+  # row for the current build. It starts to mean something on the step that stops
+  # destroying, and it has to be in place first: the other order shows every slot
+  # ever retired in one response.
+  scope :in_build, ->(source = ::ScData::Source.current) {
+    where(source: :ship_matrix).or(where(id: HardpointBuild.current(source).select(:hardpoint_id)))
+  }
+
   # Named constants rather than inline maps, because `HardpointBuild` declares
   # the same two: `group` and `category` are derived from the installed
   # component, so they move to the build row, and a build holding `40` has to
@@ -98,6 +111,31 @@ class Hardpoint < ApplicationRecord
   enum :group, GROUPS, suffix: true
 
   enum :category, CATEGORIES, suffix: true
+
+  # What the build in force says about this slot, or the row itself when no build
+  # describes it -- which is the whole matrix half.
+  #
+  # An object to read from rather than reader overrides in the style of Component
+  # and Equipment, and for a reason particular to this table: Hardpoint derives
+  # `group`, `category` and `group_key` in a `before_validation`, and the enum
+  # predicates those derivations use read the *attribute* rather than the reader.
+  # Measured -- with `group` overridden to "weapon" over a stored `thruster`,
+  # `thruster_group?` still answers true. An override would leave
+  # `hardpoint.group` and `hardpoint.thruster_group?` disagreeing, and
+  # `group_keys` reads both.
+  #
+  # Read through entirely rather than field by field: a build row's nil is an
+  # answer, not a gap. An empty port in this build has to read as empty instead
+  # of falling through to whatever the column last held.
+  def facts
+    build || self
+  end
+
+  # Not in the build we are on -- a port the loadout no longer has. Only ever
+  # true for the game-files half; a matrix slot answers to no build.
+  def retired?
+    game_files? && build.blank?
+  end
 
   def self.ransackable_attributes(auth_object = nil)
     ["category", "component_id", "created_at", "group", "id", "parent_id", "parent_type",

--- a/app/views/api/v1/components/_base.jbuilder
+++ b/app/views/api/v1/components/_base.jbuilder
@@ -34,8 +34,11 @@ json.hidden component.hidden
 # export had dropped as though it were current.
 json.retired component.retired?
 
+# Narrowed the same way the nested levels are: a component's own ports are
+# game-file slots, and one this build no longer describes has to stop being
+# listed.
 json.hardpoints do
-  json.array! component.hardpoints, partial: "api/v1/hardpoints/base", as: :hardpoint
+  json.array! component.hardpoints.in_build, partial: "api/v1/hardpoints/base", as: :hardpoint
 end
 
 json.manufacturer do

--- a/app/views/api/v1/hardpoints/_base.jbuilder
+++ b/app/views/api/v1/hardpoints/_base.jbuilder
@@ -1,29 +1,38 @@
 # frozen_string_literal: true
 
+# What the build in force says about this slot. `hardpoint` still answers for
+# what identifies it -- the name, the source, the matrix key -- while everything
+# a build has an opinion about comes from `facts`, which is the build row or the
+# row itself for a matrix slot.
+facts = hardpoint.facts
+
 json.id hardpoint.id
 json.name hardpoint.sc_name
 
-json.group_key hardpoint.group_key
+json.group_key facts.group_key
 json.matrix_key hardpoint.matrix_key
 
-json.group hardpoint.group
+json.group facts.group
 json.source hardpoint.source
 
-json.min_size hardpoint.min_size
-json.max_size hardpoint.max_size
+json.min_size facts.min_size
+json.max_size facts.max_size
 
-json.types hardpoint.types
+json.types facts.types
 
-json.category hardpoint.category
+json.category facts.category
 
 json.details hardpoint.details
 
 json.component do
-  json.partial! "api/v1/components/base", component: hardpoint.component if hardpoint.component.present?
+  json.partial! "api/v1/components/base", component: facts.component if facts.component.present?
 end
 
+# Only the children this build describes. A slot the build dropped keeps its row
+# once the cleanup stops destroying, and a port that is no longer on the ship has
+# to stop being listed rather than be described from a build ago.
 json.hardpoints do
-  json.array! hardpoint.hardpoints, partial: "api/v1/hardpoints/base", as: :hardpoint
+  json.array! hardpoint.hardpoints.in_build, partial: "api/v1/hardpoints/base", as: :hardpoint
 end
 
 json.partial! "api/shared/dates", record: hardpoint

--- a/app/views/api/v1/models/hardpoints.jbuilder
+++ b/app/views/api/v1/models/hardpoints.jbuilder
@@ -3,4 +3,10 @@
 json.array! @hardpoints,
   partial: "api/v1/hardpoints/base",
   as: :hardpoint,
-  cached: ->(hardpoint) { ["v1", hardpoint, hardpoint.component, Manufacturer.artwork_version] }
+  # The build row is in the key because the facts now come from it: a build
+  # landing under an untouched slot leaves the row's own `updated_at` alone, so
+  # keying on the slot alone would serve the previous build's loadout. For a
+  # matrix slot `facts` is the slot itself and this collapses back to one entry.
+  cached: ->(hardpoint) {
+    ["v2", hardpoint, hardpoint.facts, hardpoint.facts.component, Manufacturer.artwork_version]
+  }

--- a/test/factories/hardpoint_builds.rb
+++ b/test/factories/hardpoint_builds.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     # `game_files` explicitly rather than the hardpoint factory's random source:
     # only that half carries build rows, and a matrix slot with one would be the
     # very thing the design forbids.
-    association :hardpoint, factory: :hardpoint, source: :game_files
+    association :hardpoint, factory: [:hardpoint, :without_build], source: :game_files
     environment { ScData::Source.environment }
     version { ScData::Source.version }
     min_size { 2 }

--- a/test/factories/hardpoints.rb
+++ b/test/factories/hardpoints.rb
@@ -37,5 +37,35 @@ FactoryBot.define do
     source { Hardpoint.sources.keys.sample }
     sc_name { Faker::Alphanumeric.alphanumeric(number: 10) }
     association :parent, factory: :model
+
+    transient { with_build { true } }
+
+    # A build describing the slot, mirroring what the backfill task did for the
+    # rows already in the table. Without one a game-files slot is in no build at
+    # all, and `in_build` -- so the endpoint -- does not offer it. The same
+    # reason the component factory carries one.
+    #
+    # Only the game-files half: the matrix comes from no build and `in_build`
+    # passes it without a row.
+    after(:create) do |hardpoint, evaluator|
+      next unless evaluator.with_build
+      next unless hardpoint.game_files?
+
+      hardpoint.builds.create!(
+        environment: ScData::Source.environment,
+        version: ScData::Source.version,
+        **HardpointBuild.facts_from(hardpoint)
+      )
+
+      # The slot was validated before this row existed, so `facts` may have
+      # cached the absence. Dropped so the record behaves like a loaded one.
+      hardpoint.association(:build).reset
+    end
+
+    # For tests that manage builds themselves and would otherwise collide with
+    # the one above.
+    trait :without_build do
+      with_build { false }
+    end
   end
 end

--- a/test/integration/api/v1/models_hardpoints_test.rb
+++ b/test/integration/api/v1/models_hardpoints_test.rb
@@ -39,4 +39,62 @@ class Api::V1::ModelsHardpointsTest < ActionDispatch::IntegrationTest
   test "GET /models/:slug/hardpoints returns 404 for unknown model" do
     assert_api_response :get, 404, path_params: {slug: "unknown-model"}
   end
+
+  # The facts come from the build row now, not from the slot's own columns. The
+  # two are dual-written and normally agree, so the only way to show which one
+  # is being read is to make them disagree.
+  test "GET /models/:slug/hardpoints reads what the build says, not the column" do
+    model = create(:model)
+    column_component = create(:component, name: "What The Column Says")
+    build_component = create(:component, name: "What The Build Says")
+
+    hardpoint = create(:hardpoint, :without_build, parent: model, sc_name: "hardpoint_power",
+      source: :game_files, component: column_component, min_size: 1, max_size: 1)
+    create(:hardpoint_build, hardpoint:, component: build_component, min_size: 4, max_size: 4)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      entry = parsed_body.sole
+
+      assert_equal "What The Build Says", entry.dig("component", "name")
+      assert_equal 4, entry["minSize"]
+      assert_equal 4, entry["maxSize"]
+    end
+  end
+
+  # A slot the build does not describe stops being offered. It keeps its row --
+  # once the cleanup stops destroying, that is what makes a retired port
+  # survivable -- but it is not part of this ship's loadout any more.
+  test "GET /models/:slug/hardpoints leaves out a slot no build describes" do
+    model = create(:model)
+    create(:hardpoint, parent: model, sc_name: "in_this_build", source: :game_files)
+    create(:hardpoint, :without_build, parent: model, sc_name: "retired", source: :game_files)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal ["in_this_build"], parsed_body.map { |entry| entry["name"] }
+    end
+  end
+
+  # The matrix half comes from no build and has no build row to find, so it must
+  # not be filtered out by the same rule.
+  test "GET /models/:slug/hardpoints still offers the ship-matrix slots" do
+    model = create(:model)
+    create(:hardpoint, parent: model, sc_name: "curated", source: :ship_matrix)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      assert_equal ["curated"], parsed_body.map { |entry| entry["name"] }
+    end
+  end
+
+  test "GET /models/:slug/hardpoints leaves a retired child out of the nesting" do
+    model = create(:model)
+    parent = create(:hardpoint, parent: model, sc_name: "turret", source: :game_files)
+    create(:hardpoint, parent:, sc_name: "kept_gun", source: :game_files)
+    create(:hardpoint, :without_build, parent:, sc_name: "retired_gun", source: :game_files)
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      nested = parsed_body.sole["hardpoints"]
+
+      assert_equal ["kept_gun"], nested.map { |entry| entry["name"] }
+    end
+  end
 end

--- a/test/loaders/sc_data/base_loader_loadout_test.rb
+++ b/test/loaders/sc_data/base_loader_loadout_test.rb
@@ -520,7 +520,8 @@ module ScData
 
         # The retained row has to pre-exist: `retain_only` protects a leftover
         # from the cleanup and never creates one.
-        stale = create(:hardpoint, parent: @model, sc_name: "hardpoint_door",
+        # `:without_build` on purpose: the point is a slot with no build row.
+        stale = create(:hardpoint, :without_build, parent: @model, sc_name: "hardpoint_door",
           component: create(:component, sc_key: "old_door_component"), source: :game_files)
 
         update_loadout(@model, {"loadout" => [{"name" => "hardpoint_door", "key" => "cargo_door"}]})

--- a/test/models/hardpoint_build_test.rb
+++ b/test/models/hardpoint_build_test.rb
@@ -9,7 +9,7 @@ class HardpointBuildTest < ActiveSupport::TestCase
   end
 
   test "a slot carries one row per build, not two" do
-    hardpoint = create(:hardpoint, source: :game_files)
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
     create(:hardpoint_build, hardpoint:, environment: @environment, version: @version)
 
     duplicate = build(:hardpoint_build, hardpoint:, environment: @environment, version: @version)
@@ -19,7 +19,7 @@ class HardpointBuildTest < ActiveSupport::TestCase
   end
 
   test "a later build of the same environment sits beside the earlier one" do
-    hardpoint = create(:hardpoint, source: :game_files)
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
     create(:hardpoint_build, hardpoint:, environment: @environment, version: "0.0.1-live.1")
     create(:hardpoint_build, hardpoint:, environment: @environment, version: "0.0.2-live.2")
 
@@ -27,7 +27,7 @@ class HardpointBuildTest < ActiveSupport::TestCase
   end
 
   test "the same slot can be described by more than one environment" do
-    hardpoint = create(:hardpoint, source: :game_files)
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
     create(:hardpoint_build, hardpoint:, environment: "live", version: @version)
     create(:hardpoint_build, hardpoint:, environment: "ptu", version: @version)
 
@@ -45,7 +45,7 @@ class HardpointBuildTest < ActiveSupport::TestCase
   # --- Which build is in force -----------------------------------------------
 
   test "#build resolves the row for the source in force and nothing else" do
-    hardpoint = create(:hardpoint, source: :game_files)
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
     live = create(:hardpoint_build, hardpoint:, environment: "live", version: "1.0.0-live.1")
     ptu = create(:hardpoint_build, hardpoint:, environment: "ptu", version: "1.0.1-ptu.2")
 
@@ -62,7 +62,7 @@ class HardpointBuildTest < ActiveSupport::TestCase
   # destroy in `persist_loadout`. So "no build" has to be a clean nil rather than
   # some other environment's row.
   test "#build is nil for a source that does not describe the slot" do
-    hardpoint = create(:hardpoint, source: :game_files)
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
     create(:hardpoint_build, hardpoint:, environment: "live", version: "1.0.0-live.1")
 
     ScData::Source.with(ScData::Source.new(environment: "ptu", version: "1.0.1-ptu.2")) do
@@ -71,7 +71,7 @@ class HardpointBuildTest < ActiveSupport::TestCase
   end
 
   test ".retained_versions keeps the newest builds of one environment, oldest first" do
-    hardpoint = create(:hardpoint, source: :game_files)
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
 
     %w[0.0.1-live.1 0.0.2-live.2 0.0.3-live.3 0.0.4-live.4].each_with_index do |version, index|
       create(:hardpoint_build, hardpoint:, environment: "live", version:,
@@ -117,10 +117,10 @@ class HardpointBuildTest < ActiveSupport::TestCase
   # and nothing enforced it.
   test "refuses a second game_files slot of the same name on one parent" do
     model = create(:model)
-    create(:hardpoint, parent: model, sc_name: "hardpoint_power", source: :game_files)
+    create(:hardpoint, :without_build, parent: model, sc_name: "hardpoint_power", source: :game_files)
 
     assert_raises(ActiveRecord::RecordNotUnique) do
-      create(:hardpoint, parent: model, sc_name: "hardpoint_power", source: :game_files)
+      create(:hardpoint, :without_build, parent: model, sc_name: "hardpoint_power", source: :game_files)
     end
   end
 
@@ -130,24 +130,85 @@ class HardpointBuildTest < ActiveSupport::TestCase
   # duplicate groups and 2,406 excess rows, every one of them ship_matrix.
   test "allows a repeated ship_matrix slot name, which the matrix relies on" do
     model = create(:model)
-    create(:hardpoint, parent: model, sc_name: "Maneuvering Thruster", source: :ship_matrix)
+    create(:hardpoint, :without_build, parent: model, sc_name: "Maneuvering Thruster", source: :ship_matrix)
 
     assert_nothing_raised do
-      create(:hardpoint, parent: model, sc_name: "Maneuvering Thruster", source: :ship_matrix)
+      create(:hardpoint, :without_build, parent: model, sc_name: "Maneuvering Thruster", source: :ship_matrix)
     end
   end
 
   test "does not collide a game_files slot with a matrix slot of the same name" do
     model = create(:model)
-    create(:hardpoint, parent: model, sc_name: "shared_name", source: :ship_matrix)
+    create(:hardpoint, :without_build, parent: model, sc_name: "shared_name", source: :ship_matrix)
 
     assert_nothing_raised do
-      create(:hardpoint, parent: model, sc_name: "shared_name", source: :game_files)
+      create(:hardpoint, :without_build, parent: model, sc_name: "shared_name", source: :game_files)
+    end
+  end
+
+  # --- Reading through the build ---------------------------------------------
+
+  # An object to read from rather than reader overrides in the style of
+  # Component, because Hardpoint derives group, category and group_key in a
+  # before_validation and the enum predicates those use read the attribute
+  # rather than the reader -- so an override would leave `group` and
+  # `thruster_group?` disagreeing.
+  test "#facts is the build row when one describes the slot" do
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
+    build_row = create(:hardpoint_build, hardpoint:)
+
+    assert_equal build_row, hardpoint.reload.facts
+  end
+
+  # The matrix half comes from no build, and its facts live only on the row.
+  test "#facts is the slot itself when no build describes it" do
+    hardpoint = create(:hardpoint, :without_build, source: :ship_matrix)
+
+    assert_equal hardpoint, hardpoint.facts
+  end
+
+  # A build row's nil is an answer, not a gap: an empty port in this build has
+  # to read as empty rather than falling through to the column.
+  test "#facts answers with the build's emptiness rather than the column's value" do
+    hardpoint = create(:hardpoint, :without_build, source: :game_files,
+      component: create(:component))
+    create(:hardpoint_build, hardpoint:, component: nil)
+
+    assert_nil hardpoint.reload.facts.component
+    assert_not_nil hardpoint.component, "the column still holds what it held"
+  end
+
+  test "#retired? is true only for a game-files slot no build describes" do
+    assert_predicate create(:hardpoint, :without_build, source: :game_files), :retired?
+    assert_not_predicate create(:hardpoint, source: :game_files), :retired?
+    assert_not_predicate create(:hardpoint, :without_build, source: :ship_matrix), :retired?
+  end
+
+  test ".in_build keeps the slots this build describes and the whole matrix half" do
+    described = create(:hardpoint, source: :game_files)
+    retired = create(:hardpoint, :without_build, source: :game_files)
+    matrix = create(:hardpoint, :without_build, source: :ship_matrix)
+
+    ids = Hardpoint.in_build.pluck(:id)
+
+    assert_includes ids, described.id
+    assert_includes ids, matrix.id
+    assert_not_includes ids, retired.id
+  end
+
+  test ".in_build resolves against the source asked for" do
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
+    create(:hardpoint_build, hardpoint:, environment: "ptu", version: "9.9.9-ptu.1")
+
+    assert_not_includes Hardpoint.in_build.pluck(:id), hardpoint.id
+
+    ScData::Source.with(ScData::Source.new(environment: "ptu", version: "9.9.9-ptu.1")) do
+      assert_includes Hardpoint.in_build.pluck(:id), hardpoint.id
     end
   end
 
   test "goes away with the slot it describes" do
-    hardpoint = create(:hardpoint, source: :game_files)
+    hardpoint = create(:hardpoint, :without_build, source: :game_files)
     build_row = create(:hardpoint_build, hardpoint:)
 
     hardpoint.destroy!

--- a/test/tasks/maintenance/backfill_hardpoint_builds_task_test.rb
+++ b/test/tasks/maintenance/backfill_hardpoint_builds_task_test.rb
@@ -10,8 +10,8 @@ module Maintenance
     end
 
     test "#collection is the game-file slots and not the matrix ones" do
-      game_files = create(:hardpoint, source: :game_files)
-      matrix = create(:hardpoint, source: :ship_matrix)
+      game_files = create(:hardpoint, :without_build, source: :game_files)
+      matrix = create(:hardpoint, :without_build, source: :ship_matrix)
 
       ids = @task.collection.pluck(:id)
 
@@ -44,7 +44,7 @@ module Maintenance
     # `before_validation`. They have to survive the trip as the same enum value,
     # which is what the shared constant on Hardpoint is for.
     test "#process carries the derived group and category across as themselves" do
-      hardpoint = create(:hardpoint, source: :game_files,
+      hardpoint = create(:hardpoint, :without_build, source: :game_files,
         component: create(:component, category: "weapons"))
 
       @task.process(hardpoint)
@@ -58,7 +58,7 @@ module Maintenance
     # Additive and re-runnable: the row for a source is updated in place rather
     # than a second one landing beside it.
     test "#process is idempotent for the same source" do
-      hardpoint = create(:hardpoint, source: :game_files, min_size: 2)
+      hardpoint = create(:hardpoint, :without_build, source: :game_files, min_size: 2)
 
       @task.process(hardpoint)
       @task.process(hardpoint)
@@ -67,7 +67,7 @@ module Maintenance
     end
 
     test "#process picks up a slot whose facts changed since the last run" do
-      hardpoint = create(:hardpoint, source: :game_files, min_size: 2)
+      hardpoint = create(:hardpoint, :without_build, source: :game_files, min_size: 2)
       @task.process(hardpoint)
 
       hardpoint.update!(min_size: 5, max_size: 5)
@@ -79,7 +79,7 @@ module Maintenance
     # Another environment's row is a separate row, not a rewrite of this one --
     # the whole point of the table.
     test "#process leaves another environment's row alone" do
-      hardpoint = create(:hardpoint, source: :game_files, min_size: 2)
+      hardpoint = create(:hardpoint, :without_build, source: :game_files, min_size: 2)
       other = create(:hardpoint_build, hardpoint:, environment: "ptu",
         version: "9.9.9-ptu.1", min_size: 7)
 


### PR DESCRIPTION
Step 3 of `docs/exec-plans/sc-data-hardpoints-per-build.md`. The API resolves
what is in a slot through the build row, and a slot no build describes stops
being offered.

**Invisible on deploy, by construction.** The cleanup still destroys every slot a
load did not name, so a game-files slot exists if and only if it has a row for
the current build — and the backfill task has given every existing one a row. It
starts to matter on step 4, and it has to be in place first: the other order puts
every slot ever retired into one response.

## `facts` is an object, not reader overrides — and that is measured

`Component` and `Equipment` override their readers (`READ_THROUGH.each { define_method … }`).
That does not work here. `Hardpoint` derives `group`, `category` and `group_key`
in a `before_validation`, and the **enum predicates those derivations use read
the attribute, not the reader**:

```
attribut:   thruster
reader:     weapon          # overridden
praedikat:  thruster_group? -> true, weapon_group? -> false
```

So an override would leave `hardpoint.group` and `hardpoint.thruster_group?`
disagreeing, and `Hardpoint#group_keys` reads both. `facts` — the build row, or
the slot itself when nothing describes it — keeps the derivation out of it.

## Read through entirely, not field by field

Also unlike the catalogues, which do `value.nil? ? super() : value`. **A build
row's nil is an answer, not a gap.** An empty port in this build has to read as
empty rather than falling through to whatever the column last held. The column
answers only for a slot with *no build row at all*, which is the whole
ship-matrix half: it comes from no build, so `in_build` passes it without one and
`retired?` is never true for it.

## The fragment cache

`models/hardpoints.jbuilder` keyed on `["v1", hardpoint, hardpoint.component, …]`.
The facts come from the build row now, and a build landing under an untouched slot
leaves the slot's own `updated_at` alone — so keying on the slot alone would serve
the previous build's loadout. The build row is in the key and the prefix is `v2`.
This was on the plan's risk list.

## Tests

The one that actually proves the read-through has to make the two disagree,
since they are dual-written and normally identical:

```ruby
hardpoint = create(:hardpoint, :without_build, component: column_component, min_size: 1)
create(:hardpoint_build, hardpoint:, component: build_component, min_size: 4)
# → the endpoint answers "What The Build Says" and minSize 4
```

Plus: a slot no build describes is left out, the matrix slots are still offered,
a retired child is left out of the nesting, and on the model side `facts`,
`retired?` and `in_build` including the per-source case.

The hardpoint factory now creates a build row for a game-files slot, with a
`:without_build` trait for tests that manage builds themselves — the same reason
the component factory carries one, and without it a slot is in no build and the
endpoint does not offer it. That is why several existing tests gained the trait.

**1,324 tests** across `test/loaders/sc_data/`, `test/models/`,
`test/tasks/maintenance/` and every hardpoint, loadout, component and model
endpoint test. All green.

🤖
