### PR TITLE
refactor: drop the dead admin hardpoint views and narrow the module reads

### DIFF
--- a/app/models/hardpoint.rb
+++ b/app/models/hardpoint.rb
@@ -66,8 +66,11 @@ class Hardpoint < ApplicationRecord
     {ship_matrix: 0, game_files: 1}
 
   # The slots a build describes: the game-files ones carrying a row for it, plus
-  # the whole matrix half, which comes from no build and whose facts live only on
-  # the row.
+  # everything that is not game-files at all -- the matrix half, which comes from
+  # no build and whose facts live only on the row, and the handful of rows whose
+  # `source` is null. `IS DISTINCT FROM` rather than `= :matrix` so a null is on
+  # the unfiltered side: only the half that carries build rows is narrowed by
+  # them, and 5 module slots have no source at all.
   #
   # And -- the third clause -- everything, while this environment has no build
   # rows at all. That is the window between the build table shipping and the
@@ -90,7 +93,7 @@ class Hardpoint < ApplicationRecord
   # Named placeholders because `:environment` is asked twice, and a constant
   # because a heredoc has to open on the line it is used from.
   IN_BUILD_SQL = <<~SQL.squish
-    hardpoints.source = :matrix
+    hardpoints.source IS DISTINCT FROM :game_files
     OR EXISTS (
       SELECT 1 FROM hardpoint_builds
        WHERE hardpoint_builds.hardpoint_id = hardpoints.id
@@ -106,7 +109,7 @@ class Hardpoint < ApplicationRecord
     where(
       sanitize_sql_array([
         IN_BUILD_SQL,
-        {matrix: sources[:ship_matrix], environment: source.environment, version: source.version}
+        {game_files: sources[:game_files], environment: source.environment, version: source.version}
       ])
     )
   }

--- a/app/views/admin/api/v1/model_modules/_base.jbuilder
+++ b/app/views/admin/api/v1/model_modules/_base.jbuilder
@@ -51,7 +51,7 @@ end
 json.cargo_holds model_module.cargo_holds
 
 json.hardpoints do
-  json.array! model_module.hardpoints, partial: "api/v1/hardpoints/hardpoint", as: :hardpoint
+  json.array! model_module.hardpoints.in_build, partial: "api/v1/hardpoints/hardpoint", as: :hardpoint
 end
 
 json.partial! "api/shared/dates", record: model_module

--- a/app/views/api/v1/model_modules/_base.jbuilder
+++ b/app/views/api/v1/model_modules/_base.jbuilder
@@ -40,7 +40,7 @@ end
 json.cargo_holds model_module.cargo_holds_with_offsets
 
 json.hardpoints do
-  json.array! model_module.hardpoints, partial: "api/v1/hardpoints/hardpoint", as: :hardpoint
+  json.array! model_module.hardpoints.in_build, partial: "api/v1/hardpoints/hardpoint", as: :hardpoint
 end
 
 json.partial! "api/shared/dates", record: model_module

--- a/test/models/hardpoint_build_test.rb
+++ b/test/models/hardpoint_build_test.rb
@@ -218,6 +218,17 @@ class HardpointBuildTest < ActiveSupport::TestCase
     assert_not_includes Hardpoint.in_build.pluck(:id), retired.id
   end
 
+  # Only the half that carries build rows is narrowed by them. 5 module slots
+  # have no `source` at all, and `= :matrix` would have swept them out of the
+  # module views the moment those started using this scope.
+  test ".in_build leaves a slot with no source at all alone" do
+    sourceless = create(:hardpoint, :without_build, source: :game_files)
+    sourceless.update_column(:source, nil)
+    create(:hardpoint, source: :game_files)
+
+    assert_includes Hardpoint.in_build.pluck(:id), sourceless.id
+  end
+
   test ".in_build resolves against the source asked for" do
     hardpoint = create(:hardpoint, :without_build, source: :game_files)
     create(:hardpoint_build, hardpoint:, environment: "ptu", version: "9.9.9-ptu.1")


### PR DESCRIPTION
Three small things in the same corner.

## The dead admin hardpoint views

`app/views/admin/api/v1/hardpoints/` — four jbuilders with **no route, no
controller, no renderer and no test**. They arrived with the Vue 3 migration
(#2655) and `resources :hardpoints` was never added to the admin routes; the only
hardpoints route in the app is the public `get :hardpoints` on models.

One of them was also the last thing still emitting a `model_hardpoint_id` field,
set to the *parent* hardpoint's own id inside a legacy-shaped `loadouts` array —
which #4772 left as a follow-up. Deleting the file answers it.

## Two call sites #4761 missed

Both `model_modules/_base.jbuilder`, public and admin, render
`model_module.hardpoints` unnarrowed. Now that the cleanup retires rather than
destroys (#4762), a module slot the build no longer describes stays visible
there.

## And that exposed a bug in `in_build`

`hardpoints.source = :matrix` puts everything that is not `ship_matrix` on the
*filtered* side — including rows whose `source` is null. There are 5 of those and
they are all module slots, so adding the scope to those views would have made
them vanish:

```
ModelModule slots: 22, of which with a build row: 17
```

`IS DISTINCT FROM :game_files` is what the design actually says: only the half
that carries build rows is narrowed by them. With it, all 22 module slots resolve
and the totals are unchanged (27,540 of 27,540). There is a test for the
null-source case now.

## Tests

**1,474** across `test/integration/api/v1/` and the hardpoint build model, green.

🤖
