### PR TITLE
perf(stats): count in the database instead of in Ruby

### DIFF
--- a/app/controllers/admin/api/v1/stats_controller.rb
+++ b/app/controllers/admin/api/v1/stats_controller.rb
@@ -6,6 +6,10 @@ module Admin
       class StatsController < ::Admin::Api::BaseController
         include TrackingStatsConcern
 
+        # Ahoy writes the path a `$view` event was recorded on into its
+        # `properties` document; there is no column for it.
+        VIEWED_PAGE = Arel.sql("ahoy_events.properties->>'page'")
+
         def quick_stats
           authorize! with: ::Admin::StatsPolicy
 
@@ -21,15 +25,21 @@ module Admin
         def most_viewed_pages
           authorize! with: ::Admin::StatsPolicy
 
-          most_viewed_pages = Ahoy::Event.one_month.where(name: "$view").to_a.group_by do |event|
-            event.properties["page"]
-          end.map do |page, views|
-            {
-              label: page,
-              count: views.size,
-              tooltip: page
-            }
-          end.sort_by { |item| item[:count] }.reverse.take(10)
+          # Grouped in the database rather than in Ruby. Ten rows come back; the
+          # month behind them is tens of thousands of events, and each one was
+          # instantiated with its whole `properties` document to be counted.
+          most_viewed_pages = Ahoy::Event.one_month.where(name: "$view")
+            .group(VIEWED_PAGE)
+            .order(Arel.sql("COUNT(*) DESC"))
+            .limit(10)
+            .count
+            .map do |page, count|
+              {
+                label: page,
+                count:,
+                tooltip: page
+              }
+            end
 
           render json: most_viewed_pages.to_json
         end

--- a/app/controllers/api/v1/fleet_stats_controller.rb
+++ b/app/controllers/api/v1/fleet_stats_controller.rb
@@ -77,23 +77,28 @@ module Api
       # rubocop:enable Metrics/CyclomaticComplexity
 
       def model_counts
-        scope = @fleet.vehicles.includes(
-          :model_paint, :vehicle_upgrades, :model_upgrades, :vehicle_modules, :model_modules,
-          model: [:manufacturer]
-        )
-
-        scope = scope.where(loaner: loaner_included?)
+        scope = @fleet.vehicles.where(loaner: loaner_included?)
 
         scope = scope.where(user_id: for_members) if for_members.present?
 
-        scope = scope.includes(:model).where(models: {price: price_range}) if price_range.present?
+        scope = scope.joins(:model).where(models: {price: price_range}) if price_range.present?
 
-        scope = scope.includes(:model).where(models: {pledge_price: pledge_price_range}) if pledge_price_range.present?
+        scope = scope.joins(:model).where(models: {pledge_price: pledge_price_range}) if pledge_price_range.present?
 
         count_params = vehicle_query_params.except("sorts", "s")
         @q = scope.ransack(count_params)
 
-        @model_counts = @q.result.includes(:model).joins(:model).group("models.slug").count
+        # No `includes`: this returns a grouped count, so no vehicle is ever
+        # instantiated and nothing reads an association off one. Eager loading
+        # them only added six outer joins to every call, filtered or not.
+        #
+        # The count stays DISTINCT, though nothing `vehicle_query_params`
+        # permits joins a `has_many` today. Ransack joins what a filter names,
+        # and one naming a `has_many` returns a vehicle once per matching row --
+        # 106 instead of 49 on a fleet I tried. Dropping DISTINCT would make
+        # these numbers correct only for as long as that permit list stays as
+        # it is.
+        @model_counts = @q.result.joins(:model).group("models.slug").distinct.count(:id)
       end
 
       def vehicles_by_model

--- a/app/controllers/api/v1/public/fleet_stats_controller.rb
+++ b/app/controllers/api/v1/public/fleet_stats_controller.rb
@@ -15,12 +15,20 @@ module Api
         end
 
         def model_counts
-          scope = @fleet.vehicles.includes(:model_paint, :vehicle_upgrades, :model_upgrades, :vehicle_modules, :model_modules, model: [:manufacturer])
-
           count_params = vehicle_query_params.except("sorts", "s")
-          @q = scope.ransack(count_params)
+          @q = @fleet.vehicles.ransack(count_params)
 
-          @model_counts = @q.result.includes(:model).joins(:model).group("models.slug").count
+          # No `includes`: this returns a grouped count, so no vehicle is ever
+          # instantiated and nothing reads an association off one. Eager loading
+          # them only added six outer joins to every call, filtered or not.
+          #
+          # The count stays DISTINCT, though nothing `vehicle_query_params`
+          # permits joins a `has_many` today. Ransack joins what a filter names,
+          # and one naming a `has_many` returns a vehicle once per matching row
+          # -- 106 instead of 49 on a fleet I tried. Dropping DISTINCT would
+          # make these numbers correct only for as long as that permit list
+          # stays as it is.
+          @model_counts = @q.result.joins(:model).group("models.slug").distinct.count(:id)
         end
 
         def members


### PR DESCRIPTION
Two of the queries from PgHero's slow-query page, both doing work in Ruby the database could already do. No behaviour change — results verified equal to the old code against a production dump.

## `most_viewed_pages`

Loaded every `$view` event of the last month, with its whole `properties` document, grouped them in Ruby, and kept ten.

```ruby
Ahoy::Event.one_month.where(name: "$view").to_a.group_by { |e| e.properties["page"] }
```

Now a grouped count with `LIMIT 10`. On a production dump holding 8,059 events in the window:

| | |
|---|---|
| before | 73.1 ms |
| after | **8.4 ms** |

Live the window holds 54,258 events, so the gap there is wider — PgHero measures 205 ms across 44,269 calls, 152 min total.

## `model_counts` (both the authenticated and the public controller)

Eager-loaded six associations in front of a grouped count. No vehicle is ever instantiated and nothing reads an association off one, so the `includes` only added six outer joins to every call, filtered or not.

Measured on a fleet of 8,711 vehicles:

| | before | after |
|---|---|---|
| public (no loaner filter) | 58.3 ms | **50.3 ms** |
| authenticated (`loaner: false`) | 64.0 ms | **60.4 ms** |

## Why that second win is small, and where the real one is

Worth calling out rather than burying: this query spends most of its time in a **parallel sequential scan over all 1.57M vehicles** instead of driving from `index_fleet_vehicles_on_fleet_id_and_vehicle_id`. The planner costs the index plan higher than the scan (37,404 vs 33,377) and is wrong about it — forcing the index plan gives **14 ms**.

That is `random_page_cost = 4`, the PostgreSQL default for spinning disks, still set on the server. Same query, same fleet, with `random_page_cost = 1.1`: 14 ms and no sequential scan. That is a server configuration change affecting every query, so it does not belong in this PR — but it is a bigger lever than anything in it.

## The DISTINCT stays

Deliberate, and the one thing worth a reviewer's eye. Nothing `vehicle_query_params` permits joins a `has_many` today, so the fan-out is not reachable through the API. But a filter that named one returns a vehicle once per matching row — I measured **106 instead of 49** on a real fleet with `model_modules_name_cont`. Dropping DISTINCT would make these counts correct only for as long as that permit list stays as it is. It is not the cost driver either way.

## Verification

Compared old and new results on a production dump across every filter Ransack accepts on the scope — including the `has_many` ones the API does not expose — plus the unfiltered case. All equal.

The three existing integration tests pass (10 tests, 24 assertions): `stats_most_viewed_pages_test`, `fleets_stats_model_counts_test`, `public_fleets_stats_model_counts_test`.

## Not in this PR

The rest of the slow-query list needs decisions rather than a rewrite: the admin dashboard polls every 30 s with no caching behind it anywhere, Devise `:trackable` writes to `users` 433,159 times, and the public wishlist counts are honest scans over 1.57M rows that only caching fixes.

🤖
