### PR TITLE
feat(sc_data): retire a hardpoint's build instead of destroying the slot

### DIFF
--- a/app/lib/sc_data/loader/base_loader.rb
+++ b/app/lib/sc_data/loader/base_loader.rb
@@ -441,9 +441,29 @@ module ScData
       private def persist_loadout(parent, slots, cleanup: true)
         hardpoint_ids = slots.filter_map { |slot| persist_slot(parent, slot) }
 
-        parent.hardpoints.where(source: :game_files).where.not(id: hardpoint_ids).destroy_all if cleanup
+        retire_absent_slots(parent, hardpoint_ids) if cleanup
 
         hardpoint_ids
+      end
+
+      # What the destroy became. A slot this build no longer names keeps its row
+      # and loses its row for this build, which is what makes it retired -- so a
+      # load of one environment stops reaching into what another one wrote, and
+      # a `ModelPosition` pointing at a port survives a patch that dropped it.
+      #
+      # Scoped to this parent's own slots rather than going through
+      # `retire_absent_builds`, which is global: `persist_loadout` runs once per
+      # parent and again per nested level, so the unscoped version would retire
+      # every other ship's build rows on the first call.
+      #
+      # `where.not(id: [])` is `1=1` here on purpose, matching the destroy it
+      # replaces: a loadout that named nothing retires everything the parent had.
+      # That is the opposite of `retire_absent`, which guards against it, because
+      # there a run that loaded nothing would sweep a whole catalogue.
+      private def retire_absent_slots(parent, hardpoint_ids)
+        absent = parent.hardpoints.where(source: :game_files).where.not(id: hardpoint_ids)
+
+        HardpointBuild.current(source).where(hardpoint_id: absent.select(:id)).delete_all
       end
 
       private def persist_slot(parent, slot)

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -58,6 +58,14 @@ module ScData
 
         prune_builds(ModelBuild)
 
+        # Hardpoint builds are pruned here rather than in each loader that
+        # writes them: `prune_builds` is global to an environment, and this
+        # loader writes the bulk of them -- 15,138 model-parented slots and
+        # 3,617 nested ones against the items loader's 3,789. The module loader
+        # runs after this and writes 22, which the next run prunes; at three
+        # retained builds that is harmless.
+        prune_builds(HardpointBuild)
+
         Hardpoint.find_each(&:save) # hack to generate correct group_keys
       end
 

--- a/app/models/model_position.rb
+++ b/app/models/model_position.rb
@@ -87,7 +87,7 @@ class ModelPosition < ApplicationRecord
     end
 
     # 3. Loadmaster (if max_crew > 1 AND model has cargogrid hardpoint)
-    if model.max_crew.to_i > 1 && model.hardpoints.where(category: :cargogrid).exists?
+    if model.max_crew.to_i > 1 && model.hardpoints.in_build.where(category: :cargogrid).exists?
       positions << {
         name: "Loadmaster",
         position_type: :loadmaster,
@@ -112,14 +112,22 @@ class ModelPosition < ApplicationRecord
     model.update_column(:positions_need_curation, needs_curation) if model.positions_need_curation != needs_curation
   end
 
+  # `in_build` on all three collectors: a slot the build dropped keeps its row
+  # now that the loadout is retired rather than destroyed, and its columns still
+  # hold whatever the last load to touch it wrote. Without this, a ship keeps
+  # generating positions for a seat it no longer has.
+  #
+  # The filters stay on the columns rather than the build row because the two are
+  # dual-written and agree for any slot still in the build. They have to become
+  # joins to the build when the columns go.
   def self.collect_seat_hardpoints(model)
-    model.hardpoints.includes(:component).where(group: :seat).select do |hp|
+    model.hardpoints.in_build.includes(:component).where(group: :seat).select do |hp|
       hp.sc_name.present? && !hp.sc_name.include?("_access")
     end
   end
 
   def self.collect_manned_turret_hardpoints(model)
-    model.hardpoints.includes(:component).where.not(component: nil).select do |hp|
+    model.hardpoints.in_build.includes(:component).where.not(component: nil).select do |hp|
       hp.component&.item_type == "manned_turrets" ||
         (hp.component&.name == "Manned Turret" && hp.component&.component_type == "TurretBase")
     end

--- a/test/loaders/sc_data/base_loader_loadout_test.rb
+++ b/test/loaders/sc_data/base_loader_loadout_test.rb
@@ -391,14 +391,31 @@ module ScData
 
       # --- Cleanup ----------------------------------------------------------
 
-      test "destroys game_files hardpoints the run did not touch" do
+      # This used to destroy the row. It retires it instead: the slot stays, and
+      # what it loses is its row for this build -- which is what makes a load of
+      # one environment stop reaching into what another one wrote, and what lets
+      # a ModelPosition pointing at a dropped port survive the patch.
+      test "retires game_files hardpoints the run did not touch, keeping the row" do
         create(:component, sc_key: "kept_component")
         stale = create(:hardpoint, parent: @model, sc_name: "gone", source: :game_files)
 
         update_loadout(@model, {"loadout" => [{"name" => "kept", "key" => "kept_component"}]})
 
-        refute Hardpoint.exists?(stale.id)
-        assert_equal ["kept"], game_files_hardpoints(@model).pluck(:sc_name)
+        assert Hardpoint.exists?(stale.id), "the row survives"
+        assert_predicate stale.reload, :retired?
+        assert_equal ["kept"], game_files_hardpoints(@model).in_build.pluck(:sc_name)
+      end
+
+      # A loadout that resolved to nothing retires everything the parent had,
+      # which is what the destroy did too -- `where.not(id: [])` is `1=1`, and
+      # here that is deliberate rather than the trap it is in `retire_absent`.
+      test "retires everything under a parent when the loadout named nothing" do
+        existing = create(:hardpoint, parent: @model, sc_name: "was_here", source: :game_files)
+
+        update_loadout(@model, {"loadout" => [{"name" => "hardpoint_console_catwalk"}]})
+
+        assert Hardpoint.exists?(existing.id)
+        assert_predicate existing.reload, :retired?
       end
 
       # Ship-matrix hardpoints are the curated ones. A game-files load must not
@@ -412,20 +429,16 @@ module ScData
         assert Hardpoint.exists?(curated.id)
       end
 
-      # The finding from the first real PTU load, pinned here because nothing in
-      # the suite covered it: `hardpoints` carries no `environment`, so the two
-      # environments share one set of rows and the second load to run destroys
-      # what the first wrote rather than sitting beside it.
+      # The finding from the first real PTU load, and the reason for all of this.
+      # It was pinned as a bug in #4758 and every assertion in it has now
+      # inverted: the two environments no longer share one set of rows in any way
+      # that matters, because a load retires build rows instead of destroying
+      # slots.
       #
-      # `4.10.1-ptu.12578875` did not expose this in the real load: it agrees
-      # with `4.10.0-live.12519617` on every loadout, so there was nothing to
-      # destroy. A build where they diverge rewrites live's ship pages.
-      #
-      # This is a bug, and it is item 2 of `docs/exec-plans/sc-data-live-and-ptu.md`.
-      # Once the reads resolve through the build and the cleanup stops
-      # destroying, the live slot has to survive with no build row for ptu, and
-      # every assertion here inverts.
-      test "a load for another environment destroys the loadout the first one wrote" do
+      # `4.10.1-ptu.12578875` never exposed it -- it agrees with
+      # `4.10.0-live.12519617` on every loadout, so there was nothing to destroy.
+      # This is the divergence that build never had.
+      test "a load for another environment leaves the first one's loadout intact" do
         create(:component, sc_key: "live_component")
         create(:component, sc_key: "ptu_component")
 
@@ -438,13 +451,39 @@ module ScData
         loading_as("ptu", "1.0.1-ptu.2")
         update_loadout(@model, {"loadout" => [{"name" => "ptu_only", "key" => "ptu_component"}]})
 
-        refute Hardpoint.exists?(live_hardpoint.id), "the live slot is destroyed, not retired"
-        assert_equal ["ptu_only"], game_files_hardpoints(@model).pluck(:sc_name)
+        assert Hardpoint.exists?(live_hardpoint.id), "the live slot survives the ptu load"
+        assert HardpointBuild.exists?(live_build.id), "and so does what live said about it"
 
-        # And the build row goes with it, on the cascade. Writing build rows is
-        # not on its own enough: what live said is gone either way until the
-        # cleanup stops destroying slots.
-        refute HardpointBuild.exists?(live_build.id)
+        # Each source sees its own loadout and only its own.
+        ::ScData::Source.with(::ScData::Source.new(environment: "live", version: "1.0.0-live.1")) do
+          assert_equal ["live_only"], game_files_hardpoints(@model).in_build.pluck(:sc_name)
+        end
+
+        ::ScData::Source.with(::ScData::Source.new(environment: "ptu", version: "1.0.1-ptu.2")) do
+          assert_equal ["ptu_only"], game_files_hardpoints(@model).in_build.pluck(:sc_name)
+        end
+      end
+
+      # A later build of the same environment is the case that still has to
+      # retire: live moving on from a port means the port is gone, not that a
+      # second opinion arrived.
+      test "a later build of the same environment retires what it no longer names" do
+        create(:component, sc_key: "old_component")
+        create(:component, sc_key: "new_component")
+
+        loading_as("live", "1.0.0-live.1")
+        update_loadout(@model, {"loadout" => [{"name" => "old_slot", "key" => "old_component"}]})
+
+        loading_as("live", "1.0.1-live.2")
+        update_loadout(@model, {"loadout" => [{"name" => "new_slot", "key" => "new_component"}]})
+
+        # `loading_as` points the loader; `in_build` is a *reader* and resolves
+        # against `ScData::Source`, so the read has to name the build too.
+        ::ScData::Source.with(::ScData::Source.new(environment: "live", version: "1.0.1-live.2")) do
+          assert_equal ["new_slot"], game_files_hardpoints(@model).in_build.pluck(:sc_name)
+        end
+
+        assert_equal 2, game_files_hardpoints(@model).count, "both rows are still there"
       end
 
       # --- Dual-write --------------------------------------------------------


### PR DESCRIPTION
Step 4 of `docs/exec-plans/sc-data-hardpoints-per-build.md`, and **the one that
fixes the bug the first real PTU load found.** `persist_loadout` no longer
destroys the game-file slots a build did not name; it deletes their row for that
build and leaves the slots alone.

Follows #4761, which had to be in first: with the reads still on the columns,
stopping the destroy puts every slot ever retired into one response.

## Measured on real data

`ModelsLoader` run against `4.10.1-ptu.12578875` in a database restored from a
production dump, with `4.10.0-live.12519617` already loaded:

| | before | after the PTU load |
| --- | --- | --- |
| `game_files` slots | 22,561 | **22,561** — nothing destroyed |
| `hardpoint_builds` live/4.10.0 | 22,561 | **22,561** — untouched |
| `hardpoint_builds` ptu/4.10.1 | 0 | 17,703 — beside live's, not over it |
| `in_build` as live | 22,561 | 22,561 |
| `in_build` as ptu | 0 | 17,703 |

Before this, the same load destroyed live's 17,708 model-parented slots. (17,703
against 22,561 is not a shortfall: only `ModelsLoader` was run, and the other
4,853 slots hang off components and come from `ItemsLoader`.)

**The parent-scoping is visible in those numbers too.** A live re-load reported
`Hardpoint updated=6 unchanged=17702` — 17,708 slots touched — while all 22,561
build rows survived. The 4,853 component-parented rows `ModelsLoader` never
visits kept theirs. `retire_absent_builds` used unscoped would have deleted every
one of them on the first call, because it does
`build_class.current(source).where.not(foreign_key => loaded)` and
`persist_loadout` runs once per parent *and* again per nested level.

## What inverted

Every assertion in the two-environment characterization test. It was pinned as a
bug in #4758 precisely so this could not happen quietly, and it now asserts that
each source sees its own loadout and only its own.

Kept working, and worth its own test: **a later build of the same environment
still retires what it no longer names.** Live moving on from a port means the
port is gone, not that a second opinion arrived.

`where.not(id: [])` being `1=1` is kept deliberately, matching the destroy it
replaces: a loadout that named nothing retires everything the parent had. That is
the opposite of `retire_absent`, which guards against exactly this — because
there a run that loaded nothing would sweep a whole catalogue.

## `ModelPosition` had to come along

On the plan's risk list, and it is real: its three collectors filter on the
columns, a retired slot keeps its row now, and its columns still hold whatever
the last load to touch it wrote. Without `in_build` a ship keeps generating
positions for a seat it no longer has. The filters stay on the columns because
the two are dual-written and agree for any slot still in the build — they have to
become joins when the columns go, which is step 5.

## Also

`HardpointBuild` is pruned in `ModelsLoader`, where the bulk of the rows are
written, so the table keeps three builds an environment rather than one set per
patch forever.

**1,326 tests** across the loader, model, task and endpoint suites. All green.

🤖
