### PR TITLE
fix(sc_data): retry a failed object instead of failing the transfer

### DIFF
--- a/app/lib/sc_data/object_store.rb
+++ b/app/lib/sc_data/object_store.rb
@@ -16,9 +16,27 @@ module ScData
     # limits on the loaders container.
     CONCURRENCY = 16
 
+    # One object could not be moved after every attempt. Named rather than a
+    # bare string, because `raise "..."` is a RuntimeError and loses the class
+    # of what actually went wrong -- which is exactly what happened the first
+    # time a slow object failed a CI pull.
+    class TransferFailed < StandardError; end
+
     class NotConfigured < StandardError; end
 
     class MissingTree < StandardError; end
+
+    # A transfer is thousands of independent round trips, and each one is
+    # idempotent: a GET or a PUT of a single key. So a failure is worth another
+    # go rather than failing the whole run -- one object Hetzner did not answer
+    # in time used to kill a 15,103-object pull, in CI and in the loaders
+    # container alike.
+    #
+    # Bounded and short: the point is to ride out a slow object, not to sit
+    # through an outage. Three attempts at 0.5s and 1.0s adds at most 1.5s to a
+    # failure that was going to happen anyway.
+    ATTEMPTS = 3
+    RETRY_BACKOFF = 0.5
 
     # One object as a listing describes it.
     #
@@ -120,17 +138,43 @@ module ScData
         Thread.new do
           while (path = queue.pop)
             begin
-              yield path
+              with_retries { yield path }
             rescue => e
-              errors << "#{path}: #{e.message}"
+              errors << [path, e]
             end
           end
         end
       end.each(&:join)
 
-      raise errors.pop unless errors.empty?
+      unless errors.empty?
+        path, error = errors.pop
+
+        # The class is carried into the message as well as being the cause: this
+        # surfaces in a CI log and on a loaders container, where "which error"
+        # is the whole question.
+        raise TransferFailed, "#{path}: #{error.class}: #{error.message}"
+      end
 
       paths.size
+    end
+
+    # Retried for anything, deliberately. Telling a transient failure from a
+    # permanent one here would mean keeping a list of error classes in step with
+    # a provider's behaviour, and getting it wrong fails a whole transfer --
+    # while retrying a permanent failure only costs the backoff before it fails
+    # anyway.
+    private def with_retries
+      attempt = 0
+
+      begin
+        attempt += 1
+        yield
+      rescue
+        raise if attempt >= ATTEMPTS
+
+        sleep(RETRY_BACKOFF * attempt)
+        retry
+      end
     end
 
     private def bucket
@@ -156,7 +200,15 @@ module ScData
         endpoint: settings.fetch(:endpoint),
         access_key_id: settings.fetch(:access_key_id),
         secret_access_key: settings.fetch(:secret_access_key),
-        region: "unused"
+        region: "unused",
+
+        # The SDK classifies better than the retry above can -- throttling, 5xx
+        # and networking errors each get their own treatment and a jittered
+        # backoff. Raised from the default of three because a transfer this size
+        # will meet a slow object. `with_retries` is the backstop for whatever
+        # the SDK decides not to retry.
+        retry_limit: 5,
+        retry_mode: "standard"
       )
     end
   end

--- a/test/lib/sc_data/parsed_store_test.rb
+++ b/test/lib/sc_data/parsed_store_test.rb
@@ -169,6 +169,34 @@ module ScData
       assert File.exist?(File.join(@root, "models/aurora.json"))
     end
 
+    # --- Retries ----------------------------------------------------------
+
+    # A transfer is thousands of independent round trips and each one is
+    # idempotent, so one slow object must not fail the run. It used to: a single
+    # `commodities/jaclium_ore.json` that Hetzner did not answer in time failed a
+    # whole 15,103-object CI pull, and the same path runs on the loaders
+    # container.
+    test "#pull retries an object that failed and finishes the transfer" do
+      stub_listing("models/aurora.json" => "fetched")
+      @client.stub_responses(:get_object, [Timeout::Error.new("no answer"), {body: "fetched"}])
+
+      result = store.pull
+
+      assert_equal "fetched", File.read(File.join(@root, "models/aurora.json"))
+      assert_equal 1, result[:downloaded]
+    end
+
+    test "#pull gives up after the attempt limit and says which object and why" do
+      stub_listing("models/aurora.json" => "fetched")
+      @client.stub_responses(:get_object, Timeout::Error.new("no answer"))
+
+      error = assert_raises(::ScData::ParsedStore::TransferFailed) { store.pull }
+
+      assert_match "models/aurora.json", error.message
+      assert_match "Timeout::Error", error.message, "the class has to survive, not just the message"
+      assert_match "no answer", error.message
+    end
+
     # --- Version ----------------------------------------------------------
 
     test "#remote_version reads the version the parser stamped on the tree" do


### PR DESCRIPTION
**This is what made #4774 red**, and it would have done the same to a production
load.

```
app/lib/sc_data/object_store.rb:131:in 'each_in_parallel':
commodities/jaclium_ore.json: The server did not respond in time. (RuntimeError)
```

One object Hetzner did not answer in time failed a whole **15,103-object** pull.
A rerun passed unchanged. The same code path runs in the loaders container
through `FetchesParsedTree`, so this is not a CI-only annoyance — it fails a
`ScData::AllJob` too, which matters right before we start triggering PTU loads in
production.

#4774 made it likelier rather than causing it: adding a source to
`config/app/sc_data.yml` changes the CI cache key, which forces a full refetch
instead of a cache hit.

## Three changes

**Retries.** A transfer is thousands of independent round trips and every
operation is idempotent — a GET or a PUT of one key — so a failure gets another
go. Three attempts at 0.5s and 1.0s, so at most 1.5s added to a failure that was
going to happen anyway.

Retried for *anything*, deliberately. Telling a transient failure from a
permanent one here would mean keeping a list of error classes in step with a
provider's behaviour, and getting that wrong fails a whole transfer — while
retrying a permanent failure only costs the backoff before it fails regardless.

**The SDK's own retries** go from the default three to five in `standard` mode,
which classifies throttling, 5xx and networking errors apart and backs off with
jitter. `with_retries` is the backstop for whatever it declines to retry.

**The error class survives.** `raise errors.pop` raised a **String**, so
everything arrived as `RuntimeError` with the real class thrown away — which is
precisely why that CI log tells you nothing about what went wrong. Errors now
carry the exception object, and `TransferFailed` names the path, the class and
the message.

## Tests

Two cases: an object that fails once is retried and the transfer finishes, and
after the attempt limit the error names the object, the class and the message —
the last of which asserts `Timeout::Error` appears, because the message alone was
never the problem.

`test/lib/sc_data/` 69 tests, green.

Verified against the real bucket, since retry configuration is the kind of thing
that looks fine until it meets a network: a raw sync still settles for 77,200
unchanged in 28s, and a parsed push for 15,104 unchanged in 5s.

🤖
