### PR TITLE
fix(admin): open the mounted engines in a new tab

### DIFF
--- a/app/frontend/admin/components/Dashboard/AttentionTile.test.ts
+++ b/app/frontend/admin/components/Dashboard/AttentionTile.test.ts
@@ -1,0 +1,42 @@
+import { mountWithDefaults } from "@/shared/utils/TestUtils";
+import { describe, expect, it } from "vitest";
+import { createRouter, createWebHashHistory } from "vue-router";
+import Component from "./AttentionTile.vue";
+
+const Blank = { template: "<div />" };
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [{ path: "/workers/", name: "workers", component: Blank }],
+});
+
+const mountTile = async (props: Record<string, unknown>) => {
+  await router.push("/");
+  await router.isReady();
+
+  return mountWithDefaults<typeof Component>(Component, {
+    props: { count: 3, label: "Dead jobs", icon: "fa-skull", ...props },
+    plugins: [router],
+  });
+};
+
+describe("DashboardAttentionTile", () => {
+  it("routes in place when given a route", async () => {
+    const wrapper = await mountTile({ to: { name: "workers" } });
+
+    const link = wrapper.find("a");
+
+    expect(link.attributes("href")).toBe("#/workers/");
+    expect(link.attributes("target")).toBeUndefined();
+  });
+
+  it("opens an engine mounted outside the app in a new tab", async () => {
+    const wrapper = await mountTile({ href: "/admin/workers" });
+
+    const link = wrapper.find("a");
+
+    expect(link.attributes("href")).toBe("/admin/workers");
+    expect(link.attributes("target")).toBe("_blank");
+    expect(link.attributes("rel")).toBe("noopener");
+  });
+});

--- a/app/frontend/admin/components/Dashboard/AttentionTile.vue
+++ b/app/frontend/admin/components/Dashboard/AttentionTile.vue
@@ -9,19 +9,37 @@ import Panel from "@/shared/components/base/Panel/index.vue";
 import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import { PanelVariantsEnum } from "@/shared/components/base/Panel/types";
 import NumberFlow from "@number-flow/vue";
-import { type RouteLocationRaw } from "vue-router";
+import { RouterLink, type RouteLocationRaw } from "vue-router";
 
 type Props = {
   count: number;
   label: string;
   icon: string;
-  to: RouteLocationRaw;
+  to?: RouteLocationRaw;
+  href?: string;
   severity?: "warning" | "error";
 };
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
+  to: undefined,
+  href: undefined,
   severity: "warning",
 });
+
+/*
+ * A queue living outside the SPA - Sidekiq, PgHero - is an `href` rather than a
+ * route, and opens in its own tab: it is a tool you keep open beside the admin,
+ * not a page you navigate to and come back from.
+ *
+ * One binding rather than a `:href` and a `:to` side by side: a fallthrough
+ * `href` of `undefined` overrides the one RouterLink resolves for itself, so the
+ * internal tile rendered an anchor with no destination at all.
+ */
+const link = computed(() =>
+  props.href
+    ? { href: props.href, target: "_blank", rel: "noopener" }
+    : { to: props.to },
+);
 </script>
 
 <template>
@@ -31,8 +49,9 @@ withDefaults(defineProps<Props>(), {
     list it counts. The rail is coloured by severity rather than the theme accent,
     so a full band reads as a priority order and not as decoration.
   -->
-  <router-link
-    :to="to"
+  <component
+    :is="href ? 'a' : RouterLink"
+    v-bind="link"
     class="attention-tile"
     :class="`attention-tile--${severity}`"
     :data-test="`attention-tile-${severity}`"
@@ -48,7 +67,7 @@ withDefaults(defineProps<Props>(), {
         </div>
       </PanelBody>
     </Panel>
-  </router-link>
+  </component>
 </template>
 
 <style lang="scss" scoped>

--- a/app/frontend/admin/pages/index.vue
+++ b/app/frontend/admin/pages/index.vue
@@ -23,6 +23,8 @@ import {
   useRegistrationsPerMonth as useRegistrationsPerMonthQuery,
 } from "@/services/fyAdminApi";
 import { useSessionStore } from "@/admin/stores/session";
+import { engineUrls } from "@/admin/utils/EngineUrls";
+import { type RouteLocationRaw } from "vue-router";
 
 const { t, lUtc: l, timeDistance } = useI18n();
 
@@ -48,59 +50,70 @@ const { data: dashboard } = useDashboardQuery({
  * A figure the admin has no privilege for is absent rather than zero, which is
  * why a missing key is never treated as an "all clear" worth showing.
  */
-const attentionTiles = computed(() =>
-  [
+type AttentionTile = {
+  key: string;
+  count?: number;
+  icon: string;
+  to?: RouteLocationRaw;
+  href?: string;
+  severity: "warning" | "error";
+};
+
+const attentionTiles = computed(() => {
+  const tiles: AttentionTile[] = [
     {
       key: "unlistedModels",
       count: dashboard.value?.unlistedModelsCount,
       icon: "fa-duotone fa-rocket fa-4x",
       to: { name: "admin-unlisted-models" },
-      severity: "warning" as const,
+      severity: "warning",
     },
     {
       key: "failedImports",
       count: dashboard.value?.failedImportsCount,
       icon: "fa-duotone fa-file-import fa-4x",
       to: { name: "imports" },
-      severity: "error" as const,
+      severity: "error",
     },
     {
       key: "stuckImports",
       count: dashboard.value?.stuckImportsCount,
       icon: "fa-duotone fa-hourglass-half fa-4x",
       to: { name: "imports" },
-      severity: "warning" as const,
+      severity: "warning",
     },
     {
       key: "deadJobs",
       count: dashboard.value?.jobsDeadCount,
       icon: "fa-duotone fa-skull fa-4x",
-      to: { name: "workers" },
-      severity: "error" as const,
+      href: engineUrls.workers,
+      severity: "error",
     },
     {
       key: "retryJobs",
       count: dashboard.value?.jobsRetryCount,
       icon: "fa-duotone fa-arrow-rotate-right fa-4x",
-      to: { name: "workers" },
-      severity: "warning" as const,
+      href: engineUrls.workers,
+      severity: "warning",
     },
     {
       key: "rsiRequestLogs",
       count: dashboard.value?.unresolvedRsiRequestLogsCount,
       icon: "fa-duotone fa-plug-circle-xmark fa-4x",
       to: { name: "rsi-api-status" },
-      severity: "error" as const,
+      severity: "error",
     },
     {
       key: "notifications",
       count: dashboard.value?.actionableNotificationsCount,
       icon: "fa-duotone fa-bell-exclamation fa-4x",
       to: { name: "admin-notifications" },
-      severity: "warning" as const,
+      severity: "warning",
     },
-  ].filter((tile) => (tile.count ?? 0) > 0),
-);
+  ];
+
+  return tiles.filter((tile) => (tile.count ?? 0) > 0);
+});
 
 const percentDelta = (current?: number, before?: number) => {
   if (current === undefined || !before) {
@@ -186,6 +199,7 @@ const { data: registrationsPerMonth, ...registrationsPerMonthStatus } =
           :label="t(`labels.admin.dashboard.attention.${tile.key}`)"
           :icon="tile.icon"
           :to="tile.to"
+          :href="tile.href"
           :severity="tile.severity"
         />
       </div>

--- a/app/frontend/admin/pages/maintenance/pghero.vue
+++ b/app/frontend/admin/pages/maintenance/pghero.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
-const prefix = window.ON_SUBDOMAIN ? "" : "/admin";
-window.location.href = `${prefix}/pghero`;
+import { engineUrls } from "@/admin/utils/EngineUrls";
+
+window.location.href = engineUrls.pghero;
 </script>

--- a/app/frontend/admin/pages/maintenance/routes.ts
+++ b/app/frontend/admin/pages/maintenance/routes.ts
@@ -1,6 +1,5 @@
 import type { RouteRecordRaw } from "vue-router";
-
-const prefix = window.ON_SUBDOMAIN ? "" : "/admin";
+import { engineUrls } from "@/admin/utils/EngineUrls";
 
 /*
  * Top-level, not nested. These were children of a `/maintenance` route whose
@@ -63,7 +62,7 @@ export const routes: RouteRecordRaw[] = [
       icon: "fa-duotone fa-list-timeline",
       needsAuthentication: true,
       access: ["workers"],
-      href: `${prefix}/workers`,
+      href: engineUrls.workers,
     },
   },
   {
@@ -75,7 +74,7 @@ export const routes: RouteRecordRaw[] = [
       icon: "fa-duotone fa-database",
       needsAuthentication: true,
       access: ["pghero"],
-      href: `${prefix}/pghero`,
+      href: engineUrls.pghero,
     },
   },
   {
@@ -87,7 +86,7 @@ export const routes: RouteRecordRaw[] = [
       icon: "fa-duotone fa-clipboard-list-check",
       needsAuthentication: true,
       access: ["maintenance"],
-      href: `${prefix}/maintenance_tasks`,
+      href: engineUrls.maintenanceTasks,
     },
   },
   {

--- a/app/frontend/admin/pages/maintenance/tasks.vue
+++ b/app/frontend/admin/pages/maintenance/tasks.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
-const prefix = window.ON_SUBDOMAIN ? "" : "/admin";
-window.location.href = `${prefix}/maintenance_tasks`;
+import { engineUrls } from "@/admin/utils/EngineUrls";
+
+window.location.href = engineUrls.maintenanceTasks;
 </script>

--- a/app/frontend/admin/pages/maintenance/workers.vue
+++ b/app/frontend/admin/pages/maintenance/workers.vue
@@ -1,4 +1,5 @@
 <script lang="ts" setup>
-const prefix = window.ON_SUBDOMAIN ? "" : "/admin";
-window.location.href = `${prefix}/workers`;
+import { engineUrls } from "@/admin/utils/EngineUrls";
+
+window.location.href = engineUrls.workers;
 </script>

--- a/app/frontend/admin/utils/EngineUrls.ts
+++ b/app/frontend/admin/utils/EngineUrls.ts
@@ -1,0 +1,12 @@
+/*
+ * Rails engines mounted beside the admin app, not routes of it. They live under
+ * `/admin` only when the admin is served from a path rather than its own
+ * subdomain, which is why the prefix is read from the window and not hardcoded.
+ */
+const prefix = window.ON_SUBDOMAIN ? "" : "/admin";
+
+export const engineUrls = {
+  workers: `${prefix}/workers`,
+  pghero: `${prefix}/pghero`,
+  maintenanceTasks: `${prefix}/maintenance_tasks`,
+};

--- a/app/frontend/shared/components/AppNavigation/Items/index.test.ts
+++ b/app/frontend/shared/components/AppNavigation/Items/index.test.ts
@@ -22,6 +22,12 @@ const routes = [
       },
     ],
   },
+  {
+    path: "/pghero/",
+    name: "pghero",
+    component: Blank,
+    meta: { title: "pghero", href: "/admin/pghero" },
+  },
 ] as RouteRecordRaw[];
 
 const currentRoute = {
@@ -49,6 +55,15 @@ describe("AppNavigationItems", () => {
     const wrapper = await mountItems({});
 
     expect(wrapper.find(".nav-item__sub-menu").exists()).toBe(true);
+  });
+
+  it("opens a route with an external href in a new tab", async () => {
+    const wrapper = await mountItems({});
+
+    const link = wrapper.find('[data-test="nav-pghero"] a');
+
+    expect(link.attributes("href")).toBe("/admin/pghero");
+    expect(link.attributes("target")).toBe("_blank");
   });
 
   it("links straight to the first child when submenus are hidden", async () => {

--- a/app/frontend/shared/components/AppNavigation/Items/index.vue
+++ b/app/frontend/shared/components/AppNavigation/Items/index.vue
@@ -128,10 +128,15 @@ const hasSubmenu = (route: RouteRecordRaw) => {
   return childRoutes.length > 1;
 };
 
+/*
+ * An external `href` renders an item with no `to` for the router to derive a
+ * key from, so the name is passed explicitly - otherwise every such item shares
+ * a `data-test` of `nav-nav-item`.
+ */
 const menuKey = (route: RouteRecordRaw) => {
   return route.children
     ? `admin-menu-${route.children[0].name as string}`
-    : undefined;
+    : (route.name as string | undefined);
 };
 
 const routeTo = (route: RouteRecordRaw, nav: NavTypes = "main") => {
@@ -153,7 +158,8 @@ const routeTo = (route: RouteRecordRaw, nav: NavTypes = "main") => {
   <NavItem
     v-for="route in filteredRoutes"
     :key="route.name"
-    :to="routeTo(route)"
+    :to="route.meta?.href ? undefined : routeTo(route)"
+    :href="route.meta?.href"
     :label="t(`nav.${route.meta?.title}`)"
     :submenu-active="isSubmenuActive(route)"
     :active="isActive(route)"
@@ -166,6 +172,7 @@ const routeTo = (route: RouteRecordRaw, nav: NavTypes = "main") => {
         :key="child.name"
         :to="child.meta?.href ? undefined : { name: child.name }"
         :href="child.meta?.href"
+        :menu-key="String(child.name)"
         :label="t(`nav.${child.meta?.title}`)"
         :icon="child.meta?.icon"
         :active="isActive(child)"


### PR DESCRIPTION
Sidekiq, PgHero and Maintenance Tasks are Rails engines mounted beside the admin app, not pages of it. Opening one replaced the admin in the current tab, so getting back meant a full reload of the SPA. All three now open in a new tab.

### The nav

Each of the three routes already carries a `meta.href`, and `NavItem` already renders an `href` as `<a target="_blank" rel="noopener">` — but only the submenu branch of `AppNavigationItems` ever passed it on. Once the maintenance routes were flattened to top level they rendered as router links into the redirect shim pages, each of which sets `window.location.href` on the current tab.

Childless routes now get their name as a menu key as well: an item with an `href` has no `to` for the router to derive one from, so all three would otherwise have shared a `data-test` of `nav-nav-item`. For routes that still go through `to` the value is unchanged, so no `data-test` moves.

### The dashboard tiles

The "dead jobs" and "retry jobs" attention tiles routed to the `workers` shim, so they still left the admin in the current tab. `AttentionTile` takes an `href` beside its `to` now and swaps its root between `RouterLink` and a plain anchor.

Its destination is one `v-bind` object rather than a `:to` and an `:href` side by side: a fallthrough `href` of `undefined` overrides the href `RouterLink` resolves for itself, which left the routed tiles rendering an anchor with no destination at all. The test catches it.

### Along the way

`window.ON_SUBDOMAIN ? "" : "/admin"` was copy-pasted in four places and the dashboard was about to be a fifth, so the three engine URLs moved into `admin/utils/EngineUrls.ts`. The route meta and the redirect shims import them from there.

The shims stay — they still handle someone hitting `/admin/pghero/` directly.

### Verification

- `vitest` over `AppNavigation/` and `Dashboard/`: 11 pass, including a new `AttentionTile.test.ts` covering both branches (routed tile keeps its resolved href and no `target`; external tile gets `_blank` and `noopener`) and a new nav test for the `href` item.
- `npm run lint:ts` and eslint over `app/frontend/admin` and `AppNavigation`: clean.

Verified at the component level; not clicked through in a running admin. 🤖
