### PR TITLE
docs: plan the build compare, and measure it first

### DIFF
--- a/docs/exec-plans/sc-data-build-compare.md
+++ b/docs/exec-plans/sc-data-build-compare.md
@@ -1,0 +1,111 @@
+# SC Data: comparing two builds
+
+Item 6 of [sc-data-live-and-ptu.md](sc-data-live-and-ptu.md), written out — and
+narrower than that item implies, because a good part of it already exists.
+
+## Goal
+
+Answer "what appeared, changed and vanished between two builds", in two shapes:
+
+- **a patch** — build N against N-1 in the same environment
+- **a preview** — live against ptu, which is the question a PTU cycle raises
+
+## What already exists, and must not be rebuilt
+
+The whole vertical, for **models**, within one environment:
+
+- `ModelBuildChange` records a diff per (model, field), keyed on
+  `from_version` / `to_version`, and **replaces** rather than appends — a
+  re-parse of the same export can change values without a version bump, and the
+  second parse is the one to keep
+- `ModelsLoader` calls `ModelBuildChange.record!(build)` as it loads
+- `GET /models/{slug}/changes` serves it, with its own schema components
+- `Api::V1::Stats::BaseController` reads it
+
+So the mechanism is proven. What is missing is a different axis and a different
+altitude, not four more copies of it.
+
+## What is missing, in the order worth doing it
+
+### 1. The cross-environment axis
+
+`ModelBuildChange.for_build(environment, version)` and its `previous_build` are
+**same-environment only**: they answer "what did this patch change", never "what
+does ptu have that live does not". That second question is the whole point of a
+preview, and nothing answers it today.
+
+**It needs no new table.** Both builds are present at the same time — every
+catalogue retains `BUILDS_RETAINED = 3` per environment — so a live-against-ptu
+diff is a join over two `(environment, version)` pairs, computed on demand.
+
+### 2. A build-level overview
+
+Changes are per model today: you can ask what happened to the Gladius, not what
+happened in `4.10.1-ptu.12578875`. The overview is the page somebody actually
+opens when a build lands.
+
+### 3. The other catalogues
+
+Component, equipment, commodity and model module have no recorder. Worth doing
+after (1) and (2), because those two are what make the retained builds readable
+at all.
+
+## The decision the numbers settle: recorded or computed
+
+Measured on the real data — live `4.9.0-live.12344265` against
+`4.10.0-live.12519617`, components, 7,251 present in both:
+
+| | |
+| --- | --- |
+| appeared | **23** |
+| vanished | **61** |
+| `name` changed | **10** |
+| `type_data` changed | 420 |
+| `size`, `grade`, `durability` changed | **0** |
+
+Two things follow.
+
+**Volume is not the deciding factor.** A real patch changes a few hundred fields
+across seven thousand rows, and the on-demand join that produced the table above
+returns instantly. Recording and computing are both cheap, so the choice is
+about which questions each can answer:
+
+- **computed** works between any two builds still retained, which covers
+  live-against-ptu completely, and needs no schema
+- **recorded** survives pruning, so it is the only way to see further back than
+  three builds
+
+So: compute the preview, record the history. That is why (1) comes first — it is
+the half that needs nothing built underneath it.
+
+**And the useful diff is not "which fields differ".** 420 of the 430 field
+changes were `type_data`, a serialized blob whose diff reads as "something
+inside this changed" and tells a reader nothing. A field-level summary would
+bury the 10 renames under it. Either unpack that blob or leave it out of the
+summary — `ModelBuildChange` already stores `old_value`/`new_value` as text and
+would happily record 420 rows of noise per patch.
+
+The three numbers a person wants are **appeared, vanished, renamed**.
+
+## Constraints
+
+**It cannot reuse `ScData::Source.available`.** That list deliberately hides
+every source behind the default — which is exactly what a comparison needs to
+see. This wants its own list, built from the build rows that exist rather than
+from the config.
+
+**It needs a second selection point.** "Compare against what" is a different
+control from "which build am I reading", and the one-of-N switch in the header
+is the wrong shape for it.
+
+**A retired row is not a vanished one.** A catalogue row the export dropped
+keeps its row and loses its build row, so "vanished" means "has no build row for
+the newer build" — not "was deleted". The same distinction the loadout work
+settled for slots.
+
+## Verification
+
+The measurement above is the fixture: a compare of live `4.9.0-live.12344265`
+against `4.10.0-live.12519617` has to report 23 appeared, 61 vanished and 10
+renamed for components. Those numbers come from the production dump of
+2026-09-06 and are stable as long as both builds are retained.


### PR DESCRIPTION
Item 6 of `docs/exec-plans/sc-data-live-and-ptu.md`, planned — and it turned out
narrower than that item implies, in a useful way.

## A good part of it already exists

`ModelBuildChange` records a per-field diff for **models**, keyed on
`from_version`/`to_version`; `ModelsLoader` writes it as it loads;
`GET /models/{slug}/changes` serves it with its own schema components; and
`Api::V1::Stats::BaseController` reads it. It even gets the subtle part right —
it **replaces** rather than appends, because a re-parse of the same export can
change values without a version bump.

So the mechanism is proven. What is missing is a different **axis** and a
different **altitude**, not four more copies of it:

1. **The cross-environment axis.** `for_build` and `previous_build` are
   same-environment only. They answer "what did this patch change" and never
   "what does ptu have that live does not" — which is the whole point of a
   preview.
2. **A build-level overview.** Changes are per model today; nobody opens a ship
   page to ask what a patch did.
3. **The other four catalogues**, after those two.

## Measured before deciding

Live `4.9.0-live.12344265` against `4.10.0-live.12519617`, components, 7,251
present in both builds:

| | |
| --- | --- |
| appeared | **23** |
| vanished | **61** |
| `name` changed | **10** |
| `type_data` changed | 420 |
| `size`, `grade`, `durability` changed | **0** |

Two findings come out of that table.

**Volume decides nothing.** A real patch moves a few hundred fields across seven
thousand rows, and the join that produced this returns instantly — recording and
computing are both cheap. So the split is by question, not by cost: **compute
the preview** (both builds are retained at once, so it needs no schema at all)
and **record only the history** that has to outlive three builds. That is why
the cross-environment axis is first — it is the half with nothing to build
underneath it.

**The useful diff is not "which fields differ".** 420 of the 430 field changes
were `type_data`, a serialized blob whose diff amounts to "something inside this
changed". A field-level summary would bury the 10 renames under it, and
`ModelBuildChange` would happily record 420 rows of noise per patch. The three
numbers a person wants are **appeared, vanished, renamed**.

## Constraints recorded

- It cannot reuse `ScData::Source.available` — that list deliberately hides
  everything behind the default, which is exactly what a comparison needs to
  see.
- "Compare against what" is a second selection point, and the one-of-N switch in
  the header is the wrong control for it.
- **A retired row is not a vanished one.** A row the export dropped keeps its
  row and loses its build row, so "vanished" means "has no build row for the
  newer build" — the same distinction the loadout work settled for slots.

## Why this rather than the other open items

`sc_data_unlisted_models` is **empty**, so the bulk action would be a triage tool
for a queue with nothing in it — worth building when a patch fills it, not
before. And dropping the dual-held columns removes the fallback that makes a bad
load survivable, while the first *production* PTU load has not happened yet.

Docs only. The measurement is also the fixture: a compare of those two builds has
to report 23 / 61 / 10.

🤖
