### PR TITLE
fix(sc_data): survive a build that stopped shipping a module's item file

### DIFF
--- a/app/lib/sc_data/loader/model_modules_loader.rb
+++ b/app/lib/sc_data/loader/model_modules_loader.rb
@@ -16,6 +16,21 @@ module ScData
 
         module_data = load_module_data(model_module.sc_key)
 
+        # A build that stopped shipping this module's item file leaves the module
+        # alone rather than crashing the load. `load_item` answers nil for a path
+        # the tree does not carry and `resolve_loadout` indexes it straight away,
+        # so this used to be a NoMethodError on nil -- and since the whole of
+        # `BaseLoader.all` runs in one job, it took every loader after this one
+        # with it. Guarded the way `ModelsLoader#load_model` guards, rather than
+        # by making `resolve_loadout` tolerant: it raises on a payload carrying
+        # no loadout on purpose, and that is pinned.
+        #
+        # The module keeps the loadout the last build gave it, which is the only
+        # answer available while `ModelModule` has no build table of its own --
+        # once it has one, this is where the module would be retired from the
+        # build instead.
+        return if module_data.blank?
+
         update_loadout(model_module, module_data)
 
         update_params = {

--- a/test/loaders/sc_data/model_modules_loader_test.rb
+++ b/test/loaders/sc_data/model_modules_loader_test.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/sc_data_fixture_tree"
+
+module ScData
+  module Loader
+    class ModelModulesLoaderTest < ActiveSupport::TestCase
+      include ScDataFixtureTree
+
+      # `load_item` answers nil for a path the tree does not carry, and
+      # `resolve_loadout` indexes it straight away -- so a build that stopped
+      # shipping a module's item file used to raise `NoMethodError` on nil. And
+      # because the whole of `BaseLoader.all` runs in one job, that took every
+      # loader after this one with it.
+      #
+      # Found by reading during the first real PTU load rather than by running
+      # it: all six module keys were present in `4.10.1-ptu.12578875`, so nothing
+      # fired.
+      test "#load_model_module leaves a module alone when the build ships no item file for it" do
+        model_module = create(:model_module, sc_key: "not_in_this_build")
+
+        assert_nothing_raised do
+          empty_tree_loader(::ScData::Loader::ModelModulesLoader).load_model_module(model_module)
+        end
+      end
+
+      # The module keeps what the last build gave it, which is the only answer
+      # available while `ModelModule` has no build table of its own.
+      test "#load_model_module keeps the loadout a previous build wrote" do
+        model_module = create(:model_module, sc_key: "not_in_this_build")
+        kept = create(:hardpoint, parent: model_module, sc_name: "kept", source: :game_files)
+
+        empty_tree_loader(::ScData::Loader::ModelModulesLoader).load_model_module(model_module)
+
+        assert Hardpoint.exists?(kept.id)
+      end
+
+      # And the guard has to be the missing file, not every module: one whose
+      # file is there still loads.
+      test "#load_model_module writes the loadout for a module the build does ship" do
+        create(:component, sc_key: "aegs_avenger_thruster_main")
+        model_module = create(:model_module, sc_key: "aegs_avenger_nose_s3")
+
+        fixture_loader(::ScData::Loader::ModelModulesLoader).load_model_module(model_module)
+
+        assert_equal "flight-ready", model_module.reload.production_status
+      end
+
+      # `all` walks every keyed module, so one missing file must not stop the
+      # ones after it either.
+      test "#all carries on past a module the build does not ship" do
+        create(:model_module, sc_key: "not_in_this_build")
+        present = create(:model_module, sc_key: "aegs_avenger_nose_s3")
+        create(:component, sc_key: "aegs_avenger_thruster_main")
+
+        fixture_loader(::ScData::Loader::ModelModulesLoader).all
+
+        assert_equal "flight-ready", present.reload.production_status
+      end
+    end
+  end
+end


### PR DESCRIPTION
Finding E from the first real PTU load, now fixed. Reproduced first:

```
NoMethodError: undefined method '[]' for nil
  app/lib/sc_data/loader/base_loader.rb:324:in 'resolve_loadout'
  app/lib/sc_data/loader/model_modules_loader.rb:19:in 'load_model_module'
```

`load_item` answers nil for a path the parsed tree does not carry, and
`resolve_loadout` indexes it straight away. So a module whose key left the build
raised on nil — and because the whole of `BaseLoader.all` runs in **one job**,
that took every loader after this one with it: commodities and equipment would
not have run at all.

Found by reading rather than by running. All six `ModelModule` keys were present
in `4.10.1-ptu.12578875`, so nothing fired, which is exactly why it needed a test
that constructs the case.

## The shape of the guard

`return if module_data.blank?`, the way `ModelsLoader#load_model` already guards
— **not** by making `resolve_loadout` tolerant of a missing payload. It raises on
one deliberately and `base_loader_loadout_test.rb` pins that ("raises when the
payload carries neither loadout nor default_loadout").

The module keeps the loadout the last build gave it, which is the only answer
available while `ModelModule` has no build table of its own: the fifth catalogue
is still entirely single-source and `ScData::Source::BUILDS` does not list it.
Once it has one, this is where the module would be retired from the build
instead, and the comment says so rather than leaving the next person to work it
out.

## Tests

The loader had **no test file at all**. It has four now, and I checked they are
worth having — with the guard reverted, **three of the four fail**:

| | with the guard | without |
| --- | --- | --- |
| a module the build does not ship is left alone | pass | error |
| its previous loadout survives | pass | error |
| `all` carries on past the missing module | pass | error |
| a module the build *does* ship still loads | pass | pass |

That last one is the control: the guard has to be the missing file, not every
module.

`test/loaders/sc_data/` 158 tests, green.

🤖
