### PR TITLE
perf(stats): stop recomputing slow aggregates on every request

### DIFF
--- a/app/controllers/admin/api/v1/dashboard_controller.rb
+++ b/app/controllers/admin/api/v1/dashboard_controller.rb
@@ -18,6 +18,11 @@ module Admin
         # what needs attention now; /imports/ holds the rest.
         RECENT_FAILURE_WINDOW = 24.hours
 
+        # Only the traffic figures are cached. The attention tiles above them --
+        # failed imports, stuck imports, unlisted models -- are cheap counts on
+        # indexed columns, and they are the ones an admin is watching for.
+        TRAFFIC_TTL = 5.minutes
+
         def show
           authorize! with: ::Admin::DashboardPolicy
 
@@ -92,17 +97,30 @@ module Admin
 
           @dashboard[:online_count] = online_count
 
+          # The page polls every thirty seconds and these four scan `ahoy_visits`
+          # and `users` for a window measured in days. The date is in the key so
+          # they roll over at midnight rather than at whatever the entry's five
+          # minutes happen to be.
+          @dashboard.merge!(
+            Rails.cache.fetch("admin/dashboard/traffic/#{Time.zone.today}", expires_in: TRAFFIC_TTL) do
+              traffic_figures
+            end
+          )
+        end
+
+        private def traffic_figures
           today = Time.zone.today
 
-          @dashboard[:visits_today] = visits_on(today)
-          # The same weekday, not yesterday: traffic has a weekly shape, and a
-          # Monday compared against a Sunday reads as a spike every week.
-          @dashboard[:visits_same_weekday_last_week] = visits_on(today - 1.week)
-
-          @dashboard[:signups_this_week] = User.where(created_at: today.beginning_of_week..).count
-          @dashboard[:signups_last_week] = User.where(
-            created_at: (today - 1.week).beginning_of_week...today.beginning_of_week
-          ).count
+          {
+            visits_today: visits_on(today),
+            # The same weekday, not yesterday: traffic has a weekly shape, and a
+            # Monday compared against a Sunday reads as a spike every week.
+            visits_same_weekday_last_week: visits_on(today - 1.week),
+            signups_this_week: User.where(created_at: today.beginning_of_week..).count,
+            signups_last_week: User.where(
+              created_at: (today - 1.week).beginning_of_week...today.beginning_of_week
+            ).count
+          }
         end
 
         private def visits_on(date)

--- a/app/controllers/admin/api/v1/stats_controller.rb
+++ b/app/controllers/admin/api/v1/stats_controller.rb
@@ -10,16 +10,24 @@ module Admin
         # `properties` document; there is no column for it.
         VIEWED_PAGE = Arel.sql("ahoy_events.properties->>'page'")
 
+        # The dashboard refetches on every window focus, and these are counts
+        # over whole tables. None of them moves enough in five minutes to be
+        # worth counting again; `online_count` is deliberately not among them.
+        TOTALS_TTL = 5.minutes
+
         def quick_stats
           authorize! with: ::Admin::StatsPolicy
 
-          @quick_stats = {
-            online_count:,
-            ships_count_year: Model.year(Time.current.year).count,
-            ships_count_total: Model.count,
-            users_count_total: User.count,
-            fleets_count_total: Fleet.count
-          }
+          totals = Rails.cache.fetch("admin/stats/quick_stats", expires_in: TOTALS_TTL) do
+            {
+              ships_count_year: Model.year(Time.current.year).count,
+              ships_count_total: Model.count,
+              users_count_total: User.count,
+              fleets_count_total: Fleet.count
+            }
+          end
+
+          @quick_stats = {online_count:}.merge(totals)
         end
 
         def most_viewed_pages
@@ -47,13 +55,20 @@ module Admin
         def visits_per_day
           authorize! with: ::Admin::StatsPolicy
 
-          visits_per_day = Ahoy::Visit.without_users(tracking_blocklist).one_month
-            .group_by_day(:started_at).count
-            .map do |created_at, count|
+          # Read from the daily rollup `MetricsJob` writes, rather than
+          # aggregating a month of `ahoy_visits` on every request.
+          #
+          # The window is whole days now. The query this replaces began at a
+          # timestamp one month back, so its leftmost bar covered only part of
+          # that day and always read low -- 1,846 against the day's real 4,848
+          # on the database I checked.
+          visits_per_day = Rollup.where(time: 1.month.ago.to_date...Time.zone.today)
+            .series("Visits", interval: :day)
+            .map do |started_at, count|
             {
-              label: I18n.l(created_at.to_date, format: :day_month_short),
-              count:,
-              tooltip: I18n.l(created_at.to_date, format: :day_month)
+              label: I18n.l(started_at.to_date, format: :day_month_short),
+              count: count.to_i,
+              tooltip: I18n.l(started_at.to_date, format: :day_month)
             }
           end
 

--- a/app/controllers/api/v1/stats/base_controller.rb
+++ b/app/controllers/api/v1/stats/base_controller.rb
@@ -12,9 +12,21 @@ module Api
         # does not empty the chart, short enough that it still reads as now.
         TRENDING_WINDOW = 30.days
 
+        QUICK_STATS_TTL = 5.minutes
+
         before_action :authenticate_user!, only: []
 
         def quick_stats
+          # Twelve figures about the whole catalogue and every hangar in it, on
+          # a public page, recomputed per visitor. Two of them count their way
+          # through 1.57M vehicles. None of it is per-visitor, and none of it
+          # changes meaningfully inside five minutes.
+          @quick_stats = Rails.cache.fetch("stats/quick_stats", expires_in: QUICK_STATS_TTL) do
+            build_quick_stats
+          end
+        end
+
+        private def build_quick_stats
           models = Model.visible.active
           total = models.count
           flight_ready = models.where(production_status: "flight-ready").count
@@ -27,7 +39,7 @@ module Api
             time: Time.current.beginning_of_month
           ).first
 
-          @quick_stats = {
+          {
             ships_count_year: models.year(Time.current.year).count,
             ships_count_total: total,
             manufacturer_count: Manufacturer.with_model.count,

--- a/app/controllers/concerns/tracking_stats_concern.rb
+++ b/app/controllers/concerns/tracking_stats_concern.rb
@@ -3,12 +3,19 @@
 module TrackingStatsConcern
   ONLINE_WINDOW = 15.minutes
 
+  # Short, because this is the one figure on the dashboard that is meant to read
+  # as now. It still collapses the 30-second poll, and the several admins who
+  # may have the page open, down to one pair of queries a minute.
+  ONLINE_COUNT_TTL = 1.minute
+
   # Signed-in clients are counted through `users.last_active_at`, which every API
   # client updates, while Ahoy only sees the web frontend. Anonymous visits still
   # have to come from Ahoy, and they cannot overlap with the user count because a
   # visit with a `user_id` is excluded.
   private def online_count
-    active_users_count + anonymous_visits_count
+    Rails.cache.fetch("stats/online_count", expires_in: ONLINE_COUNT_TTL) do
+      active_users_count + anonymous_visits_count
+    end
   end
 
   private def active_users_count

--- a/app/jobs/metrics_job.rb
+++ b/app/jobs/metrics_job.rb
@@ -30,12 +30,22 @@ class MetricsJob < ApplicationJob
     Vehicle.visible.wanted.where(loaner: false).rollup("Vehicle Wish", interval: "month")
 
     track_ship_views
+    track_visits
     track_wishlist_by_model
     track_ship_of_the_month
     track_api_usage
   end
 
   private
+
+  # `Cleanup::VisitsJob` writes the monthly total under the same name, but it
+  # runs once a month, which no per-day chart can be built on. The day interval
+  # is the only safe one here for the reason `track_ship_views` gives: a visit
+  # is purged after a month, and a day is always complete before that happens.
+  def track_visits
+    Ahoy::Visit.without_users(User.where(tracking: false).pluck(:id))
+      .rollup("Visits", interval: "day", column: :started_at)
+  end
 
   # Ahoy keeps visits for a month (`Cleanup::VisitsJob`) and rolls up nothing but
   # a monthly total, so per-ship views are gone before anything can read them.

--- a/test/integration/api/v1/stats_show_test.rb
+++ b/test/integration/api/v1/stats_show_test.rb
@@ -44,4 +44,31 @@ class Api::V1::StatsShowTest < ActionDispatch::IntegrationTest
       assert_equal 100.0, parsed_body["paintedVehiclesPercent"]
     end
   end
+
+  # The test environment caches into a null store, so every other example here
+  # recomputes and none of them would notice the cache being dropped. This one
+  # puts a real store in place and asks whether the second request used it.
+  test "GET /stats/quick-stats serves a repeat request from the cache" do
+    model = create(:model)
+    create(:vehicle, model:, wanted: false, loaner: false)
+
+    with_cache_store(ActiveSupport::Cache::MemoryStore.new) do
+      cached = nil
+      assert_api_response(:get, 200) { cached = parsed_body["vehiclesCount"] }
+
+      create(:vehicle, model:, wanted: false, loaner: false)
+
+      assert_api_response(:get, 200) do
+        assert_equal cached, parsed_body["vehiclesCount"]
+      end
+    end
+  end
+
+  private def with_cache_store(store)
+    previous = Rails.cache
+    Rails.cache = store
+    yield
+  ensure
+    Rails.cache = previous
+  end
 end

--- a/test/jobs/metrics_job_test.rb
+++ b/test/jobs/metrics_job_test.rb
@@ -156,6 +156,38 @@ class MetricsJobTest < ActiveJob::TestCase
     assert_operator Rollup.where(name: "Vehicle Wish", interval: "month").count, :>, 0
   end
 
+  # `Cleanup::VisitsJob` writes the same name at a monthly interval and runs
+  # once a month. The per-day chart reads this one.
+  test "#perform rolls up visits per day" do
+    2.times { visit_on(2.days.ago) }
+
+    MetricsJob.new.perform
+
+    assert_equal 2, visits_rolled_up_on(2.days.ago)
+  end
+
+  test "#perform leaves a visit by a user who objects to tracking out of the daily rollup" do
+    visit_on(2.days.ago, user: create(:user, tracking: false))
+    visit_on(2.days.ago)
+
+    MetricsJob.new.perform
+
+    assert_equal 1, visits_rolled_up_on(2.days.ago)
+  end
+
+  private def visit_on(time, user: nil)
+    Ahoy::Visit.create!(
+      started_at: time,
+      user:,
+      visit_token: SecureRandom.uuid,
+      visitor_token: SecureRandom.uuid
+    )
+  end
+
+  private def visits_rolled_up_on(time)
+    Rollup.where(name: "Visits", interval: "day", time: time.to_date).sum(:value)
+  end
+
   private def wishlist_additions(model)
     Rollup.where(
       name: MetricsJob::ROLLUP_WISHLIST_BY_MODEL,


### PR DESCRIPTION
The admin dashboard refetches every thirty seconds; the stats page refetches on every window focus. Behind both, and behind the public stats page, nothing was cached — `Rails.cache` appeared exactly once in the whole application (`exchange_rate_fetcher.rb`).

That is where PgHero's call counts come from: 49,291 × `SELECT COUNT(*) FROM users`, 40,155 visits-per-day aggregations, 5,794 passes over the public figures at 220 ms each.

## `visits_per_day` reads a rollup now

| | |
|---|---|
| aggregating a month of `ahoy_visits` per request | 28.2 ms |
| reading the daily rollup | **0.67 ms** |

`MetricsJob` writes it, next to the ship views it already rolls up daily and for the same reason its comment gives: `Cleanup::VisitsJob` writes the same name at a *monthly* interval and runs once a month, which no per-day chart can be built on.

**One visible change.** The query being replaced began at a timestamp one month back, so its leftmost bar covered only part of that day and always read low — **1,846 against that day's real 4,848** on the database I checked. The rollup window is whole days, so that bar is now the whole day. Verified day by day against the live query: same 31 keys, same values, that boundary day the only difference.

## Five-minute entries for the rest

- admin totals (`Model.count`, `User.count`, `Fleet.count`, ships this year)
- the dashboard's traffic figures — the date is in the key so they roll over at midnight rather than at whatever the entry's five minutes happen to be
- public `quick_stats`, **220.6 ms** per call, twelve figures over the whole catalogue and 1.57M vehicles, recomputed per visitor

`online_count` gets **one minute** instead — it is the one figure meant to read as now, and a minute still collapses the poll and several admins down to one pair of queries.

**The attention tiles are deliberately not cached.** Failed imports, stuck imports, unlisted models, actionable notifications: cheap counts on indexed columns, absent from PgHero's slow list, and the reason an admin has the page open at all.

## Testing

The test environment caches into a null store, so none of this would have been covered by what already exists. Both new tests were checked by breaking the thing they cover:

- `stats_show_test` puts a real store in place and asks whether the second request used it — fails 1 vs 2 when the cache key stops deduplicating.
- the two `MetricsJob` rollup tests — the first fails 2 vs 0.0 without `track_visits`, the second fails 1 vs 2.0 if the tracking blocklist is dropped.

32 tests across the touched endpoints pass; `bin/ruby-lint` is clean.

## Note for the reviewer

`most_viewed_pages` in the same admin controller is deliberately untouched — that is #4786, which is still open. Both PRs edit `admin/api/v1/stats_controller.rb` but different methods, so whichever lands second should merge cleanly.

🤖
