### PR TITLE
perf(models): read the filter values off the column

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -550,14 +550,19 @@ class Model < ApplicationRecord
     end
   end
 
+  # Eight values, read off the column rather than out of a model. Building them
+  # in Ruby loaded every visible ship in full to look at one string on each.
   def self.classifications
-    Model.visible.active.order(classification: :asc).all.map(&:classification).compact_blank.compact.uniq
+    Model.visible.active.order(:classification).distinct.pluck(:classification).compact_blank
   end
 
+  # As `classifications`, and with an order it did not have: the list was
+  # whatever order the rows came back in, which is no order at all once ninety
+  # of them are in a filter.
   def self.focus_filters(classification: nil)
     scope = Model.visible.active
     scope = scope.where(classification: classification) if classification.present?
-    scope.map(&:focus).compact_blank.compact.uniq.map do |item|
+    scope.order(:focus).distinct.pluck(:focus).compact_blank.map do |item|
       Filter.new(
         category: "focus",
         label: item.humanize,


### PR DESCRIPTION
The same shape as #4786, in the model filters: work done in Ruby that the column could answer directly.

`Model.classifications` and `Model.focus_filters` each loaded every visible, active ship **in full** and then read one string off each. Eight distinct classifications come out of 243 rows; ninety-three focus values come out of the same 243.

| | before | after |
|---|---|---|
| `classifications` | 16.05 ms | **1.84 ms** |
| `focus_filters` | 12.73 ms | **0.80 ms** |

Measured on a production dump. PgHero counts 30,344 calls of the classifications query alone — it is reached from the model filters, the hangar stats and the fleet stats.

## One deliberate change

**The focus list is ordered now.** It had none before, so it arrived in whatever order the rows came back in — heap order, which shifts as rows are updated. That is no order at all by the time ninety-three values are sitting in a filter dropdown, so it is now alphabetical.

`classifications` was already ordered by classification and its output is unchanged, value for value:

```
["combat", "competition", "exploration", "ground", "industrial", "multi", "support", "transport"]
```

The focus values are the same 93, verified as a set against the old code on a production dump, including with the `classification:` argument applied.

## Not touched

`production_status_filters`, `dock_size_filters` and `size_filters` sit right beside these two and look similar, but they build from constants and an enum — they never hit the database.

68 tests across the filter endpoints, the hangar stats and the model unit tests pass; `bin/ruby-lint` is clean.

🤖
