### PR TITLE
fix(pghero): serve PgHero's assets from the app, not the CDN

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,8 +29,15 @@ Rails.application.configure do
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
-  config.action_controller.asset_host = Rails.configuration.app.cdn_endpoint || endpoints.frontend_endpoint
-  config.asset_host = Rails.configuration.app.cdn_endpoint || endpoints.frontend_endpoint
+  # The CDN pull zone only holds Vite's build output. PgHero renders through Rails' asset
+  # helpers, and the pghero_assets middleware serves those files from the app itself, so they
+  # have to stay on the origin instead of being prefixed with the asset host.
+  cdn_host = Rails.configuration.app.cdn_endpoint || endpoints.frontend_endpoint
+  origin_served_assets = %r{\A/(?:javascripts|images|stylesheets)/pghero}
+  asset_host = ->(source) { cdn_host unless origin_served_assets.match?(source) }
+
+  config.action_controller.asset_host = asset_host
+  config.asset_host = asset_host
 
   # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
   # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
@@ -42,9 +49,6 @@ Rails.application.configure do
   config.public_file_server.headers = {
     "Cache-Control" => "public, max-age=31536000, immutable"
   }
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.asset_host = Rails.configuration.app.cdn_endpoint
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache


### PR DESCRIPTION
The PgHero screen renders unstyled on production — no CSS, no charts.

## Why

PgHero's layout uses Rails' `stylesheet_link_tag` / `javascript_include_tag` / `favicon_link_tag`. Production points `asset_host` at the CDN pull zone, so the helpers prefix it onto every path they generate. The pull zone only holds Vite's build output:

```
https://cdn.fltyrd.net/stylesheets/pghero/application.css   → 404
https://admin.fleetyards.net/stylesheets/pghero/application.css → 200  text/css  14071b
```

The `pghero_assets` middleware serves those files correctly from the app origin — but with a host prefixed onto the path, nothing ever asks the origin for them. Anything outside the Vite stack that renders through Rails' asset helpers hits this.

## The change

`asset_host` becomes a proc: no host for the three paths that middleware answers, CDN for everything else. Checked against ActionView:

```
pghero/application  stylesheet => /stylesheets/pghero/application.css
pghero/application  javascript => /javascripts/pghero/application.js
pghero/favicon.png  image      => /images/pghero/favicon.png
frontend            stylesheet => https://cdn.fltyrd.net/stylesheets/frontend.css
```

Sidekiq and Maintenance Tasks are unaffected — one serves its assets outside Rails' helpers, the other links an absolute CDN URL, which the helpers leave alone. Mailers keep their own `action_mailer.asset_host`.

Also drops a second `config.asset_host` assignment further down the file. It overwrote the first and lost its `frontend_endpoint` fallback doing so; production sets a `cdn_endpoint`, so that changes nothing today.

Staging inherits from `production.rb`, so it is covered too.

## Verifying after deploy

Load `/pghero` — it should be styled. Or check that the stylesheet is same-origin rather than `cdn.fltyrd.net`.

🤖
