### PR TITLE
perf(users): stop counting a remembered cookie as a sign-in

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,6 +267,30 @@ class User < ApplicationRecord
     where(confirmed_at: nil)
   end
 
+  # Devise counts a sign-in on every authentication that is not a session fetch,
+  # and with `remember_for` at six months against a two-hour session timeout,
+  # most of those are the cookie proving who someone is again rather than anyone
+  # signing in. Over one reporting window that was 433,159 writes to the busiest
+  # table in the database, while the query that looks an account up by login ran
+  # 27,858 times -- so about one in sixteen of them followed a password.
+  #
+  # Skipping the rest leaves `sign_in_count` counting what its name says, and
+  # `last_sign_in_at` holding the last time someone really signed in. Nothing
+  # loses "when was this account last used" -- that is `last_active_at`, which
+  # every API client updates.
+  def update_tracked_fields!(request)
+    return if remembered_authentication?(request)
+
+    super
+  end
+
+  private def remembered_authentication?(request)
+    warden = request.env["warden"]
+    return false if warden.nil?
+
+    warden.winning_strategy.is_a?(Devise::Strategies::Rememberable)
+  end
+
   def set_normalized_login_fields
     self.normalized_email = email.downcase
     self.normalized_username = username.downcase

--- a/test/integration/api/v1/sessions_test.rb
+++ b/test/integration/api/v1/sessions_test.rb
@@ -117,6 +117,27 @@ class Api::V1::SessionsTest < ActionDispatch::IntegrationTest
     assert_predicate remember_cookie(browser).to_s, :empty?
   end
 
+  test "a remembered browser does not count as another sign in" do
+    user = create(:user, password: "enterprise")
+    browser = sign_in_remembered(user)
+    signed_in = user.reload.slice(:sign_in_count, :current_sign_in_at)
+
+    browser.cookies.delete(Rails.configuration.cookie_prefix)
+    browser.get "/api/v1/users/me"
+
+    assert_equal 200, browser.response.status
+    assert_equal signed_in, user.reload.slice(:sign_in_count, :current_sign_in_at)
+  end
+
+  test "signing in with a password still counts" do
+    user = create(:user, password: "enterprise")
+    browser = open_session
+
+    assert_difference -> { user.reload.sign_in_count }, 1 do
+      sign_in_json(browser, user, remember: true)
+    end
+  end
+
   private def sign_in_remembered(user)
     browser = open_session
     sign_in_json(browser, user, remember: true)


### PR DESCRIPTION
The largest single entry in PgHero's report: **231 min, 3 % of all database time, 433,159 calls** of

```sql
UPDATE users SET sign_in_count = $1, current_sign_in_at = $2, last_sign_in_at = $3, updated_at = $4 WHERE id = $5
```

## What it actually is

Devise's trackable hook fires on `after_set_user except: :fetch` — every authentication that is not a session being read back. With `remember_for = 6.months` against `timeout_in = 2.hours`, a returning user's session lapses, the remember cookie picks them back up, and that is an authentication. One write to the busiest table in the database, every time.

The same report has the number that proves it. The query that looks an account up by login (`normalized_username = $1 OR normalized_email = $2`, `user.rb:247`) ran **27,858** times. So of 433,159 counted sign-ins, about one in sixteen followed a password. `sign_in_count` has been counting cookie restores.

## The fix

`update_tracked_fields!` returns early when the Rememberable strategy is the one that authenticated. The field counts sign-ins again, and `last_sign_in_at` holds the last time someone really signed in.

Nothing loses "when was this account last used" — that was never this column's job. It is `last_active_at`, which every API client updates (`api/base_controller.rb`, throttled to 15 minutes via `update_column`) and which is indexed for exactly that.

## Why not just drop `:trackable`

That was my first instinct and it is wrong — the columns are load-bearing:

- `current_sign_in_at` is the OIDC `auth_time` claim (`config/initializers/doorkeeper_openid_connect.rb:15`)
- the admin user list sorts on `lastSignInAt`, and both timestamps are in `User.ransackable_attributes`

Reading `auth_time` as the last real authentication rather than the last cookie restore is arguably closer to what the claim is specified to mean, not further from it.

## On the 32 ms

Worth being straight about: the statement itself is cheap — **3.56 ms** for a single-row primary-key update on an idle copy of the database. The 32 ms average in production is contention and WAL on a hot table, not plan cost, and `max_wal_size = 1GB` with `shared_buffers = 128MB` is the profile that produces it. This PR removes most of the writes; it does not make the remaining ones faster. The server settings are a separate conversation.

## Tests

Two, and they pin the behaviour from both sides. Each was checked by forcing the other's behaviour:

- **a remembered browser does not count as another sign in** — signs in with remember-me, drops the session cookie, makes a request; neither `sign_in_count` nor `current_sign_in_at` moves. Fails without the early return.
- **signing in with a password still counts** — fails (1 vs 0) if the skip is made unconditional.

They build on the `sign_in_remembered` helper this file already had. 80 tests across sessions, omniauth callbacks, confirm-access and the user model pass; `bin/ruby-lint` is clean.

🤖
