### PR TITLE
perf(db): move the database off five spinning-disk defaults

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -74,7 +74,46 @@ env:
 accessories:
   db:
     image: postgres:16
-    cmd: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
+    # Everything below the two `pg_stat_statements` flags is off its default,
+    # and the defaults are the ones PostgreSQL ships for a machine nothing here
+    # resembles. Strength of the case differs per line and is noted with it.
+    #
+    # random_page_cost         Measured. At 4 a random read is priced like a
+    #                          seek on a spinning disk, and the planner rejects
+    #                          index scans it should take -- the fleet counts
+    #                          read all 1.57M rows of `vehicles` instead of the
+    #                          few thousand in the fleet. At 1.1 that query goes
+    #                          61ms -> 15ms and the hangar list 63ms -> 13ms,
+    #                          with none of six measured getting slower.
+    # shared_buffers           Sized, not measured. The database is 2.5GB and
+    #                          `vehicles` plus `fleet_vehicles` with their
+    #                          indexes are 630MB of it; at 128MB none of that
+    #                          hot set can live in the buffers at all. 1GB of
+    #                          the container's 4GB leaves room for the ~45
+    #                          connections and their work_mem.
+    # max_wal_size             Suspected. The sign-in tracking UPDATE takes
+    #                          3.56ms on an idle copy and 32ms here, which is
+    #                          what checkpoints forced by WAL volume rather
+    #                          than by time look like. Costs disk and a longer
+    #                          crash recovery.
+    # wal_compression          Same suspicion, other end: less WAL means fewer
+    #                          forced checkpoints and smaller full-page writes,
+    #                          for some CPU.
+    # effective_io_concurrency 1 is the value for a single spindle. Little is
+    #                          expected of this on a mostly-cached database; it
+    #                          is here because it costs nothing.
+    #
+    # work_mem is deliberately left alone: six of the slow queries were checked
+    # with EXPLAIN (ANALYZE, BUFFERS) and none spilled to disk.
+    cmd: >-
+      postgres
+      -c shared_preload_libraries=pg_stat_statements
+      -c pg_stat_statements.track=all
+      -c random_page_cost=1.1
+      -c shared_buffers=1GB
+      -c max_wal_size=4GB
+      -c wal_compression=lz4
+      -c effective_io_concurrency=200
     port: "5432:5432"
     env:
       clear:


### PR DESCRIPTION
Every planner and WAL setting on this database is still the PostgreSQL default, and those defaults are sized for a machine with a spinning disk and a fraction of this container's memory. Five are worth changing. The case for each is different, so it is written next to it in the file rather than bundled into one claim.

## Measured: `random_page_cost` 4 → 1.1

At 4 a random read is priced like a seek on a spinning disk, and the planner rejects index scans it should take. Counting a fleet's ships reads **all 1,573,370 rows of `vehicles`** instead of starting from `index_fleet_vehicles_on_fleet_id_and_vehicle_id` and looking up the few thousand in the fleet. The planner costs the index plan at 37,404 against the scan's 33,377 — wrong by a factor of four.

Six queries from PgHero's list, on a production dump, best of three:

| query | `rpc=4` | `rpc=1.1` |
|---|---|---|
| fleet model counts (125,136 calls) | 61.0 ms | **15.3 ms** |
| hangar list by classification (61,111 calls) | 62.6 ms | **13.0 ms** |
| models by classification | 0.64 ms | 0.30 ms |
| `COUNT(*)` vehicles (wanted) | 49.7 ms | 49.6 ms |
| vehicles grouped by model name | 64.9 ms | 64.9 ms |
| visits by day | 6.0 ms | 5.8 ms |

**Two get four times faster, four are unchanged, none got slower.** The four that do not move are full aggregates where a sequential scan is the right plan — and it stays chosen, which is why they were measured.

## Sized, not measured: `shared_buffers` 128MB → 1GB

The database is **2,506 MB**. `vehicles` (427 MB) and `fleet_vehicles` (206 MB) with their indexes are 630 MB of it, and that is the hot path. At 128 MB none of it can live in the buffers — it survives only in the OS page cache inside the same cgroup, one copy and one syscall further away.

1 GB of the container's 4 GB leaves room for ~45 connections at 4 MB `work_mem` plus process overhead — roughly 2.6 GB worst case.

The production cache hit ratio would turn this from sized into measured:

```sql
SELECT round(sum(blks_hit) * 100.0 / nullif(sum(blks_hit + blks_read), 0), 2)
FROM pg_stat_database WHERE datname = current_database();
```

## Suspected: `max_wal_size` 1GB → 4GB, `wal_compression` off → lz4

The sign-in tracking UPDATE (#4793) is **3.56 ms on an idle copy and 32 ms in production**. A single-row primary-key update does not get 9× slower from plan cost; that is the shape of checkpoints forced by WAL volume rather than by time, after which every write pays full-page writes. More WAL headroom pushes checkpoints back to the timeout; compression shrinks what has to be written either way.

Costs: disk for WAL, a longer crash recovery, some CPU. Confirmable in one query:

```sql
SELECT checkpoints_timed, checkpoints_req FROM pg_stat_bgwriter;
```

## Free: `effective_io_concurrency` 1 → 200

1 is the value for a single spindle. Little is expected of it on a mostly-cached database — it is here because it costs nothing to correct.

## Left alone, deliberately

- **`work_mem` 4MB** — six of the slow queries read with `EXPLAIN (ANALYZE, BUFFERS)`: every sort `quicksort` in memory, every hash `Batches: 1`, no `Disk:` anywhere. Raising it would buy nothing.
- **`default_statistics_target` 100** — the misestimate above is the *cost model*, not the statistics: 2,553 rows estimated against 2,044 actual.
- **`jit` on** — the most expensive of these plans costs 37,162 against a `jit_above_cost` of 100,000. It never fires.
- **`max_connections` 100** — PgHero reports 45 in use.
- **`maintenance_work_mem` 64MB** — PgHero reports vacuuming healthy, and each autovacuum worker would take the new value.

## Verification

The whole command line was booted against **`postgres:16`** — the image live runs, not the `postgres:16-alpine` used in docker-compose — and read back from `pg_settings`:

```
effective_io_concurrency = 200
max_wal_size             = 4096 MB
random_page_cost         = 1.1
shared_buffers           = 131072 8kB
wal_compression          = lz4
shared_preload_libraries = pg_stat_statements
```

`lz4` is available in that image (`HINT: Available values: pglz, lz4, zstd, on, off`), and an invalid value is rejected at startup — a typo here would keep the database down rather than run it misconfigured.

`cmd` is now a folded scalar so the flags read one per line; it parses to exactly the string that was booted.

## Applying it

Merging changes nothing on its own. Kamal applies accessory `cmd` on `kamal accessory reboot db`, which **restarts the database**. Neither `deploy.live.yml` nor `deploy.stage.yml` overrides `cmd`, so both inherit it.

🤖
