### PR TITLE
fix(sc_data): derive a model's facts from this build's slots only

### DIFF
--- a/app/lib/sc_data/loader/model_modules_loader.rb
+++ b/app/lib/sc_data/loader/model_modules_loader.rb
@@ -23,7 +23,10 @@ module ScData
         }
 
         update_params = update_metrics(module_data, update_params)
-        update_params = update_cargo_holds(model_module.hardpoints.game_files, update_params)
+        # This build's slots, for the same reason the models loader asks that
+        # way: a slot the build dropped keeps its row and would still be counted
+        # into the module's cargo holds.
+        update_params = update_cargo_holds(model_module.hardpoints.in_build(source), update_params)
 
         apply(model_module, update_params.merge(update_reason: :sc_loader))
       end

--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -89,12 +89,21 @@ module ScData
         update_params = {}
 
         # Computed here because they read the loadout `update_loadout` just wrote.
-        update_params[:fuel_consumption] = model.fuel_consumption_from_hardpoints
-        update_params.merge!(model.accelerations_from_hardpoints)
+        update_params[:fuel_consumption] = model.fuel_consumption_from_hardpoints(source)
+        update_params.merge!(model.accelerations_from_hardpoints(source))
 
         update_params = update_metrics(model, model_data, update_params)
         update_params = update_personal_inventory(model_data, update_params)
-        hardpoints = model.hardpoints.game_files
+        # This build's slots, not every game-file slot the model has ever had.
+        # Before the cleanup stopped destroying, those were the same set; now a
+        # port a build dropped keeps its row, and six derived facts below --
+        # cargo holds, three kinds of fuel tank, the refuel boom and the speeds
+        # -- would go on counting it.
+        #
+        # `source` rather than the ambient one: a loader can be pointed at an
+        # environment by setting `sc_environment`, without `ScData::Source.with`
+        # around it.
+        hardpoints = model.hardpoints.in_build(source)
         update_params = update_cargo_holds(hardpoints, update_params)
         update_params = update_quantum_fuel_tanks(hardpoints, update_params)
         update_params = update_hydrogen_fuel_tanks(hardpoints, update_params)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -635,10 +635,10 @@ class Model < ApplicationRecord
   # takes to reach SCM speed, which is `scm_speed / main_acceleration`. Every
   # figure those columns expressed still follows from these two and a speed the
   # model already carries, and these say what they hold.
-  def accelerations_from_hardpoints
+  def accelerations_from_hardpoints(source = ::ScData::Source.current)
     thrust = {"Main" => 0.0, "Retro" => 0.0}
 
-    thruster_components.each do |data|
+    thruster_components(source).each do |data|
       next unless thrust.key?(data["thruster_type"])
 
       thrust[data["thruster_type"]] += data["thrust_capacity"].to_f
@@ -664,8 +664,15 @@ class Model < ApplicationRecord
   # `HashWithIndifferentAccess`, which the YAML coder's safe load refuses to read
   # back, and a single one of them would otherwise take down a whole load. Every
   # load rewrites the column, so they heal rather than accumulate.
-  private def thruster_components
-    hardpoints.includes(:component).where(group: :thruster).filter_map do |hardpoint|
+  # Narrowed to the build in force: a thruster port a build dropped keeps its
+  # row now that the loadout is retired rather than destroyed, and it would go
+  # on contributing thrust to the accelerations and fuel consumption derived
+  # from this.
+  # The source is passed rather than read from `ScData::Source`: both callers are
+  # the models loader, and a loader can be pointed at an environment by setting
+  # `sc_environment` without `ScData::Source.with` around it.
+  private def thruster_components(source)
+    hardpoints.in_build(source).includes(:component).where(group: :thruster).filter_map do |hardpoint|
       next if hardpoint.component.blank?
 
       begin
@@ -706,8 +713,8 @@ class Model < ApplicationRecord
   # Returns rather than assigns, so the loader can put it through `update_params`
   # like every other game-file fact and it reaches the build as well as the row.
   # Assigning it here is what kept it out of both.
-  def fuel_consumption_from_hardpoints
-    thrusters = thruster_components
+  def fuel_consumption_from_hardpoints(source = ::ScData::Source.current)
+    thrusters = thruster_components(source)
 
     thrusters.sum do |thruster|
       thruster.dig("fuel_burn_rate_per10_k_newton").to_f

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -385,6 +385,22 @@ class ModelTest < ActiveSupport::TestCase
     assert_equal({main_acceleration: 50.0, retro_acceleration: 20.0}, model.reload.accelerations_from_hardpoints)
   end
 
+  # The cleanup retires a slot rather than destroying it (#4762), so a thruster
+  # port a build dropped keeps its row -- and used to keep contributing thrust,
+  # because this read every game-file slot the model had ever had. That is not a
+  # two-environment problem: it fires on the next live patch that drops a port.
+  test "leaves out a thruster this build no longer describes" do
+    model = create(:model, mass: 1_000.0)
+    main = create(:component, category: "thrusters", type_data: {"thruster_type" => "Main", "thrust_capacity" => 25_000.0})
+
+    create(:hardpoint, parent: model, component: main, source: :game_files)
+    dropped = create(:hardpoint, :without_build, parent: model, component: main, source: :game_files)
+    create(:hardpoint_build, hardpoint: dropped, environment: "live", version: "0.0.1-live.1")
+
+    assert_equal 25.0, model.reload.accelerations_from_hardpoints[:main_acceleration],
+      "one thruster of 25kN over 1000kg, not two"
+  end
+
   test "sums every thruster of the same kind" do
     model = create(:model, mass: 1_000.0)
     main = create(:component, category: "thrusters", type_data: {"thruster_type" => "Main", "thrust_capacity" => 25_000.0})


### PR DESCRIPTION
**A consequence of #4762 that I missed when I wrote it**, and the most
consequential of today's loose ends.

Before the cleanup stopped destroying, "every game-file slot on this model" and
"the slots this build describes" were the same set — everything else had been
deleted. They are not any more: a port a build drops keeps its row.

## Eight derived facts read the wrong set

| where | facts |
| --- | --- |
| `ModelsLoader`, one `hardpoints` variable | cargo holds, quantum / hydrogen / external fuel tanks, refuel boom, speeds |
| `ModelModulesLoader` | a module's cargo holds |
| `Model#thruster_components` | accelerations, fuel consumption |

**This is not a two-environment problem.** It fires on the next live patch that
drops a port: the slot stays, and the ship keeps the cargo grid or the thrust it
no longer has. Every one of these ends up on the model row *and* its build row,
so it would have been wrong in both.

## The source is passed, not read

At every site, `in_build(source)` with the loader's own source rather than the
ambient `ScData::Source.current`. A loader can be pointed at an environment by
setting `sc_environment` without `ScData::Source.with` around it — the fixture
test helper does exactly that — so the ambient source is not reliably the
loader's source. `accelerations_from_hardpoints` and
`fuel_consumption_from_hardpoints` take it as an argument for the same reason;
both callers are the loader.

## The test earns its place

Two 25 kN thrusters on a 1,000 kg ship, one of them retired. With the fix: 25.0.
Reverting just `app/models/model.rb`:

```
FAIL ModelTest#test_leaves_out_a_thruster_this_build_no_longer_describes
     Expected: 25.0
```

`test/loaders/sc_data/` and `test/models/` — **205 tests**, green.

🤖
