### PR TITLE
chore: run the same postgres image everywhere

### DIFF
--- a/.github/workflows/api-schema-check.job.yml
+++ b/.github/workflows/api-schema-check.job.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.2-alpine
+        image: postgres:16
         env:
           POSTGRES_USER: root
           POSTGRES_DB: fleetyards_test

--- a/.github/workflows/e2e.job.yml
+++ b/.github/workflows/e2e.job.yml
@@ -30,7 +30,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.2-alpine
+        image: postgres:16
         env:
           POSTGRES_USER: root
           POSTGRES_DB: fleetyards_test

--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -29,7 +29,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13.2-alpine
+        image: postgres:16
         env:
           POSTGRES_USER: root
           POSTGRES_DB: fleetyards_test

--- a/.github/workflows/seeds.job.yml
+++ b/.github/workflows/seeds.job.yml
@@ -15,7 +15,7 @@ jobs:
       REDIS_URL: redis://localhost:6379
     services:
       postgres:
-        image: postgres:13.2-alpine
+        image: postgres:16
         env:
           POSTGRES_USER: root
           POSTGRES_DB: fleetyards_test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,17 @@ bin/setup                         # Set up a checkout (allocates a worktree's po
 bin/teardown                      # Release everything bin/setup allocated to a worktree, before removing it
 ```
 
+Postgres runs the same `postgres:16` image locally, in CI and in production. That
+is deliberate: the Alpine variant links musl, which has no locale collation and
+sorts text by byte instead, so `ORDER BY` gave one answer locally and another one
+live.
+
+A data directory carries the collation its indexes were built under. If yours was
+created by an Alpine image, every text index in it is sorted the musl way and this
+image will read it the glibc way — nothing warns, because musl reports no
+collation version to compare against, and an index lookup simply stops finding
+rows. Recreate the volume, or `REINDEX DATABASE fleetyards_dev` once.
+
 ### Testing
 ```bash
 bin/rails test                    # Backend tests (Minitest)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 name: fleetyards-dev
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:16
     restart: always
     command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
     environment:


### PR DESCRIPTION
CI ran `postgres:13.2-alpine` — all four jobs — while development and production run 16. Two divergences came with that, and neither announced itself.

## The version gap enforces a different rule than production

`supports_nulls_not_distinct?` (>= 15) is the **only** version guard in the PostgreSQL adapter this schema reaches — I checked every `database_version` comparison in ActiveRecord; the rest are 12 and below. And on 13, Rails does not fail, it omits:

```ruby
# activerecord/.../abstract/schema_creation.rb:119
sql << "NULLS NOT DISTINCT" if supports_nulls_not_distinct? && index.nulls_not_distinct
```

So `index_item_price_snapshots_on_item_and_day` (`db/schema.rb:885`) has been unique with **NULLS DISTINCT in every test run and NULLS NOT DISTINCT in production**. `db:schema:load` went green either way, so nothing pointed at it. A test asserting that two snapshots with a NULL `location` collide would have passed CI while production rejected the second row — or the other way round.

## The libc gap sorts text differently

Alpine links musl, which has no locale collation and falls back to byte order. Both databases report `lc_collate = en_US.utf8`, and yet:

```
alpine/musl:  Banane | Gun Ship | Gunboat | Zeus | apple | Ärger
debian/glibc: apple | Ärger | Banane | Gunboat | Gun Ship | Zeus
```

Of the 93 focus values behind the ship filters, two land in a different position (`Gun Ship` and `Medium Freight / Gun Ship` — glibc ignores the space at the primary level, musl does not). Small here, but it means any `ORDER BY` on text answers one way locally and another way live.

Everything now uses `postgres:16`, the image production already runs: the four workflows and `docker-compose.yml`.

## Read this before pulling: existing local volumes

A data directory carries the collation its indexes were built under. Pointing this image at a volume an Alpine image created leaves every text index sorted the musl way and read the glibc way.

I measured what that does, on a throwaway volume:

- **No warning in the log.** musl reports no collation version, so `datcollversion` is empty and Postgres has nothing to compare against.
- An index scan and a sequential scan return **different orders** for the same query.
- `WHERE w = 'apple'` through the index returns **0 rows** for a row that is there.

`REINDEX DATABASE fleetyards_dev` fixes it, and so does recreating the volume — verified both. The note is in `AGENTS.md` next to the docker-compose line so it is where someone will actually hit it.

CI is unaffected: those databases are created fresh every run.

## Verification

On a fresh `postgres:16` container, against this branch:

- the schema loads, and the index comes back `nulls_not_distinct: true` — the thing CI was missing
- `604 tests, 1376 assertions, 0 failures` in `test/models`
- the model filter tests (the `ORDER BY focus` from #4792) and the item price suites: `35 tests, 110 assertions, 0 failures`

## Follow-up, not in here

If #4794 lands, production gets planner settings that `docker-compose.yml` does not have, and dev drifts from production again — on the planner this time rather than on collation. Worth mirroring the same flags locally once that one is settled.

🤖
