### PR TITLE
feat(admin): give the admin a view of the live hardpoints

### DIFF
--- a/app/api_components/admin/v1/schemas/admin_hardpoint.rb
+++ b/app/api_components/admin/v1/schemas/admin_hardpoint.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      # The live `hardpoints` table as the admin sees it: a superset of the
+      # public `Hardpoint`, with the parent, the tag lists, and the two answers
+      # the admin UI needs in order to decide what to offer -- whether the slot
+      # is editable and whether the build still describes it.
+      #
+      # Named `AdminHardpoint` rather than `Hardpoint` because the shared
+      # component of that name is emitted into this document too, and two
+      # definitions cannot share one name.
+      class AdminHardpoint
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            id: {type: :string, format: :uuid},
+            name: {type: :string},
+            parentId: {type: :string, format: :uuid},
+            parentType: {type: :string},
+            source: ::Shared::V1::Schemas::Enums::HardpointSourceEnum,
+
+            # The loader owns the game-files half and rewrites it on every load,
+            # so only the curated half may be changed. The frontend reads this
+            # rather than deriving it from `source`, so the rule lives in one
+            # place.
+            editable: {type: :boolean},
+
+            # Not in the build in force. Only ever true for the game-files half.
+            retired: {type: :boolean},
+
+            group: ::Shared::V1::Schemas::Enums::HardpointGroupEnum,
+            category: ::Shared::V1::Schemas::Enums::HardpointCategoryEnum,
+            groupKey: {type: :string},
+            matrixKey: {type: :string},
+            minSize: {type: :integer},
+            maxSize: {type: :integer},
+            types: {type: :array, items: {type: :string}},
+            portTags: {type: :array, items: {type: :string}},
+            requiredTags: {type: :array, items: {type: :string}},
+            flags: {type: :array, items: {type: :string}},
+            details: {type: :string},
+            component: {"$ref": "#/components/schemas/Component"},
+            hardpoints: {type: :array, items: {"$ref": "#/components/schemas/AdminHardpoint"}},
+            createdAt: {type: :string, format: "date-time"},
+            updatedAt: {type: :string, format: "date-time"}
+          },
+          additionalProperties: false,
+          required: %w[id name source editable retired createdAt updatedAt]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/admin_hardpoints.rb
+++ b/app/api_components/admin/v1/schemas/admin_hardpoints.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class AdminHardpoints < ::Shared::V1::Schemas::BaseList
+        include OpenapiRuby::Components::Base
+
+        schema({
+          properties: {
+            items: {type: :array, items: {"$ref": "#/components/schemas/AdminHardpoint"}}
+          },
+          required: %w[items]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/admin_hardpoint_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/admin_hardpoint_input.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        # `source` is deliberately absent. A created slot is always
+        # `ship_matrix`, and an update must not move one between owners: the
+        # loader owns the game-files half and would rewrite it on the next load
+        # anyway.
+        class AdminHardpointInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              parentId: {type: :string, format: :uuid},
+              parentType: {type: :string},
+              scName: {type: :string},
+              componentId: {type: [:string, :null], format: :uuid},
+              group: ::Shared::V1::Schemas::Enums::HardpointGroupEnum,
+              category: ::Shared::V1::Schemas::Enums::HardpointCategoryEnum,
+              minSize: {type: [:integer, :null]},
+              maxSize: {type: [:integer, :null]},
+              details: {type: [:string, :null]}
+            },
+            additionalProperties: false
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/queries/admin_hardpoint_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/admin_hardpoint_query.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Queries
+        class AdminHardpointQuery
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              parentIdEq: {type: :string, format: :uuid},
+              parentTypeEq: {type: :string},
+              sourceEq: ::Shared::V1::Schemas::Enums::HardpointSourceEnum,
+              groupEq: ::Shared::V1::Schemas::Enums::HardpointGroupEnum,
+              categoryEq: ::Shared::V1::Schemas::Enums::HardpointCategoryEnum,
+              componentIdEq: {type: :string, format: :uuid},
+              scNameCont: {type: :string}
+            },
+            additionalProperties: false,
+            example: {}
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/api/v1/hardpoints_controller.rb
+++ b/app/controllers/admin/api/v1/hardpoints_controller.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Admin
+  module Api
+    module V1
+      # The live `hardpoints` table, which the admin had no view of at all: the
+      # page it used to have edited `model_hardpoints`, the predecessor table no
+      # load had written since 2024, and that went with the legacy tables in
+      # #4772.
+      #
+      # Read for both halves, write for the curated one only -- see
+      # `Admin::HardpointPolicy` for why. A created slot is always `ship_matrix`
+      # rather than taking the source from the request, so there is no way to
+      # ask for a game-files row the next load would rewrite.
+      class HardpointsController < ::Admin::Api::BaseController
+        before_action :set_hardpoint, only: %i[show update destroy]
+
+        # Top-level slots only. The nested ones come with their parent, through
+        # the `loadouts` array the view renders, because a loadout is a tree and
+        # a flat page of it reads as noise.
+        def index
+          authorize! with: ::Admin::HardpointPolicy
+
+          hardpoint_query_params["sorts"] ||= "sc_name asc"
+
+          @q = authorized_scope(Hardpoint.where.not(parent_type: "Hardpoint"))
+            .ransack(hardpoint_query_params)
+
+          @hardpoints = @q.result
+            .includes(:component, hardpoints: :component)
+            .page(params.fetch(:page, nil))
+            .per(params.fetch(:per_page, nil))
+        end
+
+        def show
+        end
+
+        def create
+          @hardpoint = Hardpoint.new(hardpoint_params.merge(source: :ship_matrix))
+
+          authorize! @hardpoint, with: ::Admin::HardpointPolicy
+
+          if @hardpoint.save
+            render :show, status: :created
+          else
+            render json: ValidationError.new("hardpoint.create", errors: @hardpoint.errors),
+              status: :bad_request
+          end
+        end
+
+        def update
+          if @hardpoint.update(hardpoint_params)
+            render :show, status: :ok
+          else
+            render json: ValidationError.new("hardpoint.update", errors: @hardpoint.errors),
+              status: :bad_request
+          end
+        end
+
+        def destroy
+          @hardpoint.destroy
+
+          head :no_content
+        end
+
+        private def set_hardpoint
+          @hardpoint = Hardpoint.find(params[:id])
+
+          authorize! @hardpoint, with: ::Admin::HardpointPolicy
+        end
+
+        # `source` is not permitted: `create` forces the curated half and an
+        # update must not move a slot between owners.
+        private def hardpoint_params
+          @hardpoint_params ||= params.permit(
+            :parent_id, :parent_type, :sc_name, :component_id, :group, :category,
+            :min_size, :max_size, :details
+          )
+        end
+
+        private def hardpoint_query_params
+          @hardpoint_query_params ||= params.permit(q: [
+            :parent_id_eq, :parent_type_eq, :source_eq, :group_eq, :category_eq,
+            :component_id_eq, :sc_name_cont, :sorts
+          ]).fetch(:q, {})
+        end
+      end
+    end
+  end
+end

--- a/app/policies/admin/hardpoint_policy.rb
+++ b/app/policies/admin/hardpoint_policy.rb
@@ -1,5 +1,24 @@
 module Admin
   class HardpointPolicy < BasePolicy
+    # The two halves of `hardpoints` have different owners, and only one of them
+    # is an admin's to change.
+    #
+    # `game_files` belongs to the loader: `persist_slot` rewrites those rows on
+    # every load, so an edit here would last until the next one and then vanish
+    # without a word. That is exactly what made the legacy `model_hardpoints`
+    # editor pointless.
+    #
+    # `ship_matrix` is the curated half -- `persist_loadout` scopes its cleanup
+    # to `game_files` precisely so a load cannot reach hand-entered data -- and
+    # that is the half this allows.
+    #
+    # Reading is allowed for both: `index?` and `show?` still alias to `manage?`.
+    def update?
+      manage? && record.ship_matrix?
+    end
+
+    alias_rule :destroy?, to: :update?
+
     private def resource_access
       [:models]
     end

--- a/app/views/admin/api/v1/hardpoints/_base.jbuilder
+++ b/app/views/admin/api/v1/hardpoints/_base.jbuilder
@@ -1,39 +1,52 @@
 # frozen_string_literal: true
 
+# What the build in force says about this slot. `hardpoint` answers for what
+# identifies it -- the name, the parent, the source -- while everything a build
+# has an opinion about comes from `facts`, which is the build row or the row
+# itself for a matrix slot.
+facts = hardpoint.facts
+
 json.id hardpoint.id
 json.name hardpoint.sc_name
-json.type hardpoint.category
-json.group hardpoint.group
+
+json.parent_id hardpoint.parent_id
+json.parent_type hardpoint.parent_type
+
+# Which half this is, and therefore whether an admin may change it: the loader
+# owns `game_files` and rewrites it on every load, the matrix half is curated.
+# The frontend needs this to decide what to offer, so it is not just a label.
 json.source hardpoint.source
-json.category hardpoint.category
-json.category_label hardpoint.category
-json.sub_category nil
-json.sub_category_label nil
-json.size hardpoint.max_size
-json.size_label hardpoint.max_size.to_s
-json.key hardpoint.group_key
-json.loadout_identifier nil
+json.editable hardpoint.ship_matrix?
+
+# Not in the build we are on -- a port the loadout no longer has. Only ever true
+# for the game-files half.
+json.retired hardpoint.retired?
+
+json.group facts.group
+json.category facts.category
+json.group_key facts.group_key
+json.matrix_key hardpoint.matrix_key
+
+json.min_size facts.min_size
+json.max_size facts.max_size
+json.types facts.types
+json.port_tags facts.port_tags
+json.required_tags facts.required_tags
+json.flags facts.flags
+
 json.details hardpoint.details
-json.mount nil
-json.item_slots nil
-json.model_id hardpoint.parent_id
 
 json.component do
-  json.partial! "api/v1/components/base", component: hardpoint.component if hardpoint.component.present?
+  json.partial! "api/v1/components/base", component: facts.component if facts.component.present?
 end
-json.component nil if hardpoint.component.blank?
+json.component nil if facts.component.blank?
 
-json.loadouts do
-  json.array! hardpoint.hardpoints do |child|
-    json.id child.id
-    json.name child.sc_name
-    json.model_hardpoint_id hardpoint.id
-    json.component do
-      json.partial! "api/v1/components/base", component: child.component if child.component.present?
-    end
-    json.component nil if child.component.blank?
-    json.partial! "api/shared/dates", record: child
-  end
+# The nested slots, which is what a loadout is. Every child the build describes,
+# rendered the same way -- the previous version of this view emitted a flat
+# `loadouts` array shaped like the legacy table's, with a `model_hardpoint_id`
+# nothing read.
+json.hardpoints do
+  json.array! hardpoint.hardpoints.in_build, partial: "admin/api/v1/hardpoints/base", as: :hardpoint
 end
 
 json.partial! "api/shared/dates", record: hardpoint

--- a/app/views/admin/api/v1/hardpoints/_hardpoint.jbuilder
+++ b/app/views/admin/api/v1/hardpoints/_hardpoint.jbuilder
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
-json.cache! ["admin-v1", hardpoint, Manufacturer.artwork_version] do
+# The build row is in the key because the facts come from it: a build landing
+# under an untouched slot leaves the row's own `updated_at` alone, so keying on
+# the slot alone would serve the previous build's loadout. For a matrix slot
+# `facts` is the slot itself and this collapses back to one entry.
+json.cache! ["admin-v2", hardpoint, hardpoint.facts, hardpoint.facts.component, Manufacturer.artwork_version] do
   json.partial!("admin/api/v1/hardpoints/base", hardpoint:)
 end

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -73,6 +73,10 @@ v1_admin_api_routes = lambda do
       put :regenerate
     end
   end
+  # Read for both halves of the table, write only for the curated one -- the
+  # policy decides, not the routes, so a refused write is a 403 rather than a
+  # missing action.
+  resources :hardpoints, only: %i[index show create update destroy]
   resources :docks, only: %i[index show create update destroy]
   resources :model_loaners, path: "model-loaners", only: %i[index show create update destroy]
   resources :model_snub_crafts, path: "model-snub-crafts", only: %i[index show create update destroy]

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -2640,6 +2640,105 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/hardpoints":
+    get:
+      summary: Hardpoints
+      tags:
+      - Hardpoints
+      operationId: listHardpoints
+      parameters:
+      - name: q
+        in: query
+        schema:
+          "$ref": "#/components/schemas/AdminHardpointQuery"
+        required: false
+        style: deepObject
+        explode: true
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminHardpoints"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    post:
+      summary: Create Hardpoint
+      tags:
+      - Hardpoints
+      operationId: createHardpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AdminHardpointInput"
+      responses:
+        '201':
+          description: created
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminHardpoint"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+  "/hardpoints/{id}":
+    parameters:
+    - name: id
+      in: path
+      schema:
+        type: string
+        format: uuid
+      required: true
+    get:
+      summary: Hardpoint
+      tags:
+      - Hardpoints
+      operationId: hardpoint
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminHardpoint"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Hardpoint
+      tags:
+      - Hardpoints
+      operationId: updateHardpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AdminHardpointInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AdminHardpoint"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+    delete:
+      summary: Destroy Hardpoint
+      tags:
+      - Hardpoints
+      operationId: destroyHardpoint
+      responses:
+        '204':
+          description: no content
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/images":
     post:
       summary: Image create
@@ -8131,6 +8230,146 @@ components:
       - name
       - permanent
       title: AdminFleetRole
+    AdminHardpoint:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        parentId:
+          type: string
+          format: uuid
+        parentType:
+          type: string
+        source:
+          "$ref": "#/components/schemas/HardpointSourceEnum"
+        editable:
+          type: boolean
+        retired:
+          type: boolean
+        group:
+          "$ref": "#/components/schemas/HardpointGroupEnum"
+        category:
+          "$ref": "#/components/schemas/HardpointCategoryEnum"
+        groupKey:
+          type: string
+        matrixKey:
+          type: string
+        minSize:
+          type: integer
+        maxSize:
+          type: integer
+        types:
+          type: array
+          items:
+            type: string
+        portTags:
+          type: array
+          items:
+            type: string
+        requiredTags:
+          type: array
+          items:
+            type: string
+        flags:
+          type: array
+          items:
+            type: string
+        details:
+          type: string
+        component:
+          "$ref": "#/components/schemas/Component"
+        hardpoints:
+          type: array
+          items:
+            "$ref": "#/components/schemas/AdminHardpoint"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+      - id
+      - name
+      - source
+      - editable
+      - retired
+      - createdAt
+      - updatedAt
+      title: AdminHardpoint
+    AdminHardpointInput:
+      type: object
+      properties:
+        parentId:
+          type: string
+          format: uuid
+        parentType:
+          type: string
+        scName:
+          type: string
+        componentId:
+          type:
+          - string
+          - 'null'
+          format: uuid
+        group:
+          "$ref": "#/components/schemas/HardpointGroupEnum"
+        category:
+          "$ref": "#/components/schemas/HardpointCategoryEnum"
+        minSize:
+          type:
+          - integer
+          - 'null'
+        maxSize:
+          type:
+          - integer
+          - 'null'
+        details:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      title: AdminHardpointInput
+    AdminHardpointQuery:
+      type: object
+      properties:
+        parentIdEq:
+          type: string
+          format: uuid
+        parentTypeEq:
+          type: string
+        sourceEq:
+          "$ref": "#/components/schemas/HardpointSourceEnum"
+        groupEq:
+          "$ref": "#/components/schemas/HardpointGroupEnum"
+        categoryEq:
+          "$ref": "#/components/schemas/HardpointCategoryEnum"
+        componentIdEq:
+          type: string
+          format: uuid
+        scNameCont:
+          type: string
+      additionalProperties: false
+      example: {}
+      title: AdminHardpointQuery
+    AdminHardpoints:
+      type: object
+      properties:
+        meta:
+          "$ref": "#/components/schemas/Meta"
+        items:
+          type: array
+          items:
+            "$ref": "#/components/schemas/AdminHardpoint"
+      additionalProperties: false
+      required:
+      - meta
+      - items
+      title: AdminHardpoints
     AdminModelMedia:
       type: object
       properties:

--- a/test/integration/admin/api/v1/hardpoints_test.rb
+++ b/test/integration/admin/api/v1/hardpoints_test.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Admin::Api::V1::HardpointsTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"admin/v1/schema"
+
+  setup do
+    @admin_user = create(:admin_user, resource_access: [:models])
+    @model = create(:model)
+    sign_in @admin_user
+  end
+
+  api_path "/hardpoints" do
+    get("Hardpoints") do
+      operationId "listHardpoints"
+      tags "Hardpoints"
+      produces "application/json"
+
+      parameter name: "q", in: :query, schema: ::Admin::V1::Schemas::Queries::AdminHardpointQuery,
+        required: false, style: :deepObject, explode: true
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::AdminHardpoints
+      end
+    end
+
+    post("Create Hardpoint") do
+      operationId "createHardpoint"
+      tags "Hardpoints"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::AdminHardpointInput
+
+      response(201, "created") do
+        schema ::Admin::V1::Schemas::AdminHardpoint
+      end
+
+      response(400, "bad request") do
+        schema ::Shared::V1::Schemas::ValidationError
+      end
+    end
+  end
+
+  api_path "/hardpoints/{id}" do
+    parameter name: "id", in: :path, schema: {type: :string, format: :uuid}, required: true
+
+    get("Hardpoint") do
+      operationId "hardpoint"
+      tags "Hardpoints"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::AdminHardpoint
+      end
+    end
+
+    put("Update Hardpoint") do
+      operationId "updateHardpoint"
+      tags "Hardpoints"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::AdminHardpointInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::AdminHardpoint
+      end
+    end
+
+    delete("Destroy Hardpoint") do
+      operationId "destroyHardpoint"
+      tags "Hardpoints"
+
+      response(204, "no content") do
+        schema nil
+      end
+    end
+  end
+
+  # --- Reading ---------------------------------------------------------------
+
+  test "GET /hardpoints lists both halves of the table" do
+    create(:hardpoint, parent: @model, sc_name: "from_the_files", source: :game_files)
+    create(:hardpoint, :without_build, parent: @model, sc_name: "curated", source: :ship_matrix)
+
+    assert_api_response :get, 200 do
+      assert_equal ["curated", "from_the_files"], parsed_body["items"].map { |item| item["name"] }.sort
+    end
+  end
+
+  # The whole point of the split: the frontend has to know which slots it may
+  # offer for editing, and the rule lives here rather than being derived from
+  # `source` in the client.
+  test "GET /hardpoints says which slots an admin may change" do
+    create(:hardpoint, parent: @model, sc_name: "from_the_files", source: :game_files)
+    create(:hardpoint, :without_build, parent: @model, sc_name: "curated", source: :ship_matrix)
+
+    assert_api_response :get, 200 do
+      editable = parsed_body["items"].to_h { |item| [item["name"], item["editable"]] }
+
+      assert_equal false, editable["from_the_files"]
+      assert_equal true, editable["curated"]
+    end
+  end
+
+  # A loadout is a tree, so the nested slots come with their parent rather than
+  # as their own rows in the page.
+  test "GET /hardpoints nests the children under their slot" do
+    parent = create(:hardpoint, parent: @model, sc_name: "turret", source: :game_files)
+    create(:hardpoint, parent:, sc_name: "gun", source: :game_files)
+
+    assert_api_response :get, 200 do
+      assert_equal ["turret"], parsed_body["items"].map { |item| item["name"] }
+      assert_equal ["gun"], parsed_body["items"].sole["hardpoints"].map { |child| child["name"] }
+    end
+  end
+
+  test "GET /hardpoints/{id} returns one slot" do
+    hardpoint = create(:hardpoint, parent: @model, source: :game_files)
+
+    assert_api_response :get, 200, path_params: {id: hardpoint.id}
+  end
+
+  # --- Writing ---------------------------------------------------------------
+
+  # `persist_loadout` scopes its cleanup to `game_files` so a load cannot reach
+  # hand-entered data, which is what makes the matrix half an admin's to own.
+  test "PUT /hardpoints/{id} changes a curated slot" do
+    hardpoint = create(:hardpoint, :without_build, parent: @model, source: :ship_matrix)
+
+    assert_api_response :put, 200, path_params: {id: hardpoint.id}, body: {scName: "renamed"}
+
+    assert_equal "renamed", hardpoint.reload.sc_name
+  end
+
+  # The loader owns the other half: `persist_slot` rewrites those rows on every
+  # load, so an edit would last until the next one and then vanish without a
+  # word. That is what made the legacy editor pointless, and refusing is more
+  # honest than accepting.
+  test "PUT /hardpoints/{id} refuses a slot the loader owns" do
+    hardpoint = create(:hardpoint, parent: @model, sc_name: "from_the_files", source: :game_files)
+
+    put "/admin/api/v1/hardpoints/#{hardpoint.id}", params: {scName: "renamed"}, as: :json
+
+    assert_response :forbidden
+    assert_equal "from_the_files", hardpoint.reload.sc_name
+  end
+
+  test "DELETE /hardpoints/{id} removes a curated slot" do
+    hardpoint = create(:hardpoint, :without_build, parent: @model, source: :ship_matrix)
+
+    assert_api_response :delete, 204, path_params: {id: hardpoint.id}
+
+    assert_not Hardpoint.exists?(hardpoint.id)
+  end
+
+  test "DELETE /hardpoints/{id} refuses a slot the loader owns" do
+    hardpoint = create(:hardpoint, parent: @model, source: :game_files)
+
+    delete "/admin/api/v1/hardpoints/#{hardpoint.id}", as: :json
+
+    assert_response :forbidden
+    assert Hardpoint.exists?(hardpoint.id)
+  end
+
+  # Created as `ship_matrix` whatever the request says, so there is no way to
+  # ask for a game-files row the next load would rewrite.
+  test "POST /hardpoints creates a curated slot" do
+    assert_api_response :post, 201,
+      body: {parentId: @model.id, parentType: "Model", scName: "hand_made"}
+
+    hardpoint = Hardpoint.find_by(sc_name: "hand_made")
+    assert_equal "ship_matrix", hardpoint.source
+    assert_equal true, parsed_body["editable"]
+  end
+end


### PR DESCRIPTION
Answers the thing you found: **the admin has no hardpoint view at all.** #4772
removed its only page along with the legacy tables, and there was never one for
the live `hardpoints` — no route, no controller, and four jbuilders nobody could
reach.

Backend only. The frontend follows; this is verifiable on its own through the
integration tests and the generated schema.

## Read both halves, write the curated one

Your rule, and it is the one already written into the loader:

| half | owner | admin |
| --- | --- | --- |
| `game_files` | the loader — `persist_slot` rewrites these rows on every load | **read only** |
| `ship_matrix` | curated — `persist_loadout` scopes its cleanup to `game_files` *precisely* so a load cannot reach hand-entered data | read and write |

An edit to a game-files slot would last until the next load and then vanish
without a word, which is exactly what made the legacy `model_hardpoints` editor
pointless.

The rule lives in `Admin::HardpointPolicy`, not the controller, so a refused
write is a **403** rather than a missing route. A created slot is always
`ship_matrix` whatever the request says, and `source` is not a permitted
parameter — there is no way to ask for a game-files row.

## The response carries the decisions

`editable` and `retired`, rather than leaving the client to derive them from
`source`: whether an admin may change a slot, and whether the build in force
still describes it. Facts come from the build row through `facts`, and the
fragment cache key gains it — a build landing under an untouched slot leaves the
row's own `updated_at` alone, so keying on the slot would serve the previous
build's loadout.

## What the old view was

Worth seeing, since it is what an admin would have got if it had ever been
routed:

```
json.sub_category nil
json.sub_category_label nil
json.loadout_identifier nil
json.mount nil
json.item_slots nil
json.model_hardpoint_id hardpoint.id   # the *parent's* id, in a flat
                                       # `loadouts` array shaped like the
                                       # legacy table's
```

It renders the nested slots as what they are now.

## One naming trap

`AdminHardpoint`, not `Hardpoint`. The shared component of that name is emitted
into the admin document too — `swagger/admin/v1/schema.yaml` already has a
`Hardpoint` — and two definitions cannot share one name.

## Verified

| | |
| --- | --- |
| the new endpoint | 9 tests, including a 403 on a game-files `PUT` and `DELETE`, and a `POST` that comes back `ship_matrix` |
| `test/integration/admin/` | 918 tests, green |
| admin schema | **+239 lines, −0**; oasdiff reports no breaking changes |
| `pnpm lint:ts` | exit 0 |
| `bin/ruby-lint` | clean |

🤖
