### PR TITLE
fix(sc_data): let in_build tolerate an environment with no builds yet

### DIFF
--- a/app/models/hardpoint.rb
+++ b/app/models/hardpoint.rb
@@ -69,13 +69,46 @@ class Hardpoint < ApplicationRecord
   # the whole matrix half, which comes from no build and whose facts live only on
   # the row.
   #
-  # A no-op today for the game-files half, because the cleanup still destroys
-  # every slot a load did not name -- so a slot exists if and only if it has a
-  # row for the current build. It starts to mean something on the step that stops
-  # destroying, and it has to be in place first: the other order shows every slot
-  # ever retired in one response.
+  # And -- the third clause -- everything, while this environment has no build
+  # rows at all. That is the window between the build table shipping and the
+  # backfill task running: without it, deploying the build-resolved reads before
+  # that task drops all 22,561 game-file slots out of
+  # `/models/{slug}/hardpoints` at once and leaves only the 4,974 matrix ones,
+  # which for most ships is nothing.
+  #
+  # Deliberately asked of the environment rather than of the slot. "This slot has
+  # no build row" looks like the same thing and is not: retiring a slot *deletes*
+  # its row for that build, and `prune_builds` later drops the older ones, so a
+  # slot that left the game four builds ago would run out of rows and read as
+  # never-described -- quietly reappearing in the API. Asked of the environment,
+  # the clause stops applying the moment anything is loaded and never applies
+  # again.
+  #
+  # It is also uncorrelated, so Postgres evaluates it once per query rather than
+  # once per row, and `EXISTS` keeps all three clauses one predicate over
+  # indexed columns instead of an `.or` of three relations.
+  # Named placeholders because `:environment` is asked twice, and a constant
+  # because a heredoc has to open on the line it is used from.
+  IN_BUILD_SQL = <<~SQL.squish
+    hardpoints.source = :matrix
+    OR EXISTS (
+      SELECT 1 FROM hardpoint_builds
+       WHERE hardpoint_builds.hardpoint_id = hardpoints.id
+         AND hardpoint_builds.environment = :environment
+         AND hardpoint_builds.version = :version
+    )
+    OR NOT EXISTS (
+      SELECT 1 FROM hardpoint_builds WHERE hardpoint_builds.environment = :environment
+    )
+  SQL
+
   scope :in_build, ->(source = ::ScData::Source.current) {
-    where(source: :ship_matrix).or(where(id: HardpointBuild.current(source).select(:hardpoint_id)))
+    where(
+      sanitize_sql_array([
+        IN_BUILD_SQL,
+        {matrix: sources[:ship_matrix], environment: source.environment, version: source.version}
+      ])
+    )
   }
 
   # Named constants rather than inline maps, because `HardpointBuild` declares
@@ -133,6 +166,7 @@ class Hardpoint < ApplicationRecord
 
   # Not in the build we are on -- a port the loadout no longer has. Only ever
   # true for the game-files half; a matrix slot answers to no build.
+  #
   def retired?
     game_files? && build.blank?
   end

--- a/test/models/hardpoint_build_test.rb
+++ b/test/models/hardpoint_build_test.rb
@@ -196,9 +196,33 @@ class HardpointBuildTest < ActiveSupport::TestCase
     assert_not_includes ids, retired.id
   end
 
+  # The deploy this exists for: the build table and the build-resolved reads can
+  # ship before the backfill task has run, and without this clause every
+  # game-file slot drops out of the API at once -- 22,561 of them, leaving only
+  # the 4,974 matrix ones, which for most ships is nothing.
+  test ".in_build keeps everything while the environment has no build rows at all" do
+    slot = create(:hardpoint, :without_build, source: :game_files)
+    HardpointBuild.delete_all
+
+    assert_includes Hardpoint.in_build.pluck(:id), slot.id
+  end
+
+  # Asked of the environment rather than of the slot, and that distinction is
+  # the point: retiring a slot deletes its row for that build and `prune_builds`
+  # drops the older ones, so a per-slot version of this clause would let a slot
+  # that left the game four builds ago run out of rows and quietly reappear.
+  test ".in_build excludes a slot with no row once the environment has any" do
+    retired = create(:hardpoint, :without_build, source: :game_files)
+    create(:hardpoint, source: :game_files)
+
+    assert_not_includes Hardpoint.in_build.pluck(:id), retired.id
+  end
+
   test ".in_build resolves against the source asked for" do
     hardpoint = create(:hardpoint, :without_build, source: :game_files)
     create(:hardpoint_build, hardpoint:, environment: "ptu", version: "9.9.9-ptu.1")
+    # So the live half has rows of its own and the transition clause stays shut.
+    create(:hardpoint, source: :game_files)
 
     assert_not_includes Hardpoint.in_build.pluck(:id), hardpoint.id
 


### PR DESCRIPTION
**A deploy-order hazard I created and did not flag.** #4759 shipped the build
table and its backfill task; #4761 made the reads resolve through it. If the
build-resolved reads deploy **before that task has run**, `in_build` has no rows
to match and drops **all 22,561 game-file slots** out of
`/models/{slug}/hardpoints` at once, leaving only the 4,974 matrix ones — which
for most ships is nothing at all.

Both PRs are already merged, so the window is open now. This closes it; running
`Maintenance::BackfillHardpointBuildsTask` is still worth doing, it just stops
being load-bearing.

## Asked of the environment, not of the slot

The obvious version of this guard is "keep a slot that has no build row". That
looks like the same thing and is a slow leak:

- retiring a slot **deletes** its row for that build (#4762), and
- `prune_builds` later drops the older ones,

so a slot that left the game four builds ago runs out of rows, reads as
never-described, and quietly reappears in the API. I wrote that version first and
a characterization test caught it.

Asked of the environment — "does this environment have any build rows at all" —
the clause shuts the moment anything is loaded and never opens again.

## Cost: none measurable

It is uncorrelated, so Postgres lifts it into an `InitPlan` and evaluates it once
per query rather than once per row.

Measured in the shape the endpoint actually uses (one model, the largest one),
alternating five rounds:

| round | without | with |
| --- | --- | --- |
| 1 | 17.45 ms | 5.81 ms |
| 2 | 5.05 ms | 4.81 ms |
| 3 | 4.91 ms | 4.67 ms |
| 4 | 4.44 ms | 4.21 ms |
| 5 | 4.26 ms | 4.45 ms |

The spread inside each variant is wider than the gap between them, so there is
nothing to report. **Two earlier figures of mine were wrong** and are worth
naming: 44 ms came from measuring an unfiltered `COUNT` over all 27,540 rows,
which no caller does, and 14 ms was a cold first run.

## Tests

Two new cases — everything is kept while the environment has no rows, and a slot
with no row is excluded once the environment has any — plus the four existing
`in_build` and endpoint tests, which now have to give a slot's *environment*
some rows for the exclusion to be the thing under test.

`retired?` keeps its old reading; nothing in a read path uses it.

**2,044 tests** across `test/models/` and `test/integration/api/v1/`, plus 181
across the loader and hardpoint suites. Green.

🤖
