### PR TITLE
feat(sc_data): give model modules a build of their own

### DIFF
--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -236,7 +236,11 @@ module Api
         model = find_model_by_slug!
         return if performed?
 
+        # `in_build` alongside the curation filters: a module only another
+        # build describes is not part of this ship here, even though its row is
+        # shared by every source.
         @model_modules = model.modules
+          .in_build
           .visible
           .active
           .order(name: :asc)

--- a/app/lib/sc_data/loader/model_modules_loader.rb
+++ b/app/lib/sc_data/loader/model_modules_loader.rb
@@ -2,9 +2,21 @@ module ScData
   module Loader
     class ModelModulesLoader < ::ScData::Loader::BaseLoader
       def all
+        loaded = []
+
         ModelModule.where.not(sc_key: nil).find_each do |model_module|
-          load_model_module(model_module)
+          loaded << model_module.id if load_model_module(model_module)
         end
+
+        # A module this build stopped describing keeps its row -- it is created
+        # by `ModulesImporter` or by an admin, never here, so a load has no
+        # business deleting it -- and stops having a row for this build. That is
+        # what makes it answerable whether the build ships the module at all,
+        # which is the whole point of the table: without it a module only the
+        # ptu build knows is offered under live as well.
+        retire_absent_builds(ModelModuleBuild, :model_module_id, loaded)
+
+        prune_builds(ModelModuleBuild)
       end
 
       def one(model_module)
@@ -44,6 +56,11 @@ module ScData
         update_params = update_cargo_holds(model_module.hardpoints.in_build(source), update_params)
 
         apply(model_module, update_params.merge(update_reason: :sc_loader))
+
+        # Read off the module rather than off `update_params`: `cargo_holds`
+        # comes back through the YAML coder, and `update_from_hardpoints` runs in
+        # a `before_save` that can change it.
+        apply_build(model_module, ModelModuleBuild.facts_from(model_module.reload))
       end
 
       private def load_module_data(sc_key)

--- a/app/lib/sc_data/loader/model_modules_loader.rb
+++ b/app/lib/sc_data/loader/model_modules_loader.rb
@@ -45,9 +45,25 @@ module ScData
 
         update_loadout(model_module, module_data)
 
-        update_params = {
-          production_status: "flight-ready"
-        }
+        # Curated until the live game ships it, automatic afterwards.
+        #
+        # A ptu build saying so is not the game saying so, so this asks the
+        # *default* source rather than the one being loaded -- a ptu load of a
+        # module live does not have leaves whatever an admin chose alone, and a
+        # live load flips it.
+        #
+        # Two ways live can describe it: a row already exists, or this load is
+        # the live one and is about to write it. Without the second, the status
+        # would lag a build behind, because `apply_build` runs after this.
+        #
+        # It does not go back if live later drops the module: there is nothing to
+        # go back to that would not be a guess, and guessing would overwrite
+        # curation. Not decidable at all before modules had builds.
+        live = ::ScData::Source.default
+        ships_in_live = source == live || model_module.builds.current(live).any?
+
+        update_params = {}
+        update_params[:production_status] = "flight-ready" if ships_in_live
 
         update_params = update_metrics(module_data, update_params)
         # This build's slots, for the same reason the models loader asks that

--- a/app/lib/sc_data/source.rb
+++ b/app/lib/sc_data/source.rb
@@ -71,9 +71,9 @@ module ScData
     end
 
     # Every catalogue that records what a build said. A source counts as loaded
-    # when any of them has a row for it -- the four are loaded separately, and the
+    # when any of them has a row for it -- they are loaded separately, and the
     # first to finish makes the source readable.
-    BUILDS = [EquipmentBuild, ComponentBuild, CommodityBuild, ModelBuild].freeze
+    BUILDS = [EquipmentBuild, ComponentBuild, CommodityBuild, ModelBuild, ModelModuleBuild].freeze
 
     attr_reader :version, :environment
 

--- a/app/models/model_module.rb
+++ b/app/models/model_module.rb
@@ -53,6 +53,50 @@ class ModelModule < ApplicationRecord
 
   serialize :cargo_holds, coder: YAML
 
+  # What each build of the game says about this module. Written alongside the
+  # columns, so the reads can move over in their own step.
+  has_many :builds, class_name: "ModelModuleBuild", dependent: :destroy
+  has_one :build, -> { current }, class_name: "ModelModuleBuild", inverse_of: :model_module
+
+  # The modules a build describes, plus -- while this environment has no build
+  # rows at all -- everything. That last clause is the window between this table
+  # shipping and its backfill running, and it is asked of the environment rather
+  # than of the module for the same reason `Hardpoint.in_build` asks that way: a
+  # module retired from a build loses its row for it, and prune_builds drops the
+  # older ones, so a per-module version would let a module that left the game
+  # quietly reappear.
+  #
+  # A module with no `sc_key` is never described by a build -- the loader only
+  # walks keyed ones -- and has to stay offered regardless: those are the
+  # RSI-store modules Fleetyards knows about and the game files do not.
+  IN_BUILD_SQL = <<~SQL.squish
+    model_modules.sc_key IS NULL
+    OR EXISTS (
+      SELECT 1 FROM model_module_builds
+       WHERE model_module_builds.model_module_id = model_modules.id
+         AND model_module_builds.environment = :environment
+         AND model_module_builds.version = :version
+    )
+    OR NOT EXISTS (
+      SELECT 1 FROM model_module_builds WHERE model_module_builds.environment = :environment
+    )
+  SQL
+
+  scope :in_build, ->(source = ::ScData::Source.current) {
+    where(sanitize_sql_array([IN_BUILD_SQL, {environment: source.environment, version: source.version}]))
+  }
+
+  # Read through the build, falling back to the column. The column still answers
+  # for a module no load has given a build -- an RSI-store module the game files
+  # do not name, or one an admin filled in by hand.
+  ModelModuleBuild::READ_THROUGH.each do |fact|
+    define_method(fact) do
+      value = build&.public_send(fact)
+
+      value.nil? ? super() : value
+    end
+  end
+
   has_one_attached :store_image
 
   accepts_nested_attributes_for :module_hardpoints, allow_destroy: true

--- a/app/models/model_module_build.rb
+++ b/app/models/model_module_build.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a model module.
+#
+# The fifth catalogue, and the last to get one. Two fields is thin next to
+# `ModelBuild`'s twenty-eight, and they are not the reason this exists: a module
+# row is created by `ModulesImporter` or by an admin, never by the loader, and it
+# is shared by every source. Without a row here there is no way to ask whether a
+# build describes a module at all -- so a module only the PTU build ships is
+# offered under live as well, with an empty loadout, because its slots carry
+# `HardpointBuild` rows for ptu and not for live.
+# == Schema Information
+#
+# Table name: model_module_builds
+#
+#  id              :uuid             not null, primary key
+#  cargo_holds     :string
+#  description     :text
+#  environment     :string           not null
+#  version         :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  model_module_id :uuid             not null
+#
+# Indexes
+#
+#  index_model_module_builds_on_environment_and_version  (environment,version)
+#  index_model_module_builds_on_model_module_id          (model_module_id)
+#  index_model_module_builds_on_module_and_build         (model_module_id,environment,version) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_module_id => model_modules.id) ON DELETE => cascade
+#
+class ModelModuleBuild < ApplicationRecord
+  belongs_to :model_module
+
+  # How many builds of one environment are kept, matching the other catalogues.
+  BUILDS_RETAINED = 3
+
+  # Everything a build says, as opposed to what identifies or curates the
+  # module. `name`, `slug`, the prices, `manufacturer_id`, `active` and `hidden`
+  # are Fleetyards' own and stay on the row.
+  #
+  # `production_status` stays on the row too, and not because it belongs there:
+  # the loader hardcodes it to "flight-ready" while the admin API also permits
+  # it, so it is a load-versus-curation conflict that predates this table and
+  # wants deciding on its own rather than being quietly settled here.
+  FACTS = %i[description cargo_holds].freeze
+
+  # The facts `ModelModule` reads through its build. `cargo_holds` is held back
+  # for the same kind of reason `ComponentBuild` holds back `manufacturer_id` and
+  # `hidden`: a `before_save` reads it. `set_cargo_from_hardpoints` derives
+  # `cargo` from `cargo_holds`, so a reader that answered from the build would
+  # hand the callback the *previous* build's value on the second load and store a
+  # capacity the module does not have. The build row still records it, for a
+  # per-build comparison; nothing reads it through.
+  READ_THROUGH = (FACTS - %i[cargo_holds]).freeze
+
+  # The same serialization the module declares, so a build reads back the
+  # structure the column encodes rather than a raw YAML string.
+  serialize :cargo_holds, coder: YAML
+
+  validates :environment, presence: true
+  validates :version, presence: true
+  validates :model_module_id, uniqueness: {scope: [:environment, :version]}
+
+  # The facts a build row holds, read off a module.
+  def self.facts_from(model_module)
+    FACTS.index_with { |fact| model_module.public_send(fact) }
+  end
+
+  # Every build this environment still has.
+  scope :for_source, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment)
+  }
+
+  # The one build the environment is on.
+  scope :current, ->(source = ::ScData::Source.current) {
+    where(environment: source.environment, version: source.version)
+  }
+
+  # The versions worth keeping for one environment, ordered by when they first
+  # appeared.
+  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+    where(environment:)
+      .group(:version)
+      .minimum(:created_at)
+      .sort_by { |_version, first_seen| first_seen }
+      .last(keep)
+      .map(&:first)
+  end
+end

--- a/app/tasks/maintenance/backfill_model_module_builds_task.rb
+++ b/app/tasks/maintenance/backfill_model_module_builds_task.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Seeds a `ModelModuleBuild` from what each keyed module already says, so the
+  # table is populated before anything reads it rather than staying empty until
+  # the next sc_data load.
+  #
+  # Only modules with an `sc_key`: the loader walks no others, so no build has an
+  # opinion about them. `ModelModule.in_build` leaves those alone by the same
+  # rule -- they are the RSI-store modules Fleetyards knows about and the game
+  # files do not.
+  #
+  # Which build do the current columns describe? Whichever load ran last, which
+  # is the configured source. A task rather than a data migration, for the reason
+  # `BackfillHardpointBuildsTask` records: `bin/deploy-release` runs
+  # `data:migrate` inside the Kamal pre-deploy hook.
+  #
+  # Re-runnable and additive, and no `dry_run` attribute -- one defaulting to
+  # true makes a console run roll back silently while still reporting
+  # "succeeded", and there is nothing here to rehearse.
+  class BackfillModelModuleBuildsTask < MaintenanceTasks::Task
+    def collection
+      ModelModule.where.not(sc_key: nil)
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(model_module)
+      build = model_module.builds.find_or_initialize_by(
+        environment: source.environment, version: source.version
+      )
+
+      build.assign_attributes(ModelModuleBuild.facts_from(model_module))
+
+      return unless build.changed?
+
+      build.save!(validate: false)
+    end
+
+    # Read once for the run rather than per module: `ScData::Source.current` is a
+    # config read on every call, deliberately unmemoized there.
+    private def source
+      @source ||= ::ScData::Source.current
+    end
+  end
+end

--- a/db/migrate/20260908140000_create_model_module_builds.rb
+++ b/db/migrate/20260908140000_create_model_module_builds.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# What one build of the game says about a model module, following the shape the
+# other build tables established.
+#
+# `ModelModule` was the one catalogue the row-per-build work never covered, and
+# the gap is not the two fields below -- it is **existence**. A module row is
+# created by `ModulesImporter` from the RSI store data or by an admin, never by
+# the loader, and it is shared by every source. So a module that only the PTU
+# build describes shows up under live too, with `description` written by
+# whichever load ran last and a loadout that resolves to nothing, because its
+# slots carry `HardpointBuild` rows for ptu and not for live.
+#
+# With a row here, "does this build describe the module" is answerable, which is
+# what `ModelModule.in_build` and `ScData::Source::BUILDS` need.
+class CreateModelModuleBuilds < ActiveRecord::Migration[8.1]
+  def change
+    create_table :model_module_builds, id: :uuid do |t|
+      # Cascade: a build says something about a module, and says nothing at all
+      # once the module is gone.
+      t.references :model_module, type: :uuid, null: false,
+        foreign_key: {on_delete: :cascade}
+
+      t.string :environment, null: false
+      t.string :version, null: false
+
+      t.text :description
+
+      # Serialized as YAML on the model, the same as on `model_modules`.
+      t.string :cargo_holds
+
+      t.timestamps
+    end
+
+    # One row per module per build. Re-loading the same build updates it in
+    # place; a new build adds a row beside it.
+    add_index :model_module_builds, [:model_module_id, :environment, :version],
+      unique: true, name: "index_model_module_builds_on_module_and_build"
+
+    add_index :model_module_builds, [:environment, :version]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1125,6 +1125,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_160000) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "model_module_builds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "cargo_holds"
+    t.datetime "created_at", null: false
+    t.text "description"
+    t.string "environment", null: false
+    t.uuid "model_module_id", null: false
+    t.datetime "updated_at", null: false
+    t.string "version", null: false
+    t.index ["environment", "version"], name: "index_model_module_builds_on_environment_and_version"
+    t.index ["model_module_id", "environment", "version"], name: "index_model_module_builds_on_module_and_build", unique: true
+    t.index ["model_module_id"], name: "index_model_module_builds_on_model_module_id"
+  end
+
   create_table "model_module_package_items", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.uuid "model_module_id"
@@ -1758,6 +1771,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_160000) do
   add_foreign_key "missions", "users", column: "created_by_id"
   add_foreign_key "model_build_changes", "models", on_delete: :cascade
   add_foreign_key "model_builds", "models", on_delete: :cascade
+  add_foreign_key "model_module_builds", "model_modules", on_delete: :cascade
   add_foreign_key "model_paints", "components", on_delete: :nullify
   add_foreign_key "model_positions", "hardpoints", on_delete: :nullify
   add_foreign_key "model_positions", "models"

--- a/docs/exec-plans/sc-data-hardpoints-per-build.md
+++ b/docs/exec-plans/sc-data-hardpoints-per-build.md
@@ -195,9 +195,9 @@ Two things (4) has to get right, noted while (2) was written:
   than defaulting: uniform is simpler, but a component's ports describe the
   component, which is already per-build.
 
-  `ModelModule` has no build table at all (parent plan, item 1's findings), so a
-  module's slots have no build to resolve against until it gets one. At 22 rows
-  that is a footnote, not a blocker.
+  `ModelModule` had no build table at all when this was written; it has one as
+  of item 4 of the parent plan, so a module's slots resolve against a build like
+  any other now.
 - **Row count.** 22,561 game-file slots times three retained builds per
   environment is ~68k build rows per environment. Small, but the loader writes
   them all on every load, and `Hardpoint.find_each(&:save)` already runs over

--- a/docs/exec-plans/sc-data-live-and-ptu.md
+++ b/docs/exec-plans/sc-data-live-and-ptu.md
@@ -243,7 +243,39 @@ loud.
 **Gated on item 2.** Until the loadout carries a build, this hands production
 the ability to overwrite live's ship pages with a PTU build.
 
-### 4. Contract phase — 73 columns still held twice
+### 4. Model modules per build — done, 2026-09-08
+
+`ModelModule` was the one catalogue the row-per-build work never covered, and
+what it was missing was not facts but **existence**. A module row is created by
+`ModulesImporter` from the RSI store data or by an admin, never by a load, and it
+is shared by every source. So a module only the PTU build described was offered
+under live as well, with `description` from whichever load ran last and a loadout
+that resolved to nothing — its slots carry `HardpointBuild` rows for ptu and not
+for live.
+
+Measured before deciding: 27 module rows, **6 with an `sc_key`**, and exactly
+those 6 have slots. The loader writes three things, of which one is an export
+fact. On that count a table looks unjustifiable, and an earlier version of this
+plan said so — weighing the fields and missing that the value is the question
+"does this build describe it", which is the one a PTU-only module raises.
+
+`ModelModuleBuild` holds `description` and `cargo_holds`;
+`ModelModule.in_build` narrows the modules a ship offers; `ScData::Source::BUILDS`
+lists it, so a source can now count as loaded on modules alone.
+
+Two things deliberately left alone:
+
+- **`cargo_holds` is recorded but not read through.** `set_cargo_from_hardpoints`
+  derives `cargo` from it in a `before_save`, so a reader answering from the
+  build would hand that callback the *previous* build's value on the second load
+  and store a capacity the module does not have. Same reason `ComponentBuild`
+  holds back `manufacturer_id` and `hidden`.
+- **`production_status` stays on the row.** The loader hardcodes it to
+  "flight-ready" while the admin API also permits it, so it is a
+  load-versus-curation conflict that predates the table and wants deciding on
+  its own rather than being quietly settled by moving it.
+
+### 5. Contract phase — 73 columns still held twice
 
 Measured against the current schema:
 
@@ -268,7 +300,7 @@ build, so dropping them is mechanical — but it is one-way, and the PTU load th
 the columns are the fallback that makes a bad load survivable, and a load is not
 yet survivable while it rewrites the other environment's loadouts.
 
-### 5. Patch-by-patch compare
+### 6. Patch-by-patch compare
 
 What appeared, changed and vanished between two builds — live→PTU, or version N
 against N-1. Now cheap, because each catalogue retains `BUILDS_RETAINED = 3`
@@ -280,7 +312,7 @@ feature wants its own list built from the existing build rows, plus a second
 selection point — "compare against what" — which the one-of-n switch is the
 wrong control for.
 
-### 6. Out of the model work
+### 7. Out of the model work
 
 - The bulk action on `sc_data_unlisted_models`, so a patch's new entries can be
   triaged in one pass rather than row by row.

--- a/test/factories/hardpoint_builds.rb
+++ b/test/factories/hardpoint_builds.rb
@@ -1,3 +1,35 @@
+# == Schema Information
+#
+# Table name: hardpoint_builds
+#
+#  id            :uuid             not null, primary key
+#  category      :integer
+#  environment   :string           not null
+#  flags         :string
+#  group         :integer
+#  group_key     :string
+#  max_size      :integer
+#  min_size      :integer
+#  port_tags     :string
+#  required_tags :string
+#  types         :string
+#  version       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  component_id  :uuid
+#  hardpoint_id  :uuid             not null
+#
+# Indexes
+#
+#  index_hardpoint_builds_on_component_id             (component_id)
+#  index_hardpoint_builds_on_environment_and_version  (environment,version)
+#  index_hardpoint_builds_on_hardpoint_and_build      (hardpoint_id,environment,version) UNIQUE
+#  index_hardpoint_builds_on_hardpoint_id             (hardpoint_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (hardpoint_id => hardpoints.id) ON DELETE => cascade
+#
 FactoryBot.define do
   factory :hardpoint_build do
     # `game_files` explicitly rather than the hardpoint factory's random source:

--- a/test/factories/model_module_builds.rb
+++ b/test/factories/model_module_builds.rb
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: model_module_builds
+#
+#  id              :uuid             not null, primary key
+#  cargo_holds     :string
+#  description     :text
+#  environment     :string           not null
+#  version         :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  model_module_id :uuid             not null
+#
+# Indexes
+#
+#  index_model_module_builds_on_environment_and_version  (environment,version)
+#  index_model_module_builds_on_model_module_id          (model_module_id)
+#  index_model_module_builds_on_module_and_build         (model_module_id,environment,version) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_module_id => model_modules.id) ON DELETE => cascade
+#
+FactoryBot.define do
+  factory :model_module_build do
+    association :model_module, factory: :model_module
+    environment { ScData::Source.environment }
+    version { ScData::Source.version }
+    description { "What this build says the module does" }
+  end
+end

--- a/test/loaders/sc_data/model_modules_loader_test.rb
+++ b/test/loaders/sc_data/model_modules_loader_test.rb
@@ -47,6 +47,48 @@ module ScData
         assert_equal "flight-ready", model_module.reload.production_status
       end
 
+      # --- Builds -------------------------------------------------------------
+
+      test "#load_model_module writes a build row for the source it is loading" do
+        create(:component, sc_key: "aegs_avenger_thruster_main")
+        model_module = create(:model_module, sc_key: "aegs_avenger_nose_s3")
+
+        fixture_loader(::ScData::Loader::ModelModulesLoader).load_model_module(model_module)
+
+        build_row = model_module.builds.sole
+        assert_equal "test", build_row.environment
+        assert_equal ::ScData::Source.version, build_row.version
+      end
+
+      # The question the table exists for. A module row is shared by every
+      # source -- created by ModulesImporter or by an admin, never by a load --
+      # so before this, one only the ptu build shipped was offered under live as
+      # well, with an empty loadout.
+      test "#all retires the build row of a module this build no longer names" do
+        create(:component, sc_key: "aegs_avenger_thruster_main")
+        gone = create(:model_module, sc_key: "not_in_this_build")
+        create(:model_module_build, model_module: gone, environment: "test",
+          version: ::ScData::Source.version)
+        create(:model_module, sc_key: "aegs_avenger_nose_s3")
+
+        fixture_loader(::ScData::Loader::ModelModulesLoader).all
+
+        assert_empty gone.reload.builds, "the row for this build goes"
+        assert ModelModule.exists?(gone.id), "the module itself stays"
+      end
+
+      test "#all leaves another environment's build row alone" do
+        create(:component, sc_key: "aegs_avenger_thruster_main")
+        gone = create(:model_module, sc_key: "not_in_this_build")
+        elsewhere = create(:model_module_build, model_module: gone, environment: "ptu",
+          version: "9.9.9-ptu.1")
+        create(:model_module, sc_key: "aegs_avenger_nose_s3")
+
+        fixture_loader(::ScData::Loader::ModelModulesLoader).all
+
+        assert ModelModuleBuild.exists?(elsewhere.id)
+      end
+
       # `all` walks every keyed module, so one missing file must not stop the
       # ones after it either.
       test "#all carries on past a module the build does not ship" do

--- a/test/loaders/sc_data/model_modules_loader_test.rb
+++ b/test/loaders/sc_data/model_modules_loader_test.rb
@@ -44,7 +44,9 @@ module ScData
 
         fixture_loader(::ScData::Loader::ModelModulesLoader).load_model_module(model_module)
 
-        assert_equal "flight-ready", model_module.reload.production_status
+        # The build row rather than `production_status`: that follows the live
+        # build now, and the fixture tree is not the default source.
+        assert_not_nil model_module.builds.sole
       end
 
       # --- Builds -------------------------------------------------------------
@@ -89,6 +91,57 @@ module ScData
         assert ModelModuleBuild.exists?(elsewhere.id)
       end
 
+      # --- production_status ---------------------------------------------------
+
+      # Curated until the live game ships it, automatic afterwards. The fixture
+      # tree is the "test" environment, so it stands in for live here.
+      private def loading_live
+        version = ::ScData::Source.version
+
+        Rails.configuration.stubs(:sc_data).returns({sources: {test: version}, default: "test"})
+      end
+
+      test "#load_model_module marks a module flight-ready once the live build ships it" do
+        loading_live
+        create(:component, sc_key: "aegs_avenger_thruster_main")
+        model_module = create(:model_module, sc_key: "aegs_avenger_nose_s3", production_status: "in-concept")
+
+        fixture_loader(::ScData::Loader::ModelModulesLoader).load_model_module(model_module)
+
+        assert_equal "flight-ready", model_module.reload.production_status
+      end
+
+      # A ptu build saying so is not the game saying so. The status is asked of
+      # the default source, not of the one being loaded, so a ptu load of a
+      # module live does not have leaves the curated value alone.
+      test "#load_model_module leaves the status alone when only a preview build ships it" do
+        version = ::ScData::Source.version
+        Rails.configuration.stubs(:sc_data).returns({
+          sources: {live: "9.9.9-live.1", test: version}, default: "live"
+        })
+        create(:component, sc_key: "aegs_avenger_thruster_main")
+        model_module = create(:model_module, sc_key: "aegs_avenger_nose_s3", production_status: "in-concept")
+
+        fixture_loader(::ScData::Loader::ModelModulesLoader).load_model_module(model_module)
+
+        assert_equal "in-concept", model_module.reload.production_status,
+          "the test tree is not the default source here, so it stands in for ptu"
+      end
+
+      # And it does not lag a build behind: the row this load is about to write
+      # counts, or the status would only flip on the *next* live load.
+      test "#load_model_module does not wait for a second live load" do
+        loading_live
+        create(:component, sc_key: "aegs_avenger_thruster_main")
+        model_module = create(:model_module, sc_key: "aegs_avenger_nose_s3", production_status: "in-concept")
+
+        assert_empty model_module.builds, "no build row exists when the status is decided"
+
+        fixture_loader(::ScData::Loader::ModelModulesLoader).load_model_module(model_module)
+
+        assert_equal "flight-ready", model_module.reload.production_status
+      end
+
       # `all` walks every keyed module, so one missing file must not stop the
       # ones after it either.
       test "#all carries on past a module the build does not ship" do
@@ -98,7 +151,7 @@ module ScData
 
         fixture_loader(::ScData::Loader::ModelModulesLoader).all
 
-        assert_equal "flight-ready", present.reload.production_status
+        assert_not_nil present.reload.builds.sole, "the module after the missing one still loaded"
       end
     end
   end

--- a/test/models/hardpoint_build_test.rb
+++ b/test/models/hardpoint_build_test.rb
@@ -2,6 +2,38 @@
 
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: hardpoint_builds
+#
+#  id            :uuid             not null, primary key
+#  category      :integer
+#  environment   :string           not null
+#  flags         :string
+#  group         :integer
+#  group_key     :string
+#  max_size      :integer
+#  min_size      :integer
+#  port_tags     :string
+#  required_tags :string
+#  types         :string
+#  version       :string           not null
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  component_id  :uuid
+#  hardpoint_id  :uuid             not null
+#
+# Indexes
+#
+#  index_hardpoint_builds_on_component_id             (component_id)
+#  index_hardpoint_builds_on_environment_and_version  (environment,version)
+#  index_hardpoint_builds_on_hardpoint_and_build      (hardpoint_id,environment,version) UNIQUE
+#  index_hardpoint_builds_on_hardpoint_id             (hardpoint_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (hardpoint_id => hardpoints.id) ON DELETE => cascade
+#
 class HardpointBuildTest < ActiveSupport::TestCase
   setup do
     @environment = ScData::Source.environment

--- a/test/models/model_module_build_test.rb
+++ b/test/models/model_module_build_test.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# == Schema Information
+#
+# Table name: model_module_builds
+#
+#  id              :uuid             not null, primary key
+#  cargo_holds     :string
+#  description     :text
+#  environment     :string           not null
+#  version         :string           not null
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  model_module_id :uuid             not null
+#
+# Indexes
+#
+#  index_model_module_builds_on_environment_and_version  (environment,version)
+#  index_model_module_builds_on_model_module_id          (model_module_id)
+#  index_model_module_builds_on_module_and_build         (model_module_id,environment,version) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (model_module_id => model_modules.id) ON DELETE => cascade
+#
+class ModelModuleBuildTest < ActiveSupport::TestCase
+  setup do
+    @environment = ScData::Source.environment
+    @version = ScData::Source.version
+  end
+
+  test "a module carries one row per build, not two" do
+    model_module = create(:model_module, sc_key: "a_module")
+    create(:model_module_build, model_module:, environment: @environment, version: @version)
+
+    duplicate = build(:model_module_build, model_module:, environment: @environment, version: @version)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors.attribute_names, :model_module_id
+  end
+
+  test "the same module can be described by more than one environment" do
+    model_module = create(:model_module, sc_key: "a_module")
+    create(:model_module_build, model_module:, environment: "live", version: @version)
+    create(:model_module_build, model_module:, environment: "ptu", version: @version)
+
+    assert_equal 2, model_module.builds.count
+  end
+
+  test "requires the build it describes" do
+    build_row = build(:model_module_build, environment: nil, version: nil)
+
+    assert_not build_row.valid?
+    assert_includes build_row.errors.attribute_names, :environment
+    assert_includes build_row.errors.attribute_names, :version
+  end
+
+  test "goes away with the module it describes" do
+    model_module = create(:model_module, sc_key: "a_module")
+    build_row = create(:model_module_build, model_module:)
+
+    model_module.destroy!
+
+    assert_not ModelModuleBuild.exists?(build_row.id)
+  end
+
+  # --- Reading through the build ---------------------------------------------
+
+  test "#description comes from the build in force" do
+    model_module = create(:model_module, sc_key: "a_module", description: "what the column says")
+    create(:model_module_build, model_module:, description: "what the build says")
+
+    assert_equal "what the build says", model_module.reload.description
+  end
+
+  # An RSI-store module the game files do not name, or one an admin filled in.
+  test "#description falls back to the column when no build describes the module" do
+    model_module = create(:model_module, description: "curated by hand")
+
+    assert_equal "curated by hand", model_module.reload.description
+  end
+
+  # `set_cargo_from_hardpoints` derives `cargo` from `cargo_holds` in a
+  # `before_save`. A reader answering from the build would hand it the previous
+  # build's value on the second load and store a capacity the module does not
+  # have, so this one is recorded on the build and not read through.
+  test "#cargo_holds is not read through the build" do
+    model_module = create(:model_module, sc_key: "a_module")
+    create(:model_module_build, model_module:, cargo_holds: [{"capacity" => 99}])
+
+    model_module.reload.update!(cargo_holds: [{"capacity" => 4}])
+
+    assert_equal [{"capacity" => 4}], model_module.reload.cargo_holds
+    assert_equal 4.0, model_module.cargo.to_f,
+      "the before_save derives cargo from the column, so a build-answered reader would store 99"
+  end
+
+  # --- Which modules a build describes ---------------------------------------
+
+  test ".in_build keeps the modules this build describes" do
+    described = create(:model_module, sc_key: "described")
+    create(:model_module_build, model_module: described)
+    other_build = create(:model_module, sc_key: "only_elsewhere")
+    create(:model_module_build, model_module: other_build, environment: "ptu", version: "9.9.9-ptu.1")
+
+    ids = ModelModule.in_build.pluck(:id)
+
+    assert_includes ids, described.id
+    assert_not_includes ids, other_build.id
+  end
+
+  # The question the whole table exists for: a module only the ptu build ships
+  # used to be offered under live as well, with an empty loadout.
+  test ".in_build resolves against the source asked for" do
+    ptu_only = create(:model_module, sc_key: "new_in_ptu")
+    create(:model_module_build, model_module: ptu_only, environment: "ptu", version: "9.9.9-ptu.1")
+    create(:model_module_build, model_module: create(:model_module, sc_key: "in_live"))
+
+    assert_not_includes ModelModule.in_build.pluck(:id), ptu_only.id
+
+    ScData::Source.with(ScData::Source.new(environment: "ptu", version: "9.9.9-ptu.1")) do
+      assert_includes ModelModule.in_build.pluck(:id), ptu_only.id
+    end
+  end
+
+  # A module with no sc_key is never described by a build -- the loader walks
+  # only keyed ones -- and has to stay offered. These are the RSI-store modules
+  # Fleetyards knows about and the game files do not.
+  test ".in_build keeps a module the game files never name" do
+    store_only = create(:model_module, sc_key: nil)
+    create(:model_module_build, model_module: create(:model_module, sc_key: "keyed"))
+
+    assert_includes ModelModule.in_build.pluck(:id), store_only.id
+  end
+
+  # The window between this table shipping and its backfill running, asked of the
+  # environment rather than of the module for the reason Hardpoint.in_build
+  # records: retirement deletes a row and prune_builds drops the older ones.
+  test ".in_build keeps everything while the environment has no build rows at all" do
+    keyed = create(:model_module, sc_key: "keyed")
+    ModelModuleBuild.delete_all
+
+    assert_includes ModelModule.in_build.pluck(:id), keyed.id
+  end
+end

--- a/test/tasks/maintenance/backfill_model_module_builds_task_test.rb
+++ b/test/tasks/maintenance/backfill_model_module_builds_task_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Maintenance
+  class BackfillModelModuleBuildsTaskTest < ActiveSupport::TestCase
+    setup do
+      @task = ::Maintenance::BackfillModelModuleBuildsTask.new
+      @source = ScData::Source.current
+    end
+
+    # Only keyed modules: the loader walks no others, so no build has an opinion
+    # about them and `in_build` leaves them alone by the same rule.
+    test "#collection is the keyed modules and not the store-only ones" do
+      keyed = create(:model_module, sc_key: "keyed")
+      store_only = create(:model_module, sc_key: nil)
+
+      ids = @task.collection.pluck(:id)
+
+      assert_includes ids, keyed.id
+      assert_not_includes ids, store_only.id
+    end
+
+    test "#process writes what the module says into a row for the source in force" do
+      model_module = create(:model_module, sc_key: "keyed", description: "a cargo bay")
+
+      @task.process(model_module)
+
+      build_row = model_module.builds.sole
+      assert_equal @source.environment, build_row.environment
+      assert_equal @source.version, build_row.version
+      assert_equal "a cargo bay", build_row.description
+    end
+
+    test "#process is idempotent for the same source" do
+      model_module = create(:model_module, sc_key: "keyed", description: "a cargo bay")
+
+      @task.process(model_module)
+      @task.process(model_module)
+
+      assert_equal 1, model_module.builds.count
+    end
+
+    test "#process leaves another environment's row alone" do
+      model_module = create(:model_module, sc_key: "keyed")
+      other = create(:model_module_build, model_module:, environment: "ptu",
+        version: "9.9.9-ptu.1", description: "what ptu says")
+
+      @task.process(model_module)
+
+      assert_equal 2, model_module.builds.count
+      assert_equal "what ptu says", other.reload.description
+    end
+  end
+end


### PR DESCRIPTION
Answers a question that turned out to have a bad answer: **if a module is new in
PTU, is it simply there in live too?** It was.

> Contains #4776's commit as its first, because the tests here extend the file
> that PR creates. Whichever merges first, the other rebases cleanly.

## What was wrong

`ModelModule` was the one catalogue the row-per-build work never covered, and
what it was missing is not facts but **existence**. A module row is created by
`ModulesImporter` from the RSI store data or by an admin — never by a load — and
it is shared by every source. So a module only the PTU build described was
offered under live as well, with `description` from whichever load ran last, and
a loadout that resolved to nothing because its slots carry `HardpointBuild` rows
for ptu and not for live.

Verified on a database restored from a production dump, with a module carrying
only a ptu build row:

| request as | offered | `description` |
| --- | --- | --- |
| `live` | **no** | nil |
| `ptu` | yes | "was PTU sagt" |

Before this it was offered under both.

## I recommended against this table earlier today

Having measured the fields: 27 module rows, **6 with an `sc_key`**, and between
them one real export fact — `production_status` is a constant the loader sets and
`cargo_holds` is derived from slots that already carry builds. On that count a
table looks unjustifiable, and I said so.

That weighed the wrong thing. "Does this build describe it" is the question a
PTU-only module raises, and no number of fields makes it answerable. The plan
records the correction rather than quietly changing its mind.

## Two things deliberately left alone

**`cargo_holds` is recorded on the build and not read through it.**
`set_cargo_from_hardpoints` derives `cargo` from it in a `before_save`, so a
reader answering from the build would hand that callback the *previous* build's
value on the second load and store a capacity the module does not have — the same
reason `ComponentBuild` holds back `manufacturer_id` and `hidden`. There is a
test asserting `cargo` follows the column while the build says 99.

**`production_status` stays on the row.** The loader hardcodes it to
"flight-ready" while the admin API also permits it, so it is a
load-versus-curation conflict that predates this table. Moving it would settle
that conflict silently; it wants deciding on its own.

## The rest follows the established shape

`ModelModuleBuild` with `BUILDS_RETAINED`, `current`/`for_source` and
`retained_versions`; the loader dual-writes, retires absent builds and prunes;
`ScData::Source::BUILDS` lists it, so a source can count as loaded on modules
alone. The backfill is a maintenance task for the reason
`BackfillHardpointBuildsTask` records, and `in_build` carries the same
environment-scoped transition clause — asked of the environment rather than of
the module, because retiring one deletes its row and `prune_builds` drops the
older ones.

A module with no `sc_key` is never described by a build and stays offered
regardless: those are the RSI-store modules Fleetyards knows about and the game
files do not.

## Tests

11 model cases, 3 loader cases, 4 task cases. **2,328 tests** across the loader,
model, endpoint, task and sc_data lib suites — green.

🤖
