### PR TITLE
feat(sc_data): serve a build list and a comparison of two builds

### DIFF
--- a/app/api_components/v1/schemas/sc_data_builds.rb
+++ b/app/api_components/v1/schemas/sc_data_builds.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # Every build there is a row for, newest first.
+    #
+    # The same shape as `ScDataSources` and a different list: that one is what a
+    # reader may be pointed *at*, which deliberately hides everything behind the
+    # default. A comparison needs exactly what it hides, and it reaches back past
+    # the config, which names one version per environment.
+    class ScDataBuilds
+      include OpenapiRuby::Components::Base
+
+      schema({
+        type: :object,
+        properties: {
+          items: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                environment: {type: :string},
+                version: {type: :string},
+                default: {type: :boolean}
+              },
+              additionalProperties: false,
+              required: %w[environment version default]
+            }
+          }
+        },
+        additionalProperties: false,
+        required: %w[items]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/sc_data_compare.rb
+++ b/app/api_components/v1/schemas/sc_data_compare.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    # What two builds say differently, per catalogue.
+    #
+    # `vanished` means the newer build has no row for the record, not that
+    # anything was deleted: a catalogue row the export drops keeps its row and
+    # loses its build.
+    #
+    # `changed` names the fields that differ rather than pre-digesting them, so a
+    # reader can pick what it cares about — a rename is a change on `name` rather
+    # than a category of its own. Prose and serialized shapes are not compared;
+    # see `ScData::BuildCompare` for the measurements behind that.
+    class ScDataCompare
+      include OpenapiRuby::Components::Base
+
+      BUILD = {
+        type: :object,
+        properties: {
+          environment: {type: :string},
+          version: {type: :string}
+        },
+        additionalProperties: false,
+        required: %w[environment version]
+      }.freeze
+
+      CATALOGUE = {
+        type: :object,
+        properties: {
+          counts: {
+            type: :object,
+            properties: {
+              appeared: {type: :integer},
+              vanished: {type: :integer},
+              changed: {type: :integer}
+            },
+            additionalProperties: false,
+            required: %w[appeared vanished changed]
+          },
+          appeared: {type: :array, items: {type: :string, format: :uuid}},
+          vanished: {type: :array, items: {type: :string, format: :uuid}},
+          changed: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                id: {type: :string, format: :uuid},
+                name: {type: [:string, :null]},
+                fields: {type: :array, items: {type: :string}}
+              },
+              additionalProperties: false,
+              required: %w[id fields]
+            }
+          }
+        },
+        additionalProperties: false,
+        required: %w[counts appeared vanished changed]
+      }.freeze
+
+      schema({
+        type: :object,
+        properties: {
+          from: BUILD,
+          to: BUILD,
+          catalogues: {
+            type: :object,
+            properties: {
+              components: CATALOGUE,
+              equipment: CATALOGUE,
+              commodities: CATALOGUE,
+              models: CATALOGUE
+            },
+            additionalProperties: false,
+            required: %w[components equipment commodities models]
+          }
+        },
+        additionalProperties: false,
+        required: %w[from to catalogues]
+      })
+    end
+  end
+end

--- a/app/api_components/v1/schemas/sc_data_compare.rb
+++ b/app/api_components/v1/schemas/sc_data_compare.rb
@@ -28,6 +28,10 @@ module V1
       CATALOGUE = {
         type: :object,
         properties: {
+          # False when one side has no rows for this catalogue at all -- it was
+          # not recorded for that build, rather than everything having appeared.
+          # The lists are empty when it is false.
+          recorded: {type: :boolean},
           counts: {
             type: :object,
             properties: {
@@ -55,7 +59,7 @@ module V1
           }
         },
         additionalProperties: false,
-        required: %w[counts appeared vanished changed]
+        required: %w[recorded counts appeared vanished changed]
       }.freeze
 
       schema({

--- a/app/controllers/api/v1/sc_data_controller.rb
+++ b/app/controllers/api/v1/sc_data_controller.rb
@@ -17,6 +17,47 @@ module Api
       def sources
         @sources = ::ScData::Source.available
       end
+
+      # Every build there is a row for, which is a different list from
+      # `sources`: that one hides everything behind the default, and a
+      # comparison needs exactly what it hides. It also reaches back past the
+      # config, which names one version per environment.
+      def builds
+        @builds = ::ScData::Source.recorded
+      end
+
+      # What two builds say differently. Both sides are named by version alone,
+      # because a version names its environment -- `4.10.1-ptu.12578875` -- so
+      # there is no pair of parameters to keep consistent.
+      #
+      # Hardpoints are left out on purpose. They are per slot rather than per
+      # catalogue entry, so a diff of 22,561 of them is a ship's loadout
+      # question and belongs on a ship, not in a summary of a build.
+      CATALOGUES = {
+        "components" => ComponentBuild,
+        "equipment" => EquipmentBuild,
+        "commodities" => CommodityBuild,
+        "models" => ModelBuild
+      }.freeze
+
+      def compare
+        @from = recorded_build(params[:from])
+        @to = recorded_build(params[:to])
+
+        # Not found rather than a validation error: the parameter is well formed
+        # and names a build nothing has a row for.
+        return not_found if @from.blank? || @to.blank?
+
+        @comparisons = CATALOGUES.transform_values do |build_class|
+          ::ScData::BuildCompare.new(build_class, from: @from, to: @to).call
+        end
+      end
+
+      private def recorded_build(version)
+        return if version.blank?
+
+        ::ScData::Source.recorded.find { |source| source.version == version }
+      end
     end
   end
 end

--- a/app/lib/sc_data/build_compare.rb
+++ b/app/lib/sc_data/build_compare.rb
@@ -20,10 +20,12 @@ module ScData
     # reverse. `vanished` means "has no row for the newer build" rather than
     # "was deleted": a catalogue row the export drops keeps its row and loses its
     # build, the same distinction the loadout work settled for slots.
-    Result = Struct.new(:appeared, :vanished, :changed) do
+    Result = Struct.new(:appeared, :vanished, :changed, :recorded) do
       def counts
         {appeared: appeared.size, vanished: vanished.size, changed: changed.size}
       end
+
+      alias_method :recorded?, :recorded
     end
 
     Change = Struct.new(:id, :name, :fields)
@@ -37,7 +39,21 @@ module ScData
     end
 
     def call
-      Result.new(appeared:, vanished:, changed:)
+      # A catalogue with no rows at all on one side was not *recorded* for that
+      # build, which is a different statement from "everything appeared" -- and
+      # reporting the lists would make it the wrong one. Commodities and models
+      # only gained build rows in 4.10.0, so comparing 4.9.0 against it would
+      # otherwise announce all 232 commodities and all 215 models as new.
+      #
+      # The lists are empty rather than merely flagged, so a reader that ignores
+      # the flag still cannot draw the wrong conclusion.
+      return Result.new([], [], [], false) unless recorded?
+
+      Result.new(appeared, vanished, changed, true)
+    end
+
+    def recorded?
+      from_rows.any? && to_rows.any?
     end
 
     # The record a build describes, derived from the one required `belongs_to`

--- a/app/lib/sc_data/source.rb
+++ b/app/lib/sc_data/source.rb
@@ -53,6 +53,26 @@ module ScData
         end
       end
 
+      # Every build any catalogue carries a row for, newest first.
+      #
+      # Built from the rows rather than from the config, and that is the whole
+      # difference from `available`: the config names one version per
+      # environment, while a comparison wants the ones before it too. Live
+      # 4.9.0 is not configured any more and is exactly what a patch diff
+      # compares 4.10.0 against.
+      #
+      # `available` is also the wrong list for another reason -- it hides
+      # everything behind the default, which is precisely what a comparison
+      # needs to see.
+      def recorded
+        BUILDS
+          .flat_map { |klass| klass.distinct.pluck(:environment, :version) }
+          .uniq
+          .map { |environment, version| new(environment:, version:) }
+          .sort_by(&:precedence)
+          .reverse
+      end
+
       # Runs a block with a source in force, and puts back whatever was there.
       # Nested so a job inside a request cannot strand the outer value.
       def with(source)
@@ -104,7 +124,9 @@ module ScData
       (precedence <=> other.precedence) == 1
     end
 
-    protected def precedence
+    # Public because an ordered list of builds needs it -- `recorded` sorts by
+    # it. `ahead_of?` is the comparison this exists for.
+    def precedence
       release, build = version.to_s.split("-", 2)
       id = build.to_s[/\d+\z/].to_i
 

--- a/app/views/api/v1/sc_data/builds.jbuilder
+++ b/app/views/api/v1/sc_data/builds.jbuilder
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+json.items do
+  json.array! @builds do |build|
+    json.environment build.environment
+    json.version build.version
+    json.default build.default?
+  end
+end

--- a/app/views/api/v1/sc_data/compare.jbuilder
+++ b/app/views/api/v1/sc_data/compare.jbuilder
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+json.from do
+  json.environment @from.environment
+  json.version @from.version
+end
+
+json.to do
+  json.environment @to.environment
+  json.version @to.version
+end
+
+json.catalogues do
+  @comparisons.each do |name, result|
+    json.set! name do
+      json.counts result.counts
+
+      json.appeared result.appeared
+      json.vanished result.vanished
+
+      # The changes carry the fields that differ, so a reader can pick the ones
+      # it cares about -- a rename is the interesting one, and it is a change on
+      # `name` rather than a category of its own.
+      json.changed do
+        json.array! result.changed do |change|
+          json.id change.id
+          json.name change.name
+          json.fields change.fields
+        end
+      end
+    end
+  end
+end

--- a/app/views/api/v1/sc_data/compare.jbuilder
+++ b/app/views/api/v1/sc_data/compare.jbuilder
@@ -13,6 +13,12 @@ end
 json.catalogues do
   @comparisons.each do |name, result|
     json.set! name do
+      # False when one side has no rows for this catalogue at all: it was not
+      # recorded for that build, which is a different statement from "everything
+      # appeared". The lists are empty in that case, so a reader that ignores
+      # this still cannot draw the wrong conclusion.
+      json.recorded result.recorded?
+
       json.counts result.counts
 
       json.appeared result.appeared

--- a/config/routes/api/v1_routes.rb
+++ b/config/routes/api/v1_routes.rb
@@ -4,6 +4,8 @@ v1_api_routes = lambda do
   get "version", to: "base#version"
   get "sc-data/version", to: "sc_data#current_version"
   get "sc-data/sources", to: "sc_data#sources"
+  get "sc-data/builds", to: "sc_data#builds"
+  get "sc-data/compare", to: "sc_data#compare"
 
   resource :features, only: %i[show]
 

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -19739,6 +19739,8 @@ components:
             components:
               type: object
               properties:
+                recorded:
+                  type: boolean
                 counts:
                   type: object
                   properties:
@@ -19785,6 +19787,7 @@ components:
                     - fields
               additionalProperties: false
               required:
+              - recorded
               - counts
               - appeared
               - vanished
@@ -19792,6 +19795,8 @@ components:
             equipment:
               type: object
               properties:
+                recorded:
+                  type: boolean
                 counts:
                   type: object
                   properties:
@@ -19838,6 +19843,7 @@ components:
                     - fields
               additionalProperties: false
               required:
+              - recorded
               - counts
               - appeared
               - vanished
@@ -19845,6 +19851,8 @@ components:
             commodities:
               type: object
               properties:
+                recorded:
+                  type: boolean
                 counts:
                   type: object
                   properties:
@@ -19891,6 +19899,7 @@ components:
                     - fields
               additionalProperties: false
               required:
+              - recorded
               - counts
               - appeared
               - vanished
@@ -19898,6 +19907,8 @@ components:
             models:
               type: object
               properties:
+                recorded:
+                  type: boolean
                 counts:
                   type: object
                   properties:
@@ -19944,6 +19955,7 @@ components:
                     - fields
               additionalProperties: false
               required:
+              - recorded
               - counts
               - appeared
               - vanished

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -9380,6 +9380,51 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/sc-data/builds":
+    get:
+      summary: SC Data Builds
+      tags:
+      - Versions
+      operationId: scDataBuilds
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataBuilds"
+  "/sc-data/compare":
+    get:
+      summary: Compare two SC Data builds
+      tags:
+      - Versions
+      operationId: scDataCompare
+      parameters:
+      - name: from
+        in: query
+        schema:
+          type: string
+        required: true
+      - name: to
+        in: query
+        schema:
+          type: string
+        required: true
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ScDataCompare"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
   "/sc-data/sources":
     get:
       summary: SC Data Sources
@@ -19640,6 +19685,281 @@ components:
       - UPGRADE
       - SKIN
       title: RsiHangarItemKindEnum
+    ScDataBuilds:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: object
+            properties:
+              environment:
+                type: string
+              version:
+                type: string
+              default:
+                type: boolean
+            additionalProperties: false
+            required:
+            - environment
+            - version
+            - default
+      additionalProperties: false
+      required:
+      - items
+      title: ScDataBuilds
+    ScDataCompare:
+      type: object
+      properties:
+        from:
+          type: object
+          properties:
+            environment:
+              type: string
+            version:
+              type: string
+          additionalProperties: false
+          required:
+          - environment
+          - version
+        to:
+          type: object
+          properties:
+            environment:
+              type: string
+            version:
+              type: string
+          additionalProperties: false
+          required:
+          - environment
+          - version
+        catalogues:
+          type: object
+          properties:
+            components:
+              type: object
+              properties:
+                counts:
+                  type: object
+                  properties:
+                    appeared:
+                      type: integer
+                    vanished:
+                      type: integer
+                    changed:
+                      type: integer
+                  additionalProperties: false
+                  required:
+                  - appeared
+                  - vanished
+                  - changed
+                appeared:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                vanished:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                changed:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                      fields:
+                        type: array
+                        items:
+                          type: string
+                    additionalProperties: false
+                    required:
+                    - id
+                    - fields
+              additionalProperties: false
+              required:
+              - counts
+              - appeared
+              - vanished
+              - changed
+            equipment:
+              type: object
+              properties:
+                counts:
+                  type: object
+                  properties:
+                    appeared:
+                      type: integer
+                    vanished:
+                      type: integer
+                    changed:
+                      type: integer
+                  additionalProperties: false
+                  required:
+                  - appeared
+                  - vanished
+                  - changed
+                appeared:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                vanished:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                changed:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                      fields:
+                        type: array
+                        items:
+                          type: string
+                    additionalProperties: false
+                    required:
+                    - id
+                    - fields
+              additionalProperties: false
+              required:
+              - counts
+              - appeared
+              - vanished
+              - changed
+            commodities:
+              type: object
+              properties:
+                counts:
+                  type: object
+                  properties:
+                    appeared:
+                      type: integer
+                    vanished:
+                      type: integer
+                    changed:
+                      type: integer
+                  additionalProperties: false
+                  required:
+                  - appeared
+                  - vanished
+                  - changed
+                appeared:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                vanished:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                changed:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                      fields:
+                        type: array
+                        items:
+                          type: string
+                    additionalProperties: false
+                    required:
+                    - id
+                    - fields
+              additionalProperties: false
+              required:
+              - counts
+              - appeared
+              - vanished
+              - changed
+            models:
+              type: object
+              properties:
+                counts:
+                  type: object
+                  properties:
+                    appeared:
+                      type: integer
+                    vanished:
+                      type: integer
+                    changed:
+                      type: integer
+                  additionalProperties: false
+                  required:
+                  - appeared
+                  - vanished
+                  - changed
+                appeared:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                vanished:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+                changed:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                      fields:
+                        type: array
+                        items:
+                          type: string
+                    additionalProperties: false
+                    required:
+                    - id
+                    - fields
+              additionalProperties: false
+              required:
+              - counts
+              - appeared
+              - vanished
+              - changed
+          additionalProperties: false
+          required:
+          - components
+          - equipment
+          - commodities
+          - models
+      additionalProperties: false
+      required:
+      - from
+      - to
+      - catalogues
+      title: ScDataCompare
     ScDataSources:
       type: object
       properties:

--- a/test/integration/api/v1/sc_data_compare_test.rb
+++ b/test/integration/api/v1/sc_data_compare_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::ScDataCompareTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  OLD = "1.0.0-live.1"
+  NEW = "1.0.1-live.2"
+  PTU = "1.0.2-ptu.3"
+
+  api_path "/sc-data/builds" do
+    get("SC Data Builds") do
+      operationId "scDataBuilds"
+      tags "Versions"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::V1::Schemas::ScDataBuilds
+      end
+    end
+  end
+
+  api_path "/sc-data/compare" do
+    get("Compare two SC Data builds") do
+      operationId "scDataCompare"
+      tags "Versions"
+      produces "application/json"
+
+      parameter name: "from", in: :query, schema: {type: :string}, required: true
+      parameter name: "to", in: :query, schema: {type: :string}, required: true
+
+      response(200, "successful") do
+        schema ::V1::Schemas::ScDataCompare
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  private def build_for(version, environment, component: nil, **facts)
+    create(:component_build,
+      component: component || create(:component, :without_build),
+      environment:, version:, **facts)
+  end
+
+  # --- The list of builds -----------------------------------------------------
+
+  # A different list from /sc-data/sources: that one hides everything behind the
+  # default, and reaches only as far as the config, which names one version per
+  # environment. A patch diff compares against the version before the configured
+  # one, so it has to see further.
+  test "GET /sc-data/builds lists every build there is a row for, newest first" do
+    build_for(OLD, "live")
+    build_for(NEW, "live")
+    build_for(PTU, "ptu")
+
+    assert_api_response :get, 200, api_path: "/sc-data/builds" do
+      assert_equal [PTU, NEW, OLD], parsed_body["items"].map { |item| item["version"] }
+    end
+  end
+
+  # --- The comparison ---------------------------------------------------------
+
+  test "GET /sc-data/compare reports what moved between two builds" do
+    arrived = build_for(NEW, "live").component
+    gone = build_for(OLD, "live").component
+
+    assert_api_response :get, 200, api_path: "/sc-data/compare", params: {from: OLD, to: NEW} do
+      components = parsed_body.dig("catalogues", "components")
+
+      assert_equal [arrived.id], components["appeared"]
+      assert_equal [gone.id], components["vanished"]
+      assert_equal({"appeared" => 1, "vanished" => 1, "changed" => 0}, components["counts"])
+    end
+  end
+
+  test "GET /sc-data/compare names the fields that differ" do
+    component = create(:component, :without_build)
+    build_for(OLD, "live", component:, name: "Old Name")
+    build_for(NEW, "live", component:, name: "New Name")
+
+    assert_api_response :get, 200, api_path: "/sc-data/compare", params: {from: OLD, to: NEW} do
+      change = parsed_body.dig("catalogues", "components", "changed").sole
+
+      assert_equal component.id, change["id"]
+      assert_equal "New Name", change["name"]
+      assert_equal ["name"], change["fields"]
+    end
+  end
+
+  # The axis the recorded change log cannot reach: it diffs within one
+  # environment and never answers "what does ptu have that live does not".
+  test "GET /sc-data/compare crosses environments" do
+    only_in_ptu = build_for(PTU, "ptu").component
+    build_for(NEW, "live")
+
+    assert_api_response :get, 200, api_path: "/sc-data/compare", params: {from: NEW, to: PTU} do
+      assert_equal [only_in_ptu.id], parsed_body.dig("catalogues", "components", "appeared")
+    end
+  end
+
+  # A version names its environment, so one parameter identifies a build and
+  # there is no pair to keep consistent.
+  test "GET /sc-data/compare reports the builds it compared" do
+    build_for(OLD, "live")
+    build_for(PTU, "ptu")
+
+    assert_api_response :get, 200, api_path: "/sc-data/compare", params: {from: OLD, to: PTU} do
+      assert_equal({"environment" => "live", "version" => OLD}, parsed_body["from"])
+      assert_equal({"environment" => "ptu", "version" => PTU}, parsed_body["to"])
+    end
+  end
+
+  # The parameter is well formed and names a build nothing has a row for, so it
+  # is a missing thing rather than a malformed request.
+  test "GET /sc-data/compare answers not found for a version with no build" do
+    build_for(OLD, "live")
+
+    assert_api_response :get, 404, api_path: "/sc-data/compare",
+      params: {from: OLD, to: "9.9.9-live.404"}
+  end
+end

--- a/test/lib/sc_data/build_compare_test.rb
+++ b/test/lib/sc_data/build_compare_test.rb
@@ -31,6 +31,9 @@ module ScData
     # deleted: a catalogue row the export drops keeps its row and loses its build.
     test "#call reports a record the newer build stopped describing" do
       gone = build_for(OLD).component
+      # A second record both builds describe, so the catalogue counts as
+      # recorded on either side and the rule below is the one under test.
+      build_for(NEW, component: build_for(OLD).component)
 
       assert_equal [gone.id], compare.vanished
       assert Component.exists?(gone.id), "the record itself is still there"
@@ -119,6 +122,26 @@ module ScData
         assert_equal foreign_key, ::ScData::BuildCompare.subject_key(build_class),
           "#{build_class} should be keyed on #{foreign_key}"
       end
+    end
+
+    # Commodities and models only gained build rows in 4.10.0, so a diff against
+    # 4.9.0 reported all 232 and all 215 of them as new -- which is a wrong
+    # answer rather than a surprising one.
+    test "#call reports a catalogue with no rows on one side as not recorded" do
+      build_for(NEW)
+
+      result = compare
+
+      assert_not result.recorded?
+      assert_empty result.appeared, "the lists stay empty so the flag cannot be ignored into a wrong reading"
+      assert_empty result.vanished
+    end
+
+    test "#call is recorded when both sides have rows" do
+      build_for(OLD)
+      build_for(NEW)
+
+      assert_predicate compare, :recorded?
     end
 
     test "#counts summarises without walking the lists again" do


### PR DESCRIPTION
Item 2 of #4788, on top of the engine from #4795 — the **altitude** the recorded
change log does not reach. Changes are per model today, so you can ask what
happened to the Gladius and not what happened in a build, which is the page
somebody opens when one lands.

## Two endpoints

**`/sc-data/builds`** is deliberately a different list from `/sc-data/sources`,
and the plan called that out before either existed. `sources` is what a reader
may be pointed *at*, so it hides everything behind the default — and a
comparison needs exactly what it hides. It also reaches only as far as the
config, which names one version per environment, while live `4.9.0` is no longer
configured and is precisely what a patch diff compares `4.10.0` against. So the
list is built from the build rows.

**`/sc-data/compare`** takes both sides as a bare version. A version names its
environment — `4.10.1-ptu.12578875` — so one parameter identifies a build and
there is no pair to keep consistent.

Hardpoints are left out of the four catalogues on purpose: they are per *slot*
rather than per catalogue entry, so a diff of 22,561 of them answers a ship's
loadout question and belongs on a ship, not in a summary of a build.

## The second commit is a wrong answer the real data caught

Running it over all four catalogues against the production dump, live `4.9.0`
against `4.10.0` reported **232 commodities and 215 models as new** — the entire
contents of both.

Neither has build rows for 4.9.0; they only gained them in 4.10.0. So "appeared"
was true of every row and meant nothing. A catalogue with no rows at all on one
side was **not recorded** for that build, which is a different statement from
"everything appeared". The lists are emptied rather than merely flagged, so a
reader that ignores the flag still cannot draw the wrong conclusion.

| | before | after |
| --- | --- | --- |
| components | +23 −61 ~359 | unchanged |
| equipment | +26 −0 ~187 | unchanged |
| commodities | **+232** | 0 / not recorded |
| models | **+215** | 0 / not recorded |

## One number I chased rather than waved away

The preview (live `4.10.0` → ptu `4.10.1`) reports 19 changed models, on
`ground_acceleration`, `ground_decceleration`, `ground_reverse_speed`,
`scm_speed` and `ground_max_speed`.

That is not a property of the builds. The live `ModelBuild` rows came from the
production dump — my live load reported them `unchanged=215`, so it never touched
them — and were written against the pre-#4746 tree with pre-#4779 code, while the
ptu rows were written locally against the re-parsed tree with current code. The
two sides differ in tree *and* code, not just in build. Worth stating so nobody
reads it as a finding about 4.10.1.

## Small API notes

`404` rather than a validation error for a version nothing recorded: the
parameter is well formed and names a build that does not exist.

`Source#precedence` becomes public, because an ordered list of builds needs it
and `ahead_of?` is the comparison it exists for.

**+332 lines to the public schema, none removed**; oasdiff against `main` reports
no breaking changes. 87 tests across `test/lib/sc_data/` and the new endpoint
test, green. No frontend code here — the compare UI is item 3.

🤖
