### PR TITLE
perf(db): act on PgHero's index report

### DIFF
--- a/app/models/cargo_hold.rb
+++ b/app/models/cargo_hold.rb
@@ -32,7 +32,6 @@
 #
 #  index_cargo_holds_on_capacity_scu                   (capacity_scu)
 #  index_cargo_holds_on_parent_and_max_container_size  (parent_type,parent_id,max_container_size_scu)
-#  index_cargo_holds_on_parent_type_and_parent_id      (parent_type,parent_id)
 #
 class CargoHold < ApplicationRecord
   belongs_to :parent, polymorphic: true, touch: true

--- a/app/models/commodity_build.rb
+++ b/app/models/commodity_build.rb
@@ -23,7 +23,6 @@
 # Indexes
 #
 #  index_commodity_builds_on_commodity_and_build             (commodity_id,environment,version) UNIQUE
-#  index_commodity_builds_on_commodity_id                    (commodity_id)
 #  index_commodity_builds_on_environment_and_commodity_type  (environment,commodity_type)
 #  index_commodity_builds_on_environment_and_version         (environment,version)
 #

--- a/app/models/component.rb
+++ b/app/models/component.rb
@@ -36,6 +36,7 @@
 # Indexes
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
+#  index_components_on_name             (name)
 #  index_components_on_sc_key           (sc_key) UNIQUE
 #  index_components_on_version          (version)
 #

--- a/app/models/component_build.rb
+++ b/app/models/component_build.rb
@@ -35,7 +35,6 @@
 # Indexes
 #
 #  index_component_builds_on_component_and_build              (component_id,environment,version) UNIQUE
-#  index_component_builds_on_component_id                     (component_id)
 #  index_component_builds_on_environment_and_component_class  (environment,component_class)
 #  index_component_builds_on_environment_and_item_type        (environment,item_type)
 #  index_component_builds_on_environment_and_version          (environment,version)

--- a/app/models/equipment_build.rb
+++ b/app/models/equipment_build.rb
@@ -40,7 +40,6 @@
 #  index_equipment_builds_on_environment_and_item_type       (environment,item_type)
 #  index_equipment_builds_on_environment_and_version         (environment,version)
 #  index_equipment_builds_on_equipment_and_build             (equipment_id,environment,version) UNIQUE
-#  index_equipment_builds_on_equipment_id                    (equipment_id)
 #  index_equipment_builds_on_manufacturer_id                 (manufacturer_id)
 #
 # Foreign Keys

--- a/app/models/fleet_event_admin.rb
+++ b/app/models/fleet_event_admin.rb
@@ -14,7 +14,6 @@
 #
 # Indexes
 #
-#  index_fleet_event_admins_on_fleet_event_id              (fleet_event_id)
 #  index_fleet_event_admins_on_fleet_event_id_and_user_id  (fleet_event_id,user_id) UNIQUE
 #  index_fleet_event_admins_on_user_id                     (user_id)
 #

--- a/app/models/fleet_event_ship.rb
+++ b/app/models/fleet_event_ship.rb
@@ -22,7 +22,6 @@
 #
 # Indexes
 #
-#  index_fleet_event_ships_on_fleet_event_team_id               (fleet_event_team_id)
 #  index_fleet_event_ships_on_fleet_event_team_id_and_position  (fleet_event_team_id,position)
 #  index_fleet_event_ships_on_model_id                          (model_id)
 #

--- a/app/models/fleet_event_ship_model.rb
+++ b/app/models/fleet_event_ship_model.rb
@@ -17,7 +17,6 @@
 # Indexes
 #
 #  index_fleet_event_ship_models_on_model_id           (model_id)
-#  index_fleet_event_ship_models_on_ship               (fleet_event_ship_id)
 #  index_fleet_event_ship_models_on_ship_and_model     (fleet_event_ship_id,model_id) UNIQUE
 #  index_fleet_event_ship_models_on_ship_and_position  (fleet_event_ship_id,position)
 #

--- a/app/models/fleet_event_signup.rb
+++ b/app/models/fleet_event_signup.rb
@@ -20,7 +20,6 @@
 # Indexes
 #
 #  idx_fleet_event_signups_on_event_and_occurrence_and_member  (fleet_event_id,occurrence_date,fleet_membership_id)
-#  index_fleet_event_signups_on_fleet_event_id                 (fleet_event_id)
 #  index_fleet_event_signups_on_fleet_event_slot_id            (fleet_event_slot_id)
 #  index_fleet_event_signups_on_fleet_membership_id            (fleet_membership_id)
 #  index_fleet_event_signups_unique_active_per_event           (fleet_event_id,occurrence_date,fleet_membership_id) UNIQUE WHERE ((status)::text <> 'withdrawn'::text)

--- a/app/models/fleet_event_slot.rb
+++ b/app/models/fleet_event_slot.rb
@@ -18,9 +18,8 @@
 #
 # Indexes
 #
-#  index_fleet_event_slots_on_model_position_id                (model_position_id)
-#  index_fleet_event_slots_on_slottable_and_position           (slottable_type,slottable_id,position)
-#  index_fleet_event_slots_on_slottable_type_and_slottable_id  (slottable_type,slottable_id)
+#  index_fleet_event_slots_on_model_position_id       (model_position_id)
+#  index_fleet_event_slots_on_slottable_and_position  (slottable_type,slottable_id,position)
 #
 # Foreign Keys
 #

--- a/app/models/fleet_event_team.rb
+++ b/app/models/fleet_event_team.rb
@@ -15,7 +15,6 @@
 #
 # Indexes
 #
-#  index_fleet_event_teams_on_fleet_event_id               (fleet_event_id)
 #  index_fleet_event_teams_on_fleet_event_id_and_position  (fleet_event_id,position)
 #
 # Foreign Keys

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/hangar_import.rb
+++ b/app/models/imports/hangar_import.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/hangar_sync.rb
+++ b/app/models/imports/hangar_sync.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/model_import.rb
+++ b/app/models/imports/model_import.rb
@@ -23,6 +23,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/models_import.rb
+++ b/app/models/imports/models_import.rb
@@ -23,6 +23,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/modules_import.rb
+++ b/app/models/imports/modules_import.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/paints_import.rb
+++ b/app/models/imports/paints_import.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/sc_data/all_import.rb
+++ b/app/models/imports/sc_data/all_import.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/sc_data/model_import.rb
+++ b/app/models/imports/sc_data/model_import.rb
@@ -23,6 +23,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/sc_data/models_import.rb
+++ b/app/models/imports/sc_data/models_import.rb
@@ -23,6 +23,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/uex_commodity_prices_import.rb
+++ b/app/models/imports/uex_commodity_prices_import.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/imports/uex_prices_import.rb
+++ b/app/models/imports/uex_prices_import.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/app/models/item_price_snapshot.rb
+++ b/app/models/item_price_snapshot.rb
@@ -22,7 +22,6 @@
 #
 # Indexes
 #
-#  index_item_price_snapshots_on_item                  (item_type,item_id)
 #  index_item_price_snapshots_on_item_and_day          (item_type,item_id,location,price_type,time_range,recorded_on) UNIQUE NULLS NOT DISTINCT
 #  index_item_price_snapshots_on_item_and_recorded_on  (item_type,item_id,recorded_on)
 #  index_item_price_snapshots_on_recorded_on           (recorded_on)

--- a/app/models/mission_ship.rb
+++ b/app/models/mission_ship.rb
@@ -21,7 +21,6 @@
 #
 # Indexes
 #
-#  index_mission_ships_on_mission_team_id               (mission_team_id)
 #  index_mission_ships_on_mission_team_id_and_position  (mission_team_id,position)
 #  index_mission_ships_on_model_id                      (model_id)
 #

--- a/app/models/mission_ship_model.rb
+++ b/app/models/mission_ship_model.rb
@@ -16,7 +16,6 @@
 #
 # Indexes
 #
-#  index_mission_ship_models_on_mission_ship_id    (mission_ship_id)
 #  index_mission_ship_models_on_model_id           (model_id)
 #  index_mission_ship_models_on_ship_and_model     (mission_ship_id,model_id) UNIQUE
 #  index_mission_ship_models_on_ship_and_position  (mission_ship_id,position)

--- a/app/models/mission_slot.rb
+++ b/app/models/mission_slot.rb
@@ -16,9 +16,8 @@
 #
 # Indexes
 #
-#  index_mission_slots_on_model_position_id                (model_position_id)
-#  index_mission_slots_on_slottable_and_position           (slottable_type,slottable_id,position)
-#  index_mission_slots_on_slottable_type_and_slottable_id  (slottable_type,slottable_id)
+#  index_mission_slots_on_model_position_id       (model_position_id)
+#  index_mission_slots_on_slottable_and_position  (slottable_type,slottable_id,position)
 #
 # Foreign Keys
 #

--- a/app/models/mission_team.rb
+++ b/app/models/mission_team.rb
@@ -14,7 +14,6 @@
 #
 # Indexes
 #
-#  index_mission_teams_on_mission_id               (mission_id)
 #  index_mission_teams_on_mission_id_and_position  (mission_id,position)
 #
 # Foreign Keys

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -120,7 +120,6 @@
 #  index_models_on_base_model_id             (base_model_id)
 #  index_models_on_classification            (classification)
 #  index_models_on_legacy_slug               (legacy_slug)
-#  index_models_on_manufacturer_id           (manufacturer_id)
 #  index_models_on_manufacturer_id_and_name  (manufacturer_id,name) UNIQUE
 #  index_models_on_production_status         (production_status)
 #  index_models_on_size                      (size)

--- a/app/models/model_build.rb
+++ b/app/models/model_build.rb
@@ -51,7 +51,6 @@
 #
 #  index_model_builds_on_environment_and_version  (environment,version)
 #  index_model_builds_on_model_and_build          (model_id,environment,version) UNIQUE
-#  index_model_builds_on_model_id                 (model_id)
 #
 # Foreign Keys
 #

--- a/app/models/model_build_change.rb
+++ b/app/models/model_build_change.rb
@@ -25,7 +25,6 @@
 #
 #  index_model_build_changes_on_build            (environment,to_version)
 #  index_model_build_changes_on_model_and_field  (model_id,environment,to_version,field) UNIQUE
-#  index_model_build_changes_on_model_id         (model_id)
 #  index_model_build_changes_on_recorded_at      (recorded_at)
 #
 # Foreign Keys

--- a/app/models/model_sale.rb
+++ b/app/models/model_sale.rb
@@ -15,7 +15,6 @@
 #
 # Indexes
 #
-#  index_model_sales_on_model_id                 (model_id)
 #  index_model_sales_on_model_id_and_started_at  (model_id,started_at) UNIQUE
 #  index_model_sales_on_model_id_ongoing         (model_id) UNIQUE WHERE (ended_at IS NULL)
 #  index_model_sales_on_started_at               (started_at)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,14 +65,18 @@
 #
 # Indexes
 #
-#  index_users_on_calendar_feed_token   (calendar_feed_token) UNIQUE
-#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_last_active_at        (last_active_at)
-#  index_users_on_normalized_username   (normalized_username)
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_unlock_token          (unlock_token) UNIQUE
-#  index_users_on_username              (username) UNIQUE
+#  index_users_on_calendar_feed_token    (calendar_feed_token) UNIQUE
+#  index_users_on_confirmation_token     (confirmation_token) UNIQUE
+#  index_users_on_email                  (email) UNIQUE
+#  index_users_on_id_where_not_tracking  (id) WHERE (tracking = false)
+#  index_users_on_last_active_at         (last_active_at)
+#  index_users_on_lower_email            (lower((email)::text))
+#  index_users_on_lower_username         (lower((username)::text))
+#  index_users_on_normalized_email       (normalized_email)
+#  index_users_on_normalized_username    (normalized_username)
+#  index_users_on_reset_password_token   (reset_password_token) UNIQUE
+#  index_users_on_unlock_token           (unlock_token) UNIQUE
+#  index_users_on_username               (username) UNIQUE
 #
 class User < ApplicationRecord
   # A version of a user row holds their old email and username verbatim, so it

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -14,7 +14,6 @@
 #
 # Indexes
 #
-#  index_vehicle_loadouts_on_vehicle_id           (vehicle_id)
 #  index_vehicle_loadouts_on_vehicle_id_and_name  (vehicle_id,name) UNIQUE
 #
 # Foreign Keys

--- a/db/migrate/20260908150000_remove_indexes_covered_by_composites.rb
+++ b/db/migrate/20260908150000_remove_indexes_covered_by_composites.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+# Every index here is the leading prefix of a wider index on the same table, so
+# it answers nothing the wider one does not. Most are the single-column index
+# `add_reference` creates, later joined by a composite that starts on the same
+# column.
+class RemoveIndexesCoveredByComposites < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :cargo_holds, column: [:parent_type, :parent_id],
+      name: "index_cargo_holds_on_parent_type_and_parent_id", algorithm: :concurrently
+    remove_index :commodity_builds, column: :commodity_id,
+      name: "index_commodity_builds_on_commodity_id", algorithm: :concurrently
+    remove_index :component_builds, column: :component_id,
+      name: "index_component_builds_on_component_id", algorithm: :concurrently
+    remove_index :equipment_builds, column: :equipment_id,
+      name: "index_equipment_builds_on_equipment_id", algorithm: :concurrently
+    remove_index :fleet_event_admins, column: :fleet_event_id,
+      name: "index_fleet_event_admins_on_fleet_event_id", algorithm: :concurrently
+    remove_index :fleet_event_ship_models, column: :fleet_event_ship_id,
+      name: "index_fleet_event_ship_models_on_ship", algorithm: :concurrently
+    remove_index :fleet_event_ships, column: :fleet_event_team_id,
+      name: "index_fleet_event_ships_on_fleet_event_team_id", algorithm: :concurrently
+    remove_index :fleet_event_signups, column: :fleet_event_id,
+      name: "index_fleet_event_signups_on_fleet_event_id", algorithm: :concurrently
+    remove_index :fleet_event_slots, column: [:slottable_type, :slottable_id],
+      name: "index_fleet_event_slots_on_slottable_type_and_slottable_id", algorithm: :concurrently
+    remove_index :fleet_event_teams, column: :fleet_event_id,
+      name: "index_fleet_event_teams_on_fleet_event_id", algorithm: :concurrently
+    remove_index :item_price_snapshots, column: [:item_type, :item_id],
+      name: "index_item_price_snapshots_on_item", algorithm: :concurrently
+    remove_index :mission_ship_models, column: :mission_ship_id,
+      name: "index_mission_ship_models_on_mission_ship_id", algorithm: :concurrently
+    remove_index :mission_ships, column: :mission_team_id,
+      name: "index_mission_ships_on_mission_team_id", algorithm: :concurrently
+    remove_index :mission_slots, column: [:slottable_type, :slottable_id],
+      name: "index_mission_slots_on_slottable_type_and_slottable_id", algorithm: :concurrently
+    remove_index :mission_teams, column: :mission_id,
+      name: "index_mission_teams_on_mission_id", algorithm: :concurrently
+    remove_index :model_build_changes, column: :model_id,
+      name: "index_model_build_changes_on_model_id", algorithm: :concurrently
+    remove_index :model_builds, column: :model_id,
+      name: "index_model_builds_on_model_id", algorithm: :concurrently
+    remove_index :model_sales, column: :model_id,
+      name: "index_model_sales_on_model_id", algorithm: :concurrently
+    remove_index :models, column: :manufacturer_id,
+      name: "index_models_on_manufacturer_id", algorithm: :concurrently
+    remove_index :vehicle_loadout_hardpoints, column: :vehicle_loadout_id,
+      name: "index_vehicle_loadout_hardpoints_on_vehicle_loadout_id", algorithm: :concurrently
+    remove_index :vehicle_loadouts, column: :vehicle_id,
+      name: "index_vehicle_loadouts_on_vehicle_id", algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260908160000_add_indexes_for_slow_queries.rb
+++ b/db/migrate/20260908160000_add_indexes_for_slow_queries.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class AddIndexesForSlowQueries < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    # `uniqueness: {case_sensitive: false}` on email and username compares
+    # LOWER(column), which no plain index on the column can answer, so both
+    # validations scanned the whole table on every user save.
+    add_index :users, "LOWER(email)", name: "index_users_on_lower_email", algorithm: :concurrently
+    add_index :users, "LOWER(username)", name: "index_users_on_lower_username", algorithm: :concurrently
+
+    # The login lookup reads either normalized column; only username was indexed.
+    add_index :users, :normalized_email, algorithm: :concurrently
+
+    # Two accounts out of sixty thousand opt out of tracking, and every stats
+    # request read the whole table to find them. Partial, so the index holds
+    # only those rows and answers from itself.
+    add_index :users, :id, where: "tracking = false",
+      name: "index_users_on_id_where_not_tracking", algorithm: :concurrently
+
+    # The hangar sync status endpoint polls for a user's latest import, and
+    # nothing indexed the column it filters on.
+    add_index :imports, :user_id, algorithm: :concurrently
+
+    # Batched iteration over one import type walks the primary key in order.
+    add_index :imports, [:type, :id], algorithm: :concurrently
+
+    add_index :components, :name, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_08_160000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -180,7 +180,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.index ["capacity_scu"], name: "index_cargo_holds_on_capacity_scu"
     t.index ["parent_type", "parent_id", "max_container_size_scu"], name: "index_cargo_holds_on_parent_and_max_container_size"
-    t.index ["parent_type", "parent_id"], name: "index_cargo_holds_on_parent_type_and_parent_id"
   end
 
   create_table "commodities", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -211,7 +210,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.string "version", null: false
     t.index ["commodity_id", "environment", "version"], name: "index_commodity_builds_on_commodity_and_build", unique: true
-    t.index ["commodity_id"], name: "index_commodity_builds_on_commodity_id"
     t.index ["environment", "commodity_type"], name: "index_commodity_builds_on_environment_and_commodity_type"
     t.index ["environment", "version"], name: "index_commodity_builds_on_environment_and_version"
   end
@@ -255,7 +253,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.string "version", null: false
     t.index ["component_id", "environment", "version"], name: "index_component_builds_on_component_and_build", unique: true
-    t.index ["component_id"], name: "index_component_builds_on_component_id"
     t.index ["environment", "component_class"], name: "index_component_builds_on_environment_and_component_class"
     t.index ["environment", "item_type"], name: "index_component_builds_on_environment_and_item_type"
     t.index ["environment", "version"], name: "index_component_builds_on_environment_and_version"
@@ -291,6 +288,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", precision: nil
     t.string "version"
     t.index ["manufacturer_id"], name: "index_components_on_manufacturer_id"
+    t.index ["name"], name: "index_components_on_name"
     t.index ["sc_key"], name: "index_components_on_sc_key", unique: true
     t.index ["version"], name: "index_components_on_version"
   end
@@ -397,7 +395,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.index ["environment", "item_type"], name: "index_equipment_builds_on_environment_and_item_type"
     t.index ["environment", "version"], name: "index_equipment_builds_on_environment_and_version"
     t.index ["equipment_id", "environment", "version"], name: "index_equipment_builds_on_equipment_and_build", unique: true
-    t.index ["equipment_id"], name: "index_equipment_builds_on_equipment_id"
     t.index ["manufacturer_id"], name: "index_equipment_builds_on_manufacturer_id"
   end
 
@@ -428,7 +425,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.uuid "user_id", null: false
     t.index ["fleet_event_id", "user_id"], name: "index_fleet_event_admins_on_fleet_event_id_and_user_id", unique: true
-    t.index ["fleet_event_id"], name: "index_fleet_event_admins_on_fleet_event_id"
     t.index ["user_id"], name: "index_fleet_event_admins_on_user_id"
   end
 
@@ -462,7 +458,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.index ["fleet_event_ship_id", "model_id"], name: "index_fleet_event_ship_models_on_ship_and_model", unique: true
     t.index ["fleet_event_ship_id", "position"], name: "index_fleet_event_ship_models_on_ship_and_position"
-    t.index ["fleet_event_ship_id"], name: "index_fleet_event_ship_models_on_ship"
     t.index ["model_id"], name: "index_fleet_event_ship_models_on_model_id"
   end
 
@@ -482,7 +477,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.index ["fleet_event_team_id", "position"], name: "index_fleet_event_ships_on_fleet_event_team_id_and_position"
-    t.index ["fleet_event_team_id"], name: "index_fleet_event_ships_on_fleet_event_team_id"
     t.index ["model_id"], name: "index_fleet_event_ships_on_model_id"
   end
 
@@ -500,7 +494,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "withdrawn_at"
     t.index ["fleet_event_id", "occurrence_date", "fleet_membership_id"], name: "idx_fleet_event_signups_on_event_and_occurrence_and_member"
     t.index ["fleet_event_id", "occurrence_date", "fleet_membership_id"], name: "index_fleet_event_signups_unique_active_per_event", unique: true, where: "((status)::text <> 'withdrawn'::text)"
-    t.index ["fleet_event_id"], name: "index_fleet_event_signups_on_fleet_event_id"
     t.index ["fleet_event_slot_id"], name: "index_fleet_event_signups_on_fleet_event_slot_id"
     t.index ["fleet_membership_id"], name: "index_fleet_event_signups_on_fleet_membership_id"
   end
@@ -518,7 +511,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.index ["model_position_id"], name: "index_fleet_event_slots_on_model_position_id"
     t.index ["slottable_type", "slottable_id", "position"], name: "index_fleet_event_slots_on_slottable_and_position"
-    t.index ["slottable_type", "slottable_id"], name: "index_fleet_event_slots_on_slottable_type_and_slottable_id"
   end
 
   create_table "fleet_event_teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -530,7 +522,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["fleet_event_id", "position"], name: "index_fleet_event_teams_on_fleet_event_id_and_position"
-    t.index ["fleet_event_id"], name: "index_fleet_event_teams_on_fleet_event_id"
   end
 
   create_table "fleet_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -844,7 +835,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.string "version"
     t.index ["aasm_state", "type"], name: "index_imports_on_aasm_state_and_type"
     t.index ["admin_user_id"], name: "index_imports_on_admin_user_id"
+    t.index ["type", "id"], name: "index_imports_on_type_and_id"
     t.index ["type"], name: "index_imports_on_type"
+    t.index ["user_id"], name: "index_imports_on_user_id"
   end
 
   create_table "inventories", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -891,7 +884,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.index ["item_type", "item_id", "location", "price_type", "time_range", "recorded_on"], name: "index_item_price_snapshots_on_item_and_day", unique: true, nulls_not_distinct: true
     t.index ["item_type", "item_id", "recorded_on"], name: "index_item_price_snapshots_on_item_and_recorded_on"
-    t.index ["item_type", "item_id"], name: "index_item_price_snapshots_on_item"
     t.index ["recorded_on"], name: "index_item_price_snapshots_on_recorded_on"
   end
 
@@ -976,7 +968,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.index ["mission_ship_id", "model_id"], name: "index_mission_ship_models_on_ship_and_model", unique: true
     t.index ["mission_ship_id", "position"], name: "index_mission_ship_models_on_ship_and_position"
-    t.index ["mission_ship_id"], name: "index_mission_ship_models_on_mission_ship_id"
     t.index ["model_id"], name: "index_mission_ship_models_on_model_id"
   end
 
@@ -995,7 +986,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.string "title"
     t.datetime "updated_at", null: false
     t.index ["mission_team_id", "position"], name: "index_mission_ships_on_mission_team_id_and_position"
-    t.index ["mission_team_id"], name: "index_mission_ships_on_mission_team_id"
     t.index ["model_id"], name: "index_mission_ships_on_model_id"
   end
 
@@ -1010,7 +1000,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.index ["model_position_id"], name: "index_mission_slots_on_model_position_id"
     t.index ["slottable_type", "slottable_id", "position"], name: "index_mission_slots_on_slottable_and_position"
-    t.index ["slottable_type", "slottable_id"], name: "index_mission_slots_on_slottable_type_and_slottable_id"
   end
 
   create_table "mission_teams", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1021,7 +1010,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["mission_id", "position"], name: "index_mission_teams_on_mission_id_and_position"
-    t.index ["mission_id"], name: "index_mission_teams_on_mission_id"
   end
 
   create_table "missions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1055,7 +1043,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.index ["environment", "to_version"], name: "index_model_build_changes_on_build"
     t.index ["model_id", "environment", "to_version", "field"], name: "index_model_build_changes_on_model_and_field", unique: true
-    t.index ["model_id"], name: "index_model_build_changes_on_model_id"
     t.index ["recorded_at"], name: "index_model_build_changes_on_recorded_at"
   end
 
@@ -1097,7 +1084,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.decimal "yaw_boosted", precision: 15, scale: 2
     t.index ["environment", "version"], name: "index_model_builds_on_environment_and_version"
     t.index ["model_id", "environment", "version"], name: "index_model_builds_on_model_and_build", unique: true
-    t.index ["model_id"], name: "index_model_builds_on_model_id"
   end
 
   create_table "model_hardpoint_loadouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1220,7 +1206,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "started_at", null: false
     t.datetime "updated_at", null: false
     t.index ["model_id", "started_at"], name: "index_model_sales_on_model_id_and_started_at", unique: true
-    t.index ["model_id"], name: "index_model_sales_on_model_id"
     t.index ["model_id"], name: "index_model_sales_on_model_id_ongoing", unique: true, where: "(ended_at IS NULL)"
     t.index ["started_at"], name: "index_model_sales_on_started_at"
   end
@@ -1357,7 +1342,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.index ["classification"], name: "index_models_on_classification"
     t.index ["legacy_slug"], name: "index_models_on_legacy_slug"
     t.index ["manufacturer_id", "name"], name: "index_models_on_manufacturer_id_and_name", unique: true
-    t.index ["manufacturer_id"], name: "index_models_on_manufacturer_id"
     t.index ["production_status"], name: "index_models_on_production_status"
     t.index ["size"], name: "index_models_on_size"
   end
@@ -1611,10 +1595,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.string "username", limit: 255, default: "", null: false
     t.integer "wanted_vehicles_count", default: 0, null: false
     t.string "youtube"
+    t.index "lower((email)::text)", name: "index_users_on_lower_email"
+    t.index "lower((username)::text)", name: "index_users_on_lower_username"
     t.index ["calendar_feed_token"], name: "index_users_on_calendar_feed_token", unique: true
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["id"], name: "index_users_on_id_where_not_tracking", where: "(tracking = false)"
     t.index ["last_active_at"], name: "index_users_on_last_active_at"
+    t.index ["normalized_email"], name: "index_users_on_normalized_email"
     t.index ["normalized_username"], name: "index_users_on_normalized_username"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
@@ -1628,7 +1616,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.datetime "updated_at", null: false
     t.uuid "vehicle_loadout_id", null: false
     t.index ["vehicle_loadout_id", "model_hardpoint_id"], name: "idx_vehicle_loadout_hardpoints_unique", unique: true
-    t.index ["vehicle_loadout_id"], name: "index_vehicle_loadout_hardpoints_on_vehicle_loadout_id"
   end
 
   create_table "vehicle_loadouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -1639,7 +1626,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_07_200000) do
     t.string "url"
     t.uuid "vehicle_id", null: false
     t.index ["vehicle_id", "name"], name: "index_vehicle_loadouts_on_vehicle_id_and_name", unique: true
-    t.index ["vehicle_id"], name: "index_vehicle_loadouts_on_vehicle_id"
   end
 
   create_table "vehicle_modules", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|

--- a/test/factories/cargo_holds.rb
+++ b/test/factories/cargo_holds.rb
@@ -32,7 +32,6 @@
 #
 #  index_cargo_holds_on_capacity_scu                   (capacity_scu)
 #  index_cargo_holds_on_parent_and_max_container_size  (parent_type,parent_id,max_container_size_scu)
-#  index_cargo_holds_on_parent_type_and_parent_id      (parent_type,parent_id)
 #
 FactoryBot.define do
   factory :cargo_hold do

--- a/test/factories/commodity_builds.rb
+++ b/test/factories/commodity_builds.rb
@@ -17,7 +17,6 @@
 # Indexes
 #
 #  index_commodity_builds_on_commodity_and_build             (commodity_id,environment,version) UNIQUE
-#  index_commodity_builds_on_commodity_id                    (commodity_id)
 #  index_commodity_builds_on_environment_and_commodity_type  (environment,commodity_type)
 #  index_commodity_builds_on_environment_and_version         (environment,version)
 #

--- a/test/factories/component_builds.rb
+++ b/test/factories/component_builds.rb
@@ -33,7 +33,6 @@
 # Indexes
 #
 #  index_component_builds_on_component_and_build              (component_id,environment,version) UNIQUE
-#  index_component_builds_on_component_id                     (component_id)
 #  index_component_builds_on_environment_and_component_class  (environment,component_class)
 #  index_component_builds_on_environment_and_item_type        (environment,item_type)
 #  index_component_builds_on_environment_and_version          (environment,version)

--- a/test/factories/components.rb
+++ b/test/factories/components.rb
@@ -34,6 +34,7 @@
 # Indexes
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
+#  index_components_on_name             (name)
 #  index_components_on_sc_key           (sc_key) UNIQUE
 #  index_components_on_version          (version)
 #

--- a/test/factories/equipment_builds.rb
+++ b/test/factories/equipment_builds.rb
@@ -38,7 +38,6 @@
 #  index_equipment_builds_on_environment_and_item_type       (environment,item_type)
 #  index_equipment_builds_on_environment_and_version         (environment,version)
 #  index_equipment_builds_on_equipment_and_build             (equipment_id,environment,version) UNIQUE
-#  index_equipment_builds_on_equipment_id                    (equipment_id)
 #  index_equipment_builds_on_manufacturer_id                 (manufacturer_id)
 #
 # Foreign Keys

--- a/test/factories/imports.rb
+++ b/test/factories/imports.rb
@@ -23,6 +23,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/test/factories/model_builds.rb
+++ b/test/factories/model_builds.rb
@@ -45,7 +45,6 @@
 #
 #  index_model_builds_on_environment_and_version  (environment,version)
 #  index_model_builds_on_model_and_build          (model_id,environment,version) UNIQUE
-#  index_model_builds_on_model_id                 (model_id)
 #
 # Foreign Keys
 #

--- a/test/factories/model_sales.rb
+++ b/test/factories/model_sales.rb
@@ -13,7 +13,6 @@
 #
 # Indexes
 #
-#  index_model_sales_on_model_id                 (model_id)
 #  index_model_sales_on_model_id_and_started_at  (model_id,started_at) UNIQUE
 #  index_model_sales_on_model_id_ongoing         (model_id) UNIQUE WHERE (ended_at IS NULL)
 #  index_model_sales_on_started_at               (started_at)

--- a/test/factories/models.rb
+++ b/test/factories/models.rb
@@ -118,7 +118,6 @@
 #  index_models_on_base_model_id             (base_model_id)
 #  index_models_on_classification            (classification)
 #  index_models_on_legacy_slug               (legacy_slug)
-#  index_models_on_manufacturer_id           (manufacturer_id)
 #  index_models_on_manufacturer_id_and_name  (manufacturer_id,name) UNIQUE
 #  index_models_on_production_status         (production_status)
 #  index_models_on_size                      (size)

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -63,14 +63,18 @@
 #
 # Indexes
 #
-#  index_users_on_calendar_feed_token   (calendar_feed_token) UNIQUE
-#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_last_active_at        (last_active_at)
-#  index_users_on_normalized_username   (normalized_username)
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_unlock_token          (unlock_token) UNIQUE
-#  index_users_on_username              (username) UNIQUE
+#  index_users_on_calendar_feed_token    (calendar_feed_token) UNIQUE
+#  index_users_on_confirmation_token     (confirmation_token) UNIQUE
+#  index_users_on_email                  (email) UNIQUE
+#  index_users_on_id_where_not_tracking  (id) WHERE (tracking = false)
+#  index_users_on_last_active_at         (last_active_at)
+#  index_users_on_lower_email            (lower((email)::text))
+#  index_users_on_lower_username         (lower((username)::text))
+#  index_users_on_normalized_email       (normalized_email)
+#  index_users_on_normalized_username    (normalized_username)
+#  index_users_on_reset_password_token   (reset_password_token) UNIQUE
+#  index_users_on_unlock_token           (unlock_token) UNIQUE
+#  index_users_on_username               (username) UNIQUE
 #
 FactoryBot.define do
   factory :user do

--- a/test/factories/vehicle_loadouts.rb
+++ b/test/factories/vehicle_loadouts.rb
@@ -14,7 +14,6 @@
 #
 # Indexes
 #
-#  index_vehicle_loadouts_on_vehicle_id           (vehicle_id)
 #  index_vehicle_loadouts_on_vehicle_id_and_name  (vehicle_id,name) UNIQUE
 #
 # Foreign Keys

--- a/test/models/commodity_build_test.rb
+++ b/test/models/commodity_build_test.rb
@@ -19,7 +19,6 @@ require "test_helper"
 # Indexes
 #
 #  index_commodity_builds_on_commodity_and_build             (commodity_id,environment,version) UNIQUE
-#  index_commodity_builds_on_commodity_id                    (commodity_id)
 #  index_commodity_builds_on_environment_and_commodity_type  (environment,commodity_type)
 #  index_commodity_builds_on_environment_and_version         (environment,version)
 #

--- a/test/models/component_build_test.rb
+++ b/test/models/component_build_test.rb
@@ -37,7 +37,6 @@ require "test_helper"
 # Indexes
 #
 #  index_component_builds_on_component_and_build              (component_id,environment,version) UNIQUE
-#  index_component_builds_on_component_id                     (component_id)
 #  index_component_builds_on_environment_and_component_class  (environment,component_class)
 #  index_component_builds_on_environment_and_item_type        (environment,item_type)
 #  index_component_builds_on_environment_and_version          (environment,version)

--- a/test/models/component_test.rb
+++ b/test/models/component_test.rb
@@ -38,6 +38,7 @@ require "test_helper"
 # Indexes
 #
 #  index_components_on_manufacturer_id  (manufacturer_id)
+#  index_components_on_name             (name)
 #  index_components_on_sc_key           (sc_key) UNIQUE
 #  index_components_on_version          (version)
 #

--- a/test/models/equipment_build_test.rb
+++ b/test/models/equipment_build_test.rb
@@ -45,7 +45,6 @@ require "test_helper"
 #  index_equipment_builds_on_environment_and_item_type       (environment,item_type)
 #  index_equipment_builds_on_environment_and_version         (environment,version)
 #  index_equipment_builds_on_equipment_and_build             (equipment_id,environment,version) UNIQUE
-#  index_equipment_builds_on_equipment_id                    (equipment_id)
 #  index_equipment_builds_on_manufacturer_id                 (manufacturer_id)
 #
 # Foreign Keys

--- a/test/models/fleet_event_signup_test.rb
+++ b/test/models/fleet_event_signup_test.rb
@@ -22,7 +22,6 @@ require "test_helper"
 # Indexes
 #
 #  idx_fleet_event_signups_on_event_and_occurrence_and_member  (fleet_event_id,occurrence_date,fleet_membership_id)
-#  index_fleet_event_signups_on_fleet_event_id                 (fleet_event_id)
 #  index_fleet_event_signups_on_fleet_event_slot_id            (fleet_event_slot_id)
 #  index_fleet_event_signups_on_fleet_membership_id            (fleet_membership_id)
 #  index_fleet_event_signups_unique_active_per_event           (fleet_event_id,occurrence_date,fleet_membership_id) UNIQUE WHERE ((status)::text <> 'withdrawn'::text)

--- a/test/models/import_test.rb
+++ b/test/models/import_test.rb
@@ -25,6 +25,8 @@
 #  index_imports_on_aasm_state_and_type  (aasm_state,type)
 #  index_imports_on_admin_user_id        (admin_user_id)
 #  index_imports_on_type                 (type)
+#  index_imports_on_type_and_id          (type,id)
+#  index_imports_on_user_id              (user_id)
 #
 # Foreign Keys
 #

--- a/test/models/model_build_change_test.rb
+++ b/test/models/model_build_change_test.rb
@@ -22,7 +22,6 @@ require "test_helper"
 #
 #  index_model_build_changes_on_build            (environment,to_version)
 #  index_model_build_changes_on_model_and_field  (model_id,environment,to_version,field) UNIQUE
-#  index_model_build_changes_on_model_id         (model_id)
 #  index_model_build_changes_on_recorded_at      (recorded_at)
 #
 # Foreign Keys

--- a/test/models/model_build_test.rb
+++ b/test/models/model_build_test.rb
@@ -47,7 +47,6 @@ require "test_helper"
 #
 #  index_model_builds_on_environment_and_version  (environment,version)
 #  index_model_builds_on_model_and_build          (model_id,environment,version) UNIQUE
-#  index_model_builds_on_model_id                 (model_id)
 #
 # Foreign Keys
 #

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -122,7 +122,6 @@ require "test_helper"
 #  index_models_on_base_model_id             (base_model_id)
 #  index_models_on_classification            (classification)
 #  index_models_on_legacy_slug               (legacy_slug)
-#  index_models_on_manufacturer_id           (manufacturer_id)
 #  index_models_on_manufacturer_id_and_name  (manufacturer_id,name) UNIQUE
 #  index_models_on_production_status         (production_status)
 #  index_models_on_size                      (size)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -65,14 +65,18 @@
 #
 # Indexes
 #
-#  index_users_on_calendar_feed_token   (calendar_feed_token) UNIQUE
-#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
-#  index_users_on_email                 (email) UNIQUE
-#  index_users_on_last_active_at        (last_active_at)
-#  index_users_on_normalized_username   (normalized_username)
-#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
-#  index_users_on_unlock_token          (unlock_token) UNIQUE
-#  index_users_on_username              (username) UNIQUE
+#  index_users_on_calendar_feed_token    (calendar_feed_token) UNIQUE
+#  index_users_on_confirmation_token     (confirmation_token) UNIQUE
+#  index_users_on_email                  (email) UNIQUE
+#  index_users_on_id_where_not_tracking  (id) WHERE (tracking = false)
+#  index_users_on_last_active_at         (last_active_at)
+#  index_users_on_lower_email            (lower((email)::text))
+#  index_users_on_lower_username         (lower((username)::text))
+#  index_users_on_normalized_email       (normalized_email)
+#  index_users_on_normalized_username    (normalized_username)
+#  index_users_on_reset_password_token   (reset_password_token) UNIQUE
+#  index_users_on_unlock_token           (unlock_token) UNIQUE
+#  index_users_on_username               (username) UNIQUE
 #
 require "test_helper"
 


### PR DESCRIPTION
Acts on PgHero's duplicate-index and slow-query pages. Two migrations, both `CONCURRENTLY`.

## Dropping 21 indexes

Each is the leading prefix of a wider index on the same table, so it answers nothing that index does not — mostly the single-column index `add_reference` creates, later joined by a composite starting on the same column. Verified one by one against `schema.rb` that the covering index exists and its leading columns match.

## Adding 7

Four are PgHero's own suggestions. Three it cannot see, because it reports which queries are slow, not why:

- **`LOWER(email)` and `LOWER(username)`** — `uniqueness: {case_sensitive: false}` compares `LOWER(column)`, which the plain unique index on `email` cannot answer, so both validations scanned the whole table on every user save. 189,447 calls each, **399 min of database time between them** — the largest single item in the report.
- **A partial index on `users` where `tracking = false`** — two accounts out of 59,946 have it set, and `tracking_stats_concern.rb` read all 59,946 rows to find them, 88,887 times.

## Measured

On a database restored from a production dump, warm:

| query | before | after |
|---|---|---|
| `LOWER(email)` uniqueness check | 19.2 ms (seq scan) | **0.032 ms** |
| hangar sync status (`imports.user_id`) | 18–48 ms (parallel seq scan) | **0.072 ms** |
| `users WHERE tracking = false` | 9.7 ms | **0.014 ms** |
| `components ORDER BY name` | 9.7 ms (external merge to disk) | **1.4 ms** |

Together the seven cover roughly **12 % of total database time** in the report.

## Two things worth a second look

**The partial index and prepared statements.** A bound parameter means Postgres has to prove `$1 = false` to use a `WHERE tracking = false` index, which a generic plan cannot do. I checked: over seven prepared executions it stayed on a custom plan with an index-only scan, so it holds in practice — but that is a planner decision, not a guarantee. If it ever regresses, caching the blocklist is the more robust fix.

**`imports.user_id` is a plain index, not a composite** with `type` and `created_at`. A user has about a dozen import rows; ordering that many costs nothing, and the column had no index at all while `admin_user_id` did.

None of the new indexes cover a column the sign-in tracking `UPDATE` writes, so those rows stay HOT-updatable — no write penalty on the hottest table.

## Not in this PR

The slow queries that need code rather than an index, largest first: the Devise `:trackable` `UPDATE` (231 min, 433,159 calls — it fires on remember-me restores, and the app already has an indexed `last_active_at`), the ahoy event and visit aggregations (~250 min), the hangar `COUNT(DISTINCT)` joins (~129 min), and uncached `COUNT(*)` calls on `users` and `vehicles` (~107 min).

🤖
