### PR TITLE
fix(middleware): scrub invalid UTF-8 from client headers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,7 @@ require_relative "boot"
 
 require "rails/all"
 require "ipaddr"
+require_relative "../lib/middleware/scrub_header_encoding"
 require_relative "../lib/middleware/transform_parameters"
 
 # Backport of Rails 8.2 `Rails.app.creds` — must load before config_for calls.

--- a/config/initializers/03_scrub_header_encoding.rb
+++ b/config/initializers/03_scrub_header_encoding.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Inserted above Rack::Cors (which 02_cors.rb puts at the top of the stack) so
+# a header carrying invalid UTF-8 is repaired before rack-cors matches Origin
+# against a regexp, and before host authorization splits the Host header.
+Rails.application.config.middleware.insert_before 0, Middleware::ScrubHeaderEncoding

--- a/lib/middleware/scrub_header_encoding.rb
+++ b/lib/middleware/scrub_header_encoding.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Middleware
+  # Bots and broken clients send header bytes that are not valid UTF-8. Rack and
+  # Rails feed those bytes straight into regexps, `String#split` and `blank?`,
+  # all of which raise `ArgumentError: invalid byte sequence in UTF-8` from deep
+  # inside gem code — a 500 wherever the request happens to touch the header
+  # first. Drop the invalid bytes before anything reads them.
+  class ScrubHeaderEncoding
+    SCRUBBED_HEADERS = %w[
+      HTTP_ACCEPT
+      HTTP_ACCEPT_ENCODING
+      HTTP_ACCEPT_LANGUAGE
+      HTTP_COOKIE
+      HTTP_HOST
+      HTTP_ORIGIN
+      HTTP_REFERER
+      HTTP_USER_AGENT
+      HTTP_X_FORWARDED_FOR
+      HTTP_X_FORWARDED_HOST
+      HTTP_X_REQUESTED_WITH
+    ].freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      SCRUBBED_HEADERS.each do |header|
+        value = env[header]
+        next if !value.is_a?(String) || value.valid_encoding?
+
+        env[header] = value.scrub("")
+      end
+
+      @app.call(env)
+    end
+  end
+end

--- a/test/integration/invalid_header_encoding_test.rb
+++ b/test/integration/invalid_header_encoding_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Bots send header bytes that are not valid UTF-8. Rack's cookie parser splits
+# the Cookie header with a regexp, which raises `ArgumentError: invalid byte
+# sequence in UTF-8` -- a 500 in whichever code touched the session first.
+class InvalidHeaderEncodingTest < ActionDispatch::IntegrationTest
+  BROWSER_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " \
+    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
+
+  test "a request with invalid bytes in the Cookie header is still served" do
+    get "/api/", headers: {
+      "HTTP_ACCEPT" => "application/json",
+      "HTTP_USER_AGENT" => BROWSER_USER_AGENT,
+      "HTTP_COOKIE" => "_fleetyards_session=abc\xFFdef".dup.force_encoding("UTF-8")
+    }
+
+    assert_response :success
+  end
+
+  test "invalid bytes in the Accept header end in content negotiation, not an error" do
+    get "/api/", headers: {"HTTP_ACCEPT" => "not\xFFa/media-type".dup.force_encoding("UTF-8")}
+
+    assert_response :not_acceptable
+  end
+end

--- a/test/lib/scrub_header_encoding_test.rb
+++ b/test/lib/scrub_header_encoding_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ScrubHeaderEncodingTest < ActiveSupport::TestCase
+  # Puma hands header values over tagged as UTF-8, invalid bytes and all --
+  # which is what makes Rack's regexps raise. A `\xFF` literal in a UTF-8
+  # source file is binary, so the encoding has to be set by hand.
+  def invalid_utf8(value)
+    value.dup.force_encoding("UTF-8")
+  end
+
+  def call(env)
+    forwarded = nil
+    app = lambda do |inner_env|
+      forwarded = inner_env
+      [200, {}, []]
+    end
+
+    Middleware::ScrubHeaderEncoding.new(app).call(env)
+    forwarded
+  end
+
+  test "drops invalid bytes from a scrubbed header" do
+    env = call("HTTP_COOKIE" => invalid_utf8("_fleetyards_session=abc\xFFdef"))
+
+    assert_equal "_fleetyards_session=abcdef", env["HTTP_COOKIE"]
+    assert_predicate env["HTTP_COOKIE"], :valid_encoding?
+  end
+
+  test "keeps a header that is already valid UTF-8" do
+    env = call("HTTP_USER_AGENT" => "Mozilla/5.0 (Ünicode)")
+
+    assert_equal "Mozilla/5.0 (Ünicode)", env["HTTP_USER_AGENT"]
+  end
+
+  test "leaves a header the request did not send unset" do
+    env = call({"HTTP_COOKIE" => nil})
+
+    assert_nil env["HTTP_COOKIE"]
+  end
+
+  test "leaves headers outside the list alone" do
+    value = invalid_utf8("abc\xFFdef")
+    env = call("HTTP_X_CUSTOM" => value)
+
+    assert_equal value, env["HTTP_X_CUSTOM"]
+  end
+end


### PR DESCRIPTION
## What

Adds `Middleware::ScrubHeaderEncoding` at the very top of the middleware stack, which drops invalid UTF-8 bytes from client-controlled request headers.

## Why

Production reports:

```
ArgumentError: invalid byte sequence in UTF-8
  config/initializers/ahoy.rb:26:in 'block in <main>'
  lib/middleware/transform_parameters.rb:17:in 'Middleware::TransformParameters#call'
```

The ahoy frame is a red herring. The request carries a `Cookie` header with bytes that are not valid UTF-8; Puma tags header values as UTF-8 regardless, so Rack's `parse_cookies_header` splits the value with a regexp and raises. Rails 8.1 validates *param* encoding and answers 400, but nothing checks headers.

The blamed frame is just the first code in the request to read a cookie: ahoy registers `before_action :track_ahoy_visit` on `ActionController::Base`, so its `exclude_method` calls `current_user` — and therefore the session — before any app filter runs. On API requests the same crash surfaces in `set_last_active_at` instead.

Sweeping the other client headers turned up the same 500 in seven more places:

| Header | Raised in |
| --- | --- |
| `Accept`, `X-Requested-With` | mime negotiation (`blank?`, `xhr?`) |
| `Accept-Encoding` | `Rack::Request#accept_encoding` |
| `Accept-Language` | also written straight into `ahoy_visits` |
| `Origin` | rack-cors origin matching |
| `Host`, `X-Forwarded-Host` | host authorization |
| `User-Agent`, `Referer`, `X-Forwarded-For` | lograge's custom payload |

`Origin` and `Host` are why the middleware is registered from an initializer rather than `config/application.rb`: it has to sit above `Rack::Cors`, which `02_cors.rb` inserts at index 0.

## Behaviour after the fix

Malformed requests get an ordinary answer instead of an exception: garbage `Accept` → 406, garbage `Host` → 403 from host authorization (a scrubbed host still has to match the allow-list), garbage `Cookie` → served, with the mangled session cookie failing signature verification, so the client looks signed out and gets a fresh session.

## Tests

- `test/lib/scrub_header_encoding_test.rb` — unit coverage for the middleware.
- `test/integration/invalid_header_encoding_test.rb` — full stack, one Cookie case and one Accept case. Both fail with the reported `ArgumentError` when the initializer is removed.

🤖
