### PR TITLE
chore(db): drop the legacy hardpoint tables

### DIFF
--- a/db/migrate/20260908170000_drop_legacy_hardpoint_tables.rb
+++ b/db/migrate/20260908170000_drop_legacy_hardpoint_tables.rb
@@ -1,0 +1,53 @@
+class DropLegacyHardpointTables < ActiveRecord::Migration[8.1]
+  def up
+    drop_table :vehicle_loadout_hardpoints
+    drop_table :model_hardpoint_loadouts
+    drop_table :model_hardpoints
+  end
+
+  def down
+    create_table "model_hardpoints", id: :uuid, default: -> { "public.gen_random_uuid()" } do |t|
+      t.integer "category"
+      t.uuid "component_id"
+      t.datetime "created_at", null: false
+      t.datetime "deleted_at", precision: nil
+      t.string "details"
+      t.integer "group"
+      t.integer "hardpoint_type"
+      t.integer "item_slot"
+      t.integer "item_slots"
+      t.string "key"
+      t.string "loadout_identifier"
+      t.uuid "model_id"
+      t.string "mount"
+      t.string "name"
+      t.integer "size"
+      t.integer "source"
+      t.integer "sub_category"
+      t.datetime "updated_at", null: false
+      t.index ["component_id"], name: "index_model_hardpoints_on_component_id"
+      t.index ["model_id"], name: "index_model_hardpoints_on_model_id"
+    end
+
+    create_table "model_hardpoint_loadouts", id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.uuid "component_id"
+      t.datetime "created_at", null: false
+      t.uuid "model_hardpoint_id"
+      t.string "name"
+      t.datetime "updated_at", null: false
+    end
+
+    create_table "vehicle_loadout_hardpoints", id: :uuid, default: -> { "gen_random_uuid()" } do |t|
+      t.uuid "component_id"
+      t.datetime "created_at", null: false
+      t.uuid "model_hardpoint_id", null: false
+      t.datetime "updated_at", null: false
+      t.uuid "vehicle_loadout_id", null: false
+      t.index ["vehicle_loadout_id", "model_hardpoint_id"], name: "idx_vehicle_loadout_hardpoints_unique", unique: true
+    end
+
+    add_foreign_key "vehicle_loadout_hardpoints", "components"
+    add_foreign_key "vehicle_loadout_hardpoints", "model_hardpoints"
+    add_foreign_key "vehicle_loadout_hardpoints", "vehicle_loadouts"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_08_160000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_08_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1086,37 +1086,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_160000) do
     t.index ["model_id", "environment", "version"], name: "index_model_builds_on_model_and_build", unique: true
   end
 
-  create_table "model_hardpoint_loadouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "component_id"
-    t.datetime "created_at", null: false
-    t.uuid "model_hardpoint_id"
-    t.string "name"
-    t.datetime "updated_at", null: false
-  end
-
-  create_table "model_hardpoints", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
-    t.integer "category"
-    t.uuid "component_id"
-    t.datetime "created_at", null: false
-    t.datetime "deleted_at", precision: nil
-    t.string "details"
-    t.integer "group"
-    t.integer "hardpoint_type"
-    t.integer "item_slot"
-    t.integer "item_slots"
-    t.string "key"
-    t.string "loadout_identifier"
-    t.uuid "model_id"
-    t.string "mount"
-    t.string "name"
-    t.integer "size"
-    t.integer "source"
-    t.integer "sub_category"
-    t.datetime "updated_at", null: false
-    t.index ["component_id"], name: "index_model_hardpoints_on_component_id"
-    t.index ["model_id"], name: "index_model_hardpoints_on_model_id"
-  end
-
   create_table "model_loaners", id: :uuid, default: -> { "public.gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "hidden", default: false
@@ -1622,15 +1591,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_160000) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
-  create_table "vehicle_loadout_hardpoints", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
-    t.uuid "component_id"
-    t.datetime "created_at", null: false
-    t.uuid "model_hardpoint_id", null: false
-    t.datetime "updated_at", null: false
-    t.uuid "vehicle_loadout_id", null: false
-    t.index ["vehicle_loadout_id", "model_hardpoint_id"], name: "idx_vehicle_loadout_hardpoints_unique", unique: true
-  end
-
   create_table "vehicle_loadouts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.boolean "active", default: false, null: false
     t.datetime "created_at", null: false
@@ -1787,8 +1747,5 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_160000) do
   add_foreign_key "sc_data_unlisted_models", "models", column: "base_model_id", on_delete: :nullify
   add_foreign_key "sc_data_unlisted_models", "models", on_delete: :nullify
   add_foreign_key "supporter_contributions", "users"
-  add_foreign_key "vehicle_loadout_hardpoints", "components"
-  add_foreign_key "vehicle_loadout_hardpoints", "model_hardpoints"
-  add_foreign_key "vehicle_loadout_hardpoints", "vehicle_loadouts"
   add_foreign_key "vehicle_loadouts", "vehicles"
 end


### PR DESCRIPTION
Phase two of the legacy removal. #4772 took out the last code that touched
`model_hardpoints`, `model_hardpoint_loadouts` and `vehicle_loadout_hardpoints`;
this drops the tables — 26,258 rows, 6,077 rows and 0 rows.

Independent of #4797, so it branches from `main` rather than stacking.

## Nothing curated is lost

The game-files half of `model_hardpoints` stopped being written on 2024-05-23,
and its 6,077 loadout rows are nested sub-ports rather than named presets — the
names are game-file port names, `missile_01_attach` 938 times — which is exactly
what `hardpoints` now expresses through `parent_type: "Hardpoint"`. So there is
no preset to migrate and no slot identity to decide.

`vehicle_loadout_hardpoints` has never held a single row. The live loadout
feature is a bookmark, and I re-measured that rather than quoting the plan: all
**342** rows carry a URL to a third-party calculator and **none** is blank. The
internal half seeded from `model_hardpoints`, so it was dead code beside a dead
table.

## The deploy-order check, done properly

The pre-deploy hook migrates *before* the new containers boot, so a drop is only
safe if the release that is **running during the migration** has no reference to
the tables. Production answers `v7.13.0` on `/v1/version`, and `git tag
--contains` puts #4772 in `v7.12.0` — so it is in the deployed release and in
the one before it. The live code during the migration window already knows
nothing about these three.

*(This paragraph originally cited `v7.12.0` as the deployed release, which was
true when the PR was opened; 7.13.0 has since shipped. The check holds either
way, and is stronger now.)*

Also checked: no `paper_trail` rows for any of the three item types (0), no
factories or tests, and `create_from_defaults!` and its `from_defaults`
parameter are gone from the tree.

## Reversible, and verified as such

`down` recreates all three with their indexes and the three foreign keys, in an
order that satisfies them. I rolled it back and `git diff db/schema.rb` came
back **empty** — byte-identical to `main` — then re-applied it. Explicit
`up`/`down` rather than `change`, because a `reversible` block inside `change`
replays in reverse position and would have added the foreign keys before the
tables existed.

91 tests across `test/models/vehicle_test.rb` and `test/lib/sc_data/`, plus the
31 in the hardpoint and vehicle-loadout endpoint tests, green. `bin/ruby-lint`
clean.

🤖

