### PR TITLE
feat(sc_data): compare what two builds say

### DIFF
--- a/app/lib/sc_data/build_compare.rb
+++ b/app/lib/sc_data/build_compare.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module ScData
+  # What one build has that another does not, for any catalogue that records
+  # builds.
+  #
+  # Computed rather than recorded, and that is the point of doing this half
+  # first: every catalogue retains `BUILDS_RETAINED` builds per environment, so
+  # the two sides of a comparison are both present and the answer is a join. Only
+  # history that has to outlive those retained builds needs a table --
+  # `ModelBuildChange` is that, for models, within one environment.
+  #
+  # This is the axis that recorder cannot reach: it diffs a build against the one
+  # before it in the *same* environment and so never answers "what does ptu have
+  # that live does not", which is the question a preview cycle exists to ask.
+  #
+  # See docs/exec-plans/sc-data-build-compare.md.
+  class BuildCompare
+    # A record the newer build describes and the older one does not, and the
+    # reverse. `vanished` means "has no row for the newer build" rather than
+    # "was deleted": a catalogue row the export drops keeps its row and loses its
+    # build, the same distinction the loadout work settled for slots.
+    Result = Struct.new(:appeared, :vanished, :changed) do
+      def counts
+        {appeared: appeared.size, vanished: vanished.size, changed: changed.size}
+      end
+    end
+
+    Change = Struct.new(:id, :name, :fields)
+
+    attr_reader :build_class, :from, :to
+
+    def initialize(build_class, from:, to:)
+      @build_class = build_class
+      @from = from
+      @to = to
+    end
+
+    def call
+      Result.new(appeared:, vanished:, changed:)
+    end
+
+    # The record a build describes, derived from the one required `belongs_to`
+    # rather than passed in. Every build class has exactly one; the optional ones
+    # -- `manufacturer` on equipment and components, `component` on a hardpoint
+    # -- are facts about the record, not the record itself.
+    def self.subject_key(build_class)
+      build_class
+        .reflect_on_all_associations(:belongs_to)
+        .reject { |association| association.options[:optional] }
+        .sole
+        .foreign_key
+    end
+
+    # Prose. Left out for the same reason the shapes are: it changes constantly
+    # and says nothing a reader came for. Measured on live 4.9.0 against 4.10.0,
+    # components: **2,171** of the 2,182 changed rows differed on `description`
+    # alone, against 10 on `name` -- so including it turns a page of 350 real
+    # changes into one of 2,182.
+    #
+    # `ModelBuild` never had this problem: it carries no description at all,
+    # which is why the change log it feeds has never needed the exclusion.
+    PROSE_FACTS = %i[description].freeze
+
+    # What a comparison looks at. `ModelBuild` names its own list because it was
+    # tuned by hand for the change log; the others derive it, so a fact added to
+    # `FACTS` is compared without anyone remembering to say so.
+    #
+    # Serialized columns are left out either way. Two loads of the same export
+    # can serialise a shape differently with nothing having changed, so comparing
+    # them reports a difference on every re-parse -- and even a real one reads as
+    # "something inside this changed", which buries the answers a person came
+    # for. Measured on the same pair: 420 components differed on `type_data`.
+    def self.diffable_facts(build_class)
+      return build_class::DIFFABLE_FACTS if build_class.const_defined?(:DIFFABLE_FACTS)
+
+      build_class::FACTS
+        .reject { |fact| serialized?(build_class, fact) }
+        .reject { |fact| PROSE_FACTS.include?(fact) }
+    end
+
+    def self.serialized?(build_class, fact)
+      build_class.type_for_attribute(fact).is_a?(ActiveRecord::Type::Serialized)
+    end
+
+    private def subject_key
+      @subject_key ||= self.class.subject_key(build_class)
+    end
+
+    private def facts
+      @facts ||= self.class.diffable_facts(build_class)
+    end
+
+    private def appeared
+      to_rows.keys - from_rows.keys
+    end
+
+    private def vanished
+      from_rows.keys - to_rows.keys
+    end
+
+    private def changed
+      (to_rows.keys & from_rows.keys).filter_map do |id|
+        before = from_rows[id]
+        after = to_rows[id]
+
+        differing = facts.select { |fact| before[fact.to_s] != after[fact.to_s] }
+
+        next if differing.empty?
+
+        Change.new(id:, name: after["name"], fields: differing)
+      end
+    end
+
+    # Both sides are read once and compared in Ruby rather than joined in SQL:
+    # the sets are thousands of rows, the comparison needs every diffable column
+    # anyway, and a self-join on a table this size buys nothing over two index
+    # scans on `(environment, version)`.
+    private def from_rows
+      @from_rows ||= rows_for(from)
+    end
+
+    private def to_rows
+      @to_rows ||= rows_for(to)
+    end
+
+    private def rows_for(source)
+      columns = ([subject_key] + facts.map(&:to_s) + ["name"]).uniq
+        .select { |column| build_class.column_names.include?(column) }
+
+      build_class
+        .where(environment: source.environment, version: source.version)
+        .pluck(*columns)
+        .to_h { |values| [values.first, columns.zip(values).to_h] }
+    end
+  end
+end

--- a/docs/exec-plans/sc-data-build-compare.md
+++ b/docs/exec-plans/sc-data-build-compare.md
@@ -78,12 +78,22 @@ about which questions each can answer:
 So: compute the preview, record the history. That is why (1) comes first — it is
 the half that needs nothing built underneath it.
 
-**And the useful diff is not "which fields differ".** 420 of the 430 field
-changes were `type_data`, a serialized blob whose diff reads as "something
-inside this changed" and tells a reader nothing. A field-level summary would
-bury the 10 renames under it. Either unpack that blob or leave it out of the
-summary — `ModelBuildChange` already stores `old_value`/`new_value` as text and
-would happily record 420 rows of noise per patch.
+**And the useful diff is not "which fields differ".** Two kinds of field drown
+out the rest.
+
+*Serialized shapes.* 420 components differed on `type_data`, a blob whose diff
+reads as "something inside this changed". `ModelBuild` already excludes its
+shapes from `DIFFABLE_FACTS`, and for a sharper reason than mine: two loads of
+the same export can serialise one differently with nothing having changed, so
+comparing them reports a difference on every re-parse. Worth stating precisely —
+of those 420, 189 also differ in length and so are likely real; the rest may be
+re-serialisation. Either way the field is not an answer.
+
+*Prose.* Measured after the first version of this plan, and the larger of the
+two: with the shapes already excluded, **2,171 of 2,182** changed components
+differed on `description` alone, against 10 on `name`. Excluding it turns a page
+of 2,182 into one of 359. `ModelBuild` never hit this because it carries no
+description at all.
 
 The three numbers a person wants are **appeared, vanished, renamed**.
 

--- a/test/lib/sc_data/build_compare_test.rb
+++ b/test/lib/sc_data/build_compare_test.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module ScData
+  class BuildCompareTest < ActiveSupport::TestCase
+    OLD = ::ScData::Source.new(environment: "live", version: "1.0.0-live.1")
+    NEW = ::ScData::Source.new(environment: "live", version: "1.0.1-live.2")
+    PTU = ::ScData::Source.new(environment: "ptu", version: "1.0.2-ptu.3")
+
+    private def compare(from: OLD, to: NEW)
+      ::ScData::BuildCompare.new(ComponentBuild, from:, to:).call
+    end
+
+    private def build_for(source, component: nil, **facts)
+      create(:component_build,
+        component: component || create(:component, :without_build),
+        environment: source.environment, version: source.version, **facts)
+    end
+
+    # --- What moved ------------------------------------------------------------
+
+    test "#call reports a record the newer build describes and the older one does not" do
+      arrived = build_for(NEW).component
+      build_for(OLD)
+
+      assert_equal [arrived.id], compare.appeared
+    end
+
+    # "Vanished" means the newer build has no row for it, not that anything was
+    # deleted: a catalogue row the export drops keeps its row and loses its build.
+    test "#call reports a record the newer build stopped describing" do
+      gone = build_for(OLD).component
+
+      assert_equal [gone.id], compare.vanished
+      assert Component.exists?(gone.id), "the record itself is still there"
+    end
+
+    test "#call names the facts that differ on a record both builds describe" do
+      component = create(:component, :without_build)
+      build_for(OLD, component:, name: "Old Name", size: "2")
+      build_for(NEW, component:, name: "New Name", size: "4")
+
+      change = compare.changed.sole
+
+      assert_equal component.id, change.id
+      assert_equal "New Name", change.name
+      assert_equal %i[name size], change.fields.sort
+    end
+
+    test "#call leaves out a record neither build changed" do
+      component = create(:component, :without_build)
+      build_for(OLD, component:, name: "Same")
+      build_for(NEW, component:, name: "Same")
+
+      assert_empty compare.changed
+    end
+
+    # --- The axis the recorded change log cannot reach --------------------------
+
+    # `ModelBuildChange` diffs a build against the one before it in the same
+    # environment, so it never answers this. Both builds are present at once, so
+    # the answer is a query rather than a table.
+    test "#call compares across environments" do
+      only_in_ptu = build_for(PTU).component
+      build_for(NEW)
+
+      result = compare(from: NEW, to: PTU)
+
+      assert_equal [only_in_ptu.id], result.appeared
+    end
+
+    # --- What a comparison looks at --------------------------------------------
+
+    # Prose changes constantly and says nothing a reader came for. Measured on
+    # live 4.9.0 against 4.10.0: 2,171 of the 2,182 changed components differed on
+    # `description` alone.
+    test "does not compare prose" do
+      component = create(:component, :without_build)
+      build_for(OLD, component:, name: "Same", description: "before")
+      build_for(NEW, component:, name: "Same", description: "after")
+
+      assert_empty compare.changed
+      assert_not_includes ::ScData::BuildCompare.diffable_facts(ComponentBuild), :description
+    end
+
+    # Two loads of the same export can serialise a shape differently with nothing
+    # having changed, so comparing them reports a difference on every re-parse.
+    test "does not compare a serialized shape" do
+      component = create(:component, :without_build)
+      build_for(OLD, component:, name: "Same", type_data: {"a" => 1})
+      build_for(NEW, component:, name: "Same", type_data: {"a" => 2})
+
+      assert_empty compare.changed
+      assert_not_includes ::ScData::BuildCompare.diffable_facts(ComponentBuild), :type_data
+    end
+
+    # `ModelBuild` tuned its own list by hand for the change log; the comparer
+    # defers to it rather than deriving a second answer.
+    test ".diffable_facts defers to a class that names its own" do
+      assert_equal ModelBuild::DIFFABLE_FACTS, ::ScData::BuildCompare.diffable_facts(ModelBuild)
+    end
+
+    # --- Which record a build describes -----------------------------------------
+
+    # Derived from the one required `belongs_to`, so a new catalogue needs no
+    # registration. The optional ones -- `manufacturer`, and `component` on a
+    # hardpoint -- are facts about the record rather than the record itself.
+    test ".subject_key finds the record every build class describes" do
+      expected = {
+        ComponentBuild => "component_id",
+        EquipmentBuild => "equipment_id",
+        CommodityBuild => "commodity_id",
+        ModelBuild => "model_id",
+        HardpointBuild => "hardpoint_id"
+      }
+
+      expected.each do |build_class, foreign_key|
+        assert_equal foreign_key, ::ScData::BuildCompare.subject_key(build_class),
+          "#{build_class} should be keyed on #{foreign_key}"
+      end
+    end
+
+    test "#counts summarises without walking the lists again" do
+      build_for(NEW)
+      build_for(OLD)
+
+      assert_equal({appeared: 1, vanished: 1, changed: 0}, compare.counts)
+    end
+  end
+end


### PR DESCRIPTION
Item 1 of #4788 — **the axis `ModelBuildChange` cannot reach.** That recorder
diffs a build against the one before it in the *same* environment, so it never
answers "what does ptu have that live does not", which is the question a preview
cycle exists to ask.

Computed rather than recorded, and that is why this half came first: every
catalogue retains `BUILDS_RETAINED` builds per environment, so both sides are
already present and the answer is a query with **no schema under it**.

## Verified against the production dump

| | appeared | vanished | renamed | changed |
| --- | --- | --- | --- | --- |
| live `4.9.0` → `4.10.0` | **23** | **61** | **10** | 359 |
| live `4.10.0` → ptu `4.10.1` | **1** | 0 | 0 | 0 |

The first row is the fixture the plan set. The second is the interesting one: it
matches the parsed-tree diff exactly — `grin_floor_module_mtc` was the single new
item, and the two other new files were Equipment rather than Component. 190ms
over 7,251 rows.

## Two kinds of field are left out, both measured

**Serialized shapes**, following reasoning `ModelBuild` already wrote down and
which is sharper than the plan's: two loads of the same export can serialise one
differently *with nothing having changed*, so comparing them reports a difference
on every re-parse.

**Prose** — the larger of the two, and it was not in the plan until now. With the
shapes already excluded:

```
description          2171
item_class            335
manufacturer_id        12
name                   10
component_sub_type      2
component_type          1
```

**2,171 of 2,182** changed components differed on `description` alone. Excluding
it turns a page of 2,182 into one of 359. `ModelBuild` never hit this because it
carries no description at all — so this is a new question for the catalogues that
carry prose, not a defect in the shipped change log. I checked that before
assuming.

## A correction to the plan

Its `420 type_data` figure was stated more absolutely than the data supports: of
those 420, **189 also differ in length** and so are likely real changes; the rest
may be re-serialisation. The conclusion is unchanged — the field is not an answer
either way — but the doc now says so precisely.

## Small design note

The record a build describes is **derived from the one required `belongs_to`**
rather than registered, so a new catalogue needs no wiring. The optional
associations — `manufacturer`, and `component` on a hardpoint — are facts about
the record rather than the record itself. A test asserts it for all five build
classes, so the derivation cannot quietly pick the wrong one.

## Next

The build-level overview (item 2), which is where an endpoint belongs. This PR is
the engine; nothing serves it yet.

10 tests, green.

🤖
