### PR TITLE
feat(admin): show what changed between two sc_data builds

### DIFF
--- a/app/api_components/v1/schemas/sc_data_compare.rb
+++ b/app/api_components/v1/schemas/sc_data_compare.rb
@@ -25,6 +25,19 @@ module V1
         required: %w[environment version]
       }.freeze
 
+      # A record identified and named. `name` is nullable because not every
+      # catalogue's build row carries one, and absent rather than blank is the
+      # honest answer when it does not.
+      ENTRY = {
+        type: :object,
+        properties: {
+          id: {type: :string, format: :uuid},
+          name: {type: [:string, :null]}
+        },
+        additionalProperties: false,
+        required: %w[id]
+      }.freeze
+
       CATALOGUE = {
         type: :object,
         properties: {
@@ -42,8 +55,8 @@ module V1
             additionalProperties: false,
             required: %w[appeared vanished changed]
           },
-          appeared: {type: :array, items: {type: :string, format: :uuid}},
-          vanished: {type: :array, items: {type: :string, format: :uuid}},
+          appeared: {type: :array, items: ENTRY},
+          vanished: {type: :array, items: ENTRY},
           changed: {
             type: :array,
             items: {

--- a/app/frontend/admin/pages/maintenance/build-compare.spec.ts
+++ b/app/frontend/admin/pages/maintenance/build-compare.spec.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { ref, nextTick } from "vue";
+
+const CATALOGUE = '[data-test="build-compare-catalogue"]';
+const NOT_RECORDED = '[data-test="build-compare-not-recorded"]';
+const ENTRY = '[data-test="build-compare-entry"]';
+const CHANGE = '[data-test="build-compare-change"]';
+const MORE = '[data-test="build-compare-more"]';
+
+const empty = () => ({
+  recorded: true,
+  counts: { appeared: 0, vanished: 0, changed: 0 },
+  appeared: [],
+  vanished: [],
+  changed: [],
+});
+
+const builds = ref<{ items: unknown[] } | undefined>(undefined);
+const comparison = ref<unknown>(undefined);
+
+vi.mock("@/services/fyApi", () => ({
+  useScDataBuilds: () => ({ data: builds, isPending: ref(false) }),
+  useScDataCompare: () => ({
+    data: comparison,
+    isPending: ref(false),
+    isError: ref(false),
+  }),
+}));
+
+vi.mock("@/shared/composables/useI18n", () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}:${JSON.stringify(params)}` : key,
+  }),
+}));
+
+import BuildComparePage from "./build-compare.vue";
+
+const mountPage = async () => {
+  const wrapper = mount(BuildComparePage, {
+    global: {
+      stubs: {
+        Heading: { template: "<div><slot /></div>" },
+        HeadingSmall: { template: "<div><slot /></div>" },
+        BasePanel: { template: "<div><slot /></div>" },
+        BasePill: { template: "<span><slot /></span>" },
+        BaseSelect: true,
+        SmallLoader: true,
+      },
+    },
+  });
+
+  await nextTick();
+
+  return wrapper;
+};
+
+const catalogueNamed = (
+  wrapper: Awaited<ReturnType<typeof mountPage>>,
+  name: string,
+) =>
+  wrapper
+    .findAll(CATALOGUE)
+    .find((panel) => panel.attributes("data-catalogue") === name)!;
+
+describe("BuildComparePage", () => {
+  beforeEach(() => {
+    builds.value = {
+      items: [
+        { environment: "ptu", version: "4.10.1-ptu", default: false },
+        { environment: "live", version: "4.10.0-live", default: true },
+      ],
+    };
+    comparison.value = undefined;
+  });
+
+  it("names what appeared and vanished rather than listing identifiers", async () => {
+    comparison.value = {
+      from: { environment: "live", version: "4.10.0-live" },
+      to: { environment: "ptu", version: "4.10.1-ptu" },
+      catalogues: {
+        components: {
+          recorded: true,
+          counts: { appeared: 1, vanished: 1, changed: 0 },
+          appeared: [{ id: "a-uuid", name: "Arrived" }],
+          vanished: [{ id: "b-uuid", name: "Departed" }],
+          changed: [],
+        },
+        equipment: empty(),
+        commodities: empty(),
+        models: empty(),
+      },
+    };
+
+    const wrapper = await mountPage();
+    const names = catalogueNamed(wrapper, "components")
+      .findAll(ENTRY)
+      .map((entry) => entry.text());
+
+    expect(names).toEqual(["Arrived", "Departed"]);
+  });
+
+  // A build row need not carry a name, and an empty row is worse than an ugly
+  // one: it gives a reader nothing at all to look up.
+  it("falls back to the identifier when a record has no name", async () => {
+    comparison.value = {
+      from: { environment: "live", version: "4.10.0-live" },
+      to: { environment: "ptu", version: "4.10.1-ptu" },
+      catalogues: {
+        components: {
+          recorded: true,
+          counts: { appeared: 1, vanished: 0, changed: 0 },
+          appeared: [{ id: "a-uuid", name: null }],
+          vanished: [],
+          changed: [],
+        },
+        equipment: empty(),
+        commodities: empty(),
+        models: empty(),
+      },
+    };
+
+    const wrapper = await mountPage();
+
+    expect(catalogueNamed(wrapper, "components").find(ENTRY).text()).toBe(
+      "a-uuid",
+    );
+  });
+
+  // The distinction the endpoint exists to make: a catalogue nobody recorded for
+  // one of the two builds must not read as one where nothing changed.
+  it("says a catalogue was not recorded instead of showing empty lists", async () => {
+    comparison.value = {
+      from: { environment: "live", version: "4.10.0-live" },
+      to: { environment: "ptu", version: "4.10.1-ptu" },
+      catalogues: {
+        components: empty(),
+        equipment: empty(),
+        commodities: {
+          recorded: false,
+          counts: { appeared: 0, vanished: 0, changed: 0 },
+          appeared: [],
+          vanished: [],
+          changed: [],
+        },
+        models: empty(),
+      },
+    };
+
+    const wrapper = await mountPage();
+
+    expect(
+      catalogueNamed(wrapper, "commodities").find(NOT_RECORDED).exists(),
+    ).toBe(true);
+    expect(
+      catalogueNamed(wrapper, "components").find(NOT_RECORDED).exists(),
+    ).toBe(false);
+  });
+
+  it("caps a long list and says how much it left out", async () => {
+    comparison.value = {
+      from: { environment: "live", version: "4.10.0-live" },
+      to: { environment: "ptu", version: "4.10.1-ptu" },
+      catalogues: {
+        components: {
+          recorded: true,
+          counts: { appeared: 0, vanished: 0, changed: 40 },
+          appeared: [],
+          vanished: [],
+          changed: Array.from({ length: 40 }, (_unused, index) => ({
+            id: `id-${index}`,
+            name: `Component ${index}`,
+            fields: ["name"],
+          })),
+        },
+        equipment: empty(),
+        commodities: empty(),
+        models: empty(),
+      },
+    };
+
+    const wrapper = await mountPage();
+    const panel = catalogueNamed(wrapper, "components");
+
+    expect(panel.findAll(CHANGE)).toHaveLength(25);
+    expect(panel.find(MORE).text()).toContain('"count":15');
+  });
+});

--- a/app/frontend/admin/pages/maintenance/build-compare.vue
+++ b/app/frontend/admin/pages/maintenance/build-compare.vue
@@ -1,0 +1,313 @@
+<script lang="ts">
+export default {
+  name: "MaintenanceBuildComparePage",
+};
+</script>
+
+<script lang="ts" setup>
+import Heading from "@/shared/components/base/Heading/index.vue";
+import HeadingSmall from "@/shared/components/base/Heading/Small/index.vue";
+import BasePanel from "@/shared/components/base/Panel/index.vue";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+import BaseSelect from "@/shared/components/base/Select/index.vue";
+import SmallLoader from "@/shared/components/SmallLoader/index.vue";
+
+import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
+import { useI18n } from "@/shared/composables/useI18n";
+import {
+  useScDataBuilds,
+  useScDataCompare,
+  type ScDataBuildsItemsItem,
+} from "@/services/fyApi";
+
+const { t } = useI18n();
+
+const { data: buildList, isPending: buildsPending } = useScDataBuilds();
+
+const builds = computed<ScDataBuildsItemsItem[]>(
+  () => buildList.value?.items || [],
+);
+
+const buildLabel = (build: ScDataBuildsItemsItem) =>
+  `${build.environment} · ${build.version}`;
+
+const buildOptions = computed(() =>
+  builds.value.map((build) => ({
+    label: buildLabel(build),
+    value: build.version,
+  })),
+);
+
+const from = ref<string | null>(null);
+const to = ref<string | null>(null);
+
+/*
+ * The two newest, which is the patch diff for whichever environment loaded
+ * last. It is a starting point rather than the interesting question -- a
+ * preview is live against ptu, and the list is ordered by build rather than
+ * grouped by environment, so no default can pick that pair on its own.
+ */
+watch(
+  builds,
+  (list) => {
+    if (from.value || to.value || list.length < 2) return;
+
+    to.value = list[0].version;
+    from.value = list[1].version;
+  },
+  { immediate: true },
+);
+
+const compareParams = computed(() => ({
+  from: from.value as string,
+  to: to.value as string,
+}));
+
+const comparable = computed(
+  () => !!from.value && !!to.value && from.value !== to.value,
+);
+
+const {
+  data: comparison,
+  isPending: comparePending,
+  isError: compareFailed,
+} = useScDataCompare(compareParams, {
+  query: { enabled: comparable },
+});
+
+const CATALOGUES = [
+  "components",
+  "equipment",
+  "commodities",
+  "models",
+] as const;
+
+type CatalogueName = (typeof CATALOGUES)[number];
+
+// The four catalogues are structurally identical but generated as four distinct
+// types, one per property of the response object, so the shared shape is spelled
+// out here rather than picked from any one of them.
+type Entry = { id: string; name?: string | null };
+type Change = { id: string; name?: string | null; fields: string[] };
+type Catalogue = {
+  recorded: boolean;
+  counts: { appeared: number; vanished: number; changed: number };
+  appeared: Entry[];
+  vanished: Entry[];
+  changed: Change[];
+};
+
+const catalogueFor = (name: CatalogueName): Catalogue | undefined =>
+  comparison.value?.catalogues?.[name] as Catalogue | undefined;
+
+/*
+ * A changed list runs to hundreds of rows -- 359 components on the pair this was
+ * built against -- and a page that renders every one of them is a page nobody
+ * scrolls to the bottom of. What is cut off is stated rather than trimmed away
+ * silently.
+ */
+const LIST_LIMIT = 25;
+
+const shown = <T,>(list: T[]) => list.slice(0, LIST_LIMIT);
+const hidden = (list: unknown[]) => Math.max(0, list.length - LIST_LIMIT);
+
+const entryName = (entry: Entry | Change) => entry.name || entry.id;
+</script>
+
+<template>
+  <Heading hero>
+    {{ t("headlines.admin.buildCompare.index") }}
+    <HeadingSmall v-if="comparison">
+      {{ comparison.from.version }} → {{ comparison.to.version }}
+    </HeadingSmall>
+  </Heading>
+
+  <div class="build-compare__picker">
+    <BaseSelect
+      v-model="from"
+      name="compare-from"
+      :options="buildOptions"
+      :nullable="false"
+      :disabled="buildsPending"
+      :label="t('labels.buildCompare.from')"
+    />
+    <BaseSelect
+      v-model="to"
+      name="compare-to"
+      :options="buildOptions"
+      :nullable="false"
+      :disabled="buildsPending"
+      :label="t('labels.buildCompare.to')"
+    />
+  </div>
+
+  <p v-if="!buildsPending && builds.length < 2" class="text-muted">
+    {{ t("labels.buildCompare.needsTwoBuilds") }}
+  </p>
+
+  <p v-else-if="!comparable" class="text-muted">
+    {{ t("labels.buildCompare.pickTwoBuilds") }}
+  </p>
+
+  <p v-else-if="compareFailed" class="text-muted">
+    {{ t("labels.buildCompare.failed") }}
+  </p>
+
+  <SmallLoader v-else-if="comparePending" />
+
+  <div v-else class="build-compare__catalogues">
+    <BasePanel
+      v-for="name in CATALOGUES"
+      :key="name"
+      class="build-compare__catalogue"
+      data-test="build-compare-catalogue"
+      :data-catalogue="name"
+    >
+      <h3>{{ t(`labels.buildCompare.catalogues.${name}`) }}</h3>
+
+      <!--
+        A catalogue with no rows on one side was never recorded for that build.
+        Saying so is the whole point: without it the answer reads as "nothing
+        changed", which is a different and wrong statement.
+      -->
+      <p
+        v-if="!catalogueFor(name)?.recorded"
+        class="text-muted"
+        data-test="build-compare-not-recorded"
+      >
+        {{ t("labels.buildCompare.notRecorded") }}
+      </p>
+
+      <template v-else>
+        <div class="build-compare__counts">
+          <BasePill
+            :variant="PillVariantsEnum.SUCCESS"
+            uppercase
+            data-test="build-compare-count-appeared"
+          >
+            {{ t("labels.buildCompare.appeared") }}
+            {{ catalogueFor(name)?.counts.appeared }}
+          </BasePill>
+          <BasePill
+            :variant="PillVariantsEnum.DANGER"
+            uppercase
+            data-test="build-compare-count-vanished"
+          >
+            {{ t("labels.buildCompare.vanished") }}
+            {{ catalogueFor(name)?.counts.vanished }}
+          </BasePill>
+          <BasePill
+            :variant="PillVariantsEnum.WARNING"
+            uppercase
+            data-test="build-compare-count-changed"
+          >
+            {{ t("labels.buildCompare.changed") }}
+            {{ catalogueFor(name)?.counts.changed }}
+          </BasePill>
+        </div>
+
+        <template
+          v-for="list in [
+            { key: 'appeared', entries: catalogueFor(name)?.appeared || [] },
+            { key: 'vanished', entries: catalogueFor(name)?.vanished || [] },
+          ]"
+          :key="list.key"
+        >
+          <div v-if="list.entries.length" class="build-compare__list">
+            <h4>{{ t(`labels.buildCompare.${list.key}`) }}</h4>
+            <ul>
+              <li
+                v-for="entry in shown(list.entries)"
+                :key="entry.id"
+                data-test="build-compare-entry"
+              >
+                {{ entryName(entry) }}
+              </li>
+            </ul>
+            <p
+              v-if="hidden(list.entries)"
+              class="text-muted"
+              data-test="build-compare-more"
+            >
+              {{
+                t("labels.buildCompare.andMore", {
+                  count: hidden(list.entries),
+                })
+              }}
+            </p>
+          </div>
+        </template>
+
+        <div
+          v-if="catalogueFor(name)?.changed.length"
+          class="build-compare__list"
+        >
+          <h4>{{ t("labels.buildCompare.changed") }}</h4>
+          <ul>
+            <li
+              v-for="change in shown(catalogueFor(name)?.changed || [])"
+              :key="change.id"
+              data-test="build-compare-change"
+            >
+              {{ entryName(change) }}
+              <span class="text-muted">{{ change.fields.join(", ") }}</span>
+            </li>
+          </ul>
+          <p
+            v-if="hidden(catalogueFor(name)?.changed || [])"
+            class="text-muted"
+            data-test="build-compare-more"
+          >
+            {{
+              t("labels.buildCompare.andMore", {
+                count: hidden(catalogueFor(name)?.changed || []),
+              })
+            }}
+          </p>
+        </div>
+      </template>
+    </BasePanel>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.build-compare__picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
+
+  > * {
+    flex: 1 1 18rem;
+  }
+}
+
+.build-compare__catalogues {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+}
+
+.build-compare__counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.build-compare__list {
+  margin-top: 1rem;
+
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  li {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: space-between;
+  }
+}
+</style>

--- a/app/frontend/admin/pages/maintenance/routes.ts
+++ b/app/frontend/admin/pages/maintenance/routes.ts
@@ -32,6 +32,20 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    // Behind `imports` rather than a privilege of its own: the page reads what
+    // an import wrote, and nobody who may not see the ledger has a use for a
+    // diff of two of its results.
+    path: "/build-compare/",
+    name: "build-compare",
+    component: () => import("@/admin/pages/maintenance/build-compare.vue"),
+    meta: {
+      title: "admin.maintenance.buildCompare",
+      icon: "fa-duotone fa-code-compare",
+      needsAuthentication: true,
+      access: ["imports"],
+    },
+  },
+  {
     path: "/features/",
     name: "admin-features",
     component: () => import("@/admin/pages/maintenance/features.vue"),

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -171,6 +171,9 @@
         "visualTests": {
           "index": "Visuelle Tests",
           "notifications": "Benachrichtigungen"
+        },
+        "buildCompare": {
+          "index": "Build-Vergleich"
         }
       },
       "welcome": "Willkommen auf",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -2193,6 +2193,24 @@
         "wishlist": "Wunschlisten-Zuwachs pro Monat",
         "patchChanges": "Patch-Änderungen",
         "notRecordedYet": "Wird erst seit dem Start der Aufzeichnung erfasst, ein Schiff kann also noch nichts haben."
+      },
+      "buildCompare": {
+        "from": "Von Build",
+        "to": "Zu Build",
+        "appeared": "Neu",
+        "vanished": "Entfallen",
+        "changed": "Geändert",
+        "notRecorded": "Für einen dieser Builds nicht erfasst.",
+        "needsTwoBuilds": "Es ist nur ein Build erfasst, es gibt also nichts zu vergleichen.",
+        "pickTwoBuilds": "Wähle zwei verschiedene Builds.",
+        "failed": "Diese beiden Builds konnten nicht verglichen werden.",
+        "andMore": "und %{count} weitere",
+        "catalogues": {
+          "components": "Komponenten",
+          "equipment": "Ausrüstung",
+          "commodities": "Waren",
+          "models": "Schiffe"
+        }
       }
     }
   }

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -237,7 +237,8 @@
           "workers": "Worker",
           "tasks": "Aufgaben",
           "imports": "Importe",
-          "rsiApiStatus": "RSI-API-Status"
+          "rsiApiStatus": "RSI-API-Status",
+          "buildCompare": "Build-Vergleich"
         },
         "supporterContributions": {
           "index": "Unterstützer-Beiträge",

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -250,7 +250,8 @@
           "tasks": "Aufgaben",
           "imports": "Importe",
           "importDetail": "Import-Details",
-          "rsiApiStatus": "RSI-API-Status"
+          "rsiApiStatus": "RSI-API-Status",
+          "buildCompare": "Build-Vergleich"
         },
         "modelPaints": {
           "index": "Modell Lackierungen",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -163,6 +163,9 @@
         "visualTests": {
           "index": "Visual Tests",
           "notifications": "Notifications"
+        },
+        "buildCompare": {
+          "index": "Build Compare"
         }
       },
       "welcome": "Welcome to",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -2190,6 +2190,24 @@
         "wishlist": "Wishlist Additions per Month",
         "patchChanges": "Patch Changes",
         "notRecordedYet": "Only recorded from the day this started, so a ship can have none yet."
+      },
+      "buildCompare": {
+        "from": "From build",
+        "to": "To build",
+        "appeared": "Appeared",
+        "vanished": "Vanished",
+        "changed": "Changed",
+        "notRecorded": "Not recorded for one of these builds.",
+        "needsTwoBuilds": "Only one build is on record, so there is nothing to compare it with.",
+        "pickTwoBuilds": "Pick two different builds.",
+        "failed": "Could not compare these two builds.",
+        "andMore": "and %{count} more",
+        "catalogues": {
+          "components": "Components",
+          "equipment": "Equipment",
+          "commodities": "Commodities",
+          "models": "Ships"
+        }
       }
     }
   }

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -237,7 +237,8 @@
           "workers": "Workers",
           "tasks": "Tasks",
           "imports": "Imports",
-          "rsiApiStatus": "RSI API Status"
+          "rsiApiStatus": "RSI API Status",
+          "buildCompare": "Build Compare"
         },
         "supporterContributions": {
           "index": "Supporter Contributions",

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -250,7 +250,8 @@
           "tasks": "Tasks",
           "imports": "Imports",
           "importDetail": "Import Detail",
-          "rsiApiStatus": "RSI API Status"
+          "rsiApiStatus": "RSI API Status",
+          "buildCompare": "Build Compare"
         },
         "modelPaints": {
           "index": "Model Paints",

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -171,6 +171,9 @@
         "visualTests": {
           "index": "Pruebas Visuales",
           "notifications": "Notificaciones"
+        },
+        "buildCompare": {
+          "index": "Comparar compilaciones"
         }
       },
       "welcome": "Welcome to",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -2193,6 +2193,24 @@
         "wishlist": "Adiciones a la lista de deseos por mes",
         "patchChanges": "Cambios del parche",
         "notRecordedYet": "Solo se registra desde que empezó el seguimiento, así que una nave puede no tener nada."
+      },
+      "buildCompare": {
+        "from": "Desde la compilación",
+        "to": "Hasta la compilación",
+        "appeared": "Nuevos",
+        "vanished": "Desaparecidos",
+        "changed": "Modificados",
+        "notRecorded": "No registrado para una de estas compilaciones.",
+        "needsTwoBuilds": "Solo hay una compilación registrada, así que no hay nada con que compararla.",
+        "pickTwoBuilds": "Elige dos compilaciones distintas.",
+        "failed": "No se han podido comparar estas dos compilaciones.",
+        "andMore": "y %{count} más",
+        "catalogues": {
+          "components": "Componentes",
+          "equipment": "Equipamiento",
+          "commodities": "Mercancías",
+          "models": "Naves"
+        }
       }
     }
   }

--- a/app/frontend/translations/es/nav.json
+++ b/app/frontend/translations/es/nav.json
@@ -237,7 +237,8 @@
           "workers": "Trabajadores",
           "tasks": "Tareas",
           "imports": "Importaciones",
-          "rsiApiStatus": "Estado API RSI"
+          "rsiApiStatus": "Estado API RSI",
+          "buildCompare": "Comparar compilaciones"
         },
         "supporterContributions": {
           "index": "Contribuciones de patrocinadores",

--- a/app/frontend/translations/es/title.json
+++ b/app/frontend/translations/es/title.json
@@ -250,7 +250,8 @@
           "tasks": "Tareas",
           "imports": "Importaciones",
           "importDetail": "Detalle de la importación",
-          "rsiApiStatus": "Estado de API RSI"
+          "rsiApiStatus": "Estado de API RSI",
+          "buildCompare": "Comparar compilaciones"
         },
         "modelPaints": {
           "index": "Pinturas de Modelos",

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -171,6 +171,9 @@
         "visualTests": {
           "index": "Tests Visuels",
           "notifications": "Notifications"
+        },
+        "buildCompare": {
+          "index": "Comparer les builds"
         }
       },
       "welcome": "Bienvenue sur",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -2197,6 +2197,24 @@
         "wishlist": "Ajouts en liste de souhaits par mois",
         "patchChanges": "Modifications de patch",
         "notRecordedYet": "Enregistré seulement depuis le début du suivi, un vaisseau peut donc n'avoir rien."
+      },
+      "buildCompare": {
+        "from": "Depuis le build",
+        "to": "Vers le build",
+        "appeared": "Apparus",
+        "vanished": "Disparus",
+        "changed": "Modifiés",
+        "notRecorded": "Non enregistré pour l'un de ces builds.",
+        "needsTwoBuilds": "Un seul build est enregistré, il n'y a donc rien à comparer.",
+        "pickTwoBuilds": "Choisis deux builds différents.",
+        "failed": "Impossible de comparer ces deux builds.",
+        "andMore": "et %{count} de plus",
+        "catalogues": {
+          "components": "Composants",
+          "equipment": "Équipement",
+          "commodities": "Marchandises",
+          "models": "Vaisseaux"
+        }
       }
     }
   }

--- a/app/frontend/translations/fr/nav.json
+++ b/app/frontend/translations/fr/nav.json
@@ -237,7 +237,8 @@
           "workers": "Travailleurs",
           "tasks": "Tâches",
           "imports": "Imports",
-          "rsiApiStatus": "État API RSI"
+          "rsiApiStatus": "État API RSI",
+          "buildCompare": "Comparer les builds"
         },
         "supporterContributions": {
           "index": "Contributions des soutiens",

--- a/app/frontend/translations/fr/title.json
+++ b/app/frontend/translations/fr/title.json
@@ -250,7 +250,8 @@
           "tasks": "Tâches",
           "imports": "Imports",
           "importDetail": "Détail de l'import",
-          "rsiApiStatus": "Statut de l'API RSI"
+          "rsiApiStatus": "Statut de l'API RSI",
+          "buildCompare": "Comparer les builds"
         },
         "modelPaints": {
           "index": "Peintures de Modèles",

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -171,6 +171,9 @@
         "visualTests": {
           "index": "Test Visivi",
           "notifications": "Notifiche"
+        },
+        "buildCompare": {
+          "index": "Confronto build"
         }
       },
       "welcome": "Benvenuto su",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -2193,6 +2193,24 @@
         "wishlist": "Aggiunte alla lista dei desideri per mese",
         "patchChanges": "Modifiche della patch",
         "notRecordedYet": "Registrato solo da quando è iniziato il tracciamento, quindi una nave può non avere nulla."
+      },
+      "buildCompare": {
+        "from": "Dalla build",
+        "to": "Alla build",
+        "appeared": "Comparsi",
+        "vanished": "Scomparsi",
+        "changed": "Modificati",
+        "notRecorded": "Non registrato per una di queste build.",
+        "needsTwoBuilds": "È registrata una sola build, quindi non c'è nulla con cui confrontarla.",
+        "pickTwoBuilds": "Scegli due build diverse.",
+        "failed": "Impossibile confrontare queste due build.",
+        "andMore": "e altri %{count}",
+        "catalogues": {
+          "components": "Componenti",
+          "equipment": "Equipaggiamento",
+          "commodities": "Merci",
+          "models": "Navi"
+        }
       }
     }
   }

--- a/app/frontend/translations/it/nav.json
+++ b/app/frontend/translations/it/nav.json
@@ -237,7 +237,8 @@
           "workers": "Worker",
           "tasks": "Attività",
           "imports": "Importazioni",
-          "rsiApiStatus": "Stato API RSI"
+          "rsiApiStatus": "Stato API RSI",
+          "buildCompare": "Confronto build"
         },
         "supporterContributions": {
           "index": "Contributi dei sostenitori",

--- a/app/frontend/translations/it/title.json
+++ b/app/frontend/translations/it/title.json
@@ -250,7 +250,8 @@
           "tasks": "Attività",
           "imports": "Importazioni",
           "importDetail": "Dettaglio importazione",
-          "rsiApiStatus": "Stato API RSI"
+          "rsiApiStatus": "Stato API RSI",
+          "buildCompare": "Confronto build"
         },
         "modelPaints": {
           "index": "Verniciature Modelli",

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -171,6 +171,9 @@
         "visualTests": {
           "index": "视觉测试",
           "notifications": "通知"
+        },
+        "buildCompare": {
+          "index": "版本对比"
         }
       },
       "welcome": "Welcome to",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -2189,6 +2189,24 @@
         "wishlist": "每月心愿单新增",
         "patchChanges": "更新改动",
         "notRecordedYet": "仅从开始记录之日起统计，因此飞船可能尚无记录。"
+      },
+      "buildCompare": {
+        "from": "起始版本",
+        "to": "目标版本",
+        "appeared": "新增",
+        "vanished": "移除",
+        "changed": "变更",
+        "notRecorded": "其中一个版本没有记录该目录。",
+        "needsTwoBuilds": "只记录了一个版本，无法进行对比。",
+        "pickTwoBuilds": "请选择两个不同的版本。",
+        "failed": "无法对比这两个版本。",
+        "andMore": "还有 %{count} 项",
+        "catalogues": {
+          "components": "部件",
+          "equipment": "装备",
+          "commodities": "商品",
+          "models": "舰船"
+        }
       }
     }
   }

--- a/app/frontend/translations/zh-CN/nav.json
+++ b/app/frontend/translations/zh-CN/nav.json
@@ -237,7 +237,8 @@
           "workers": "工作进程",
           "tasks": "任务",
           "imports": "导入",
-          "rsiApiStatus": "RSI API 状态"
+          "rsiApiStatus": "RSI API 状态",
+          "buildCompare": "版本对比"
         },
         "supporterContributions": {
           "index": "支持者贡献",

--- a/app/frontend/translations/zh-CN/title.json
+++ b/app/frontend/translations/zh-CN/title.json
@@ -250,7 +250,8 @@
           "tasks": "任务",
           "imports": "导入",
           "importDetail": "导入详情",
-          "rsiApiStatus": "RSI API 状态"
+          "rsiApiStatus": "RSI API 状态",
+          "buildCompare": "版本对比"
         },
         "modelPaints": {
           "index": "模型涂装",

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -171,6 +171,9 @@
         "visualTests": {
           "index": "視覺測試",
           "notifications": "通知"
+        },
+        "buildCompare": {
+          "index": "版本比較"
         }
       },
       "welcome": "Welcome to",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -2189,6 +2189,24 @@
         "wishlist": "每月願望清單新增",
         "patchChanges": "更新改動",
         "notRecordedYet": "僅從開始記錄之日起統計，因此飛船可能尚無記錄。"
+      },
+      "buildCompare": {
+        "from": "起始版本",
+        "to": "目標版本",
+        "appeared": "新增",
+        "vanished": "移除",
+        "changed": "變更",
+        "notRecorded": "其中一個版本沒有記錄該目錄。",
+        "needsTwoBuilds": "只記錄了一個版本，無法進行比較。",
+        "pickTwoBuilds": "請選擇兩個不同的版本。",
+        "failed": "無法比較這兩個版本。",
+        "andMore": "還有 %{count} 項",
+        "catalogues": {
+          "components": "部件",
+          "equipment": "裝備",
+          "commodities": "商品",
+          "models": "艦船"
+        }
       }
     }
   }

--- a/app/frontend/translations/zh-TW/nav.json
+++ b/app/frontend/translations/zh-TW/nav.json
@@ -237,7 +237,8 @@
           "workers": "工作程序",
           "tasks": "任務",
           "imports": "匯入",
-          "rsiApiStatus": "RSI API 狀態"
+          "rsiApiStatus": "RSI API 狀態",
+          "buildCompare": "版本比較"
         },
         "supporterContributions": {
           "index": "支持者貢獻",

--- a/app/frontend/translations/zh-TW/title.json
+++ b/app/frontend/translations/zh-TW/title.json
@@ -250,7 +250,8 @@
           "tasks": "任務",
           "imports": "匯入",
           "importDetail": "匯入詳情",
-          "rsiApiStatus": "RSI API 狀態"
+          "rsiApiStatus": "RSI API 狀態",
+          "buildCompare": "版本比較"
         },
         "modelPaints": {
           "index": "模型塗裝",

--- a/app/lib/sc_data/build_compare.rb
+++ b/app/lib/sc_data/build_compare.rb
@@ -28,6 +28,11 @@ module ScData
       alias_method :recorded?, :recorded
     end
 
+    # A record named as well as identified. The UUID is what a reader drills
+    # into; the name is the only half a person can read, and both lists are
+    # otherwise a column of identifiers nobody can act on.
+    Entry = Struct.new(:id, :name)
+
     Change = Struct.new(:id, :name, :fields)
 
     attr_reader :build_class, :from, :to
@@ -108,11 +113,13 @@ module ScData
     end
 
     private def appeared
-      to_rows.keys - from_rows.keys
+      (to_rows.keys - from_rows.keys).map { |id| Entry.new(id:, name: to_rows[id]["name"]) }
     end
 
+    # Named from the older build, which is the only side that still describes
+    # the record: the newer one has no row for it at all.
     private def vanished
-      from_rows.keys - to_rows.keys
+      (from_rows.keys - to_rows.keys).map { |id| Entry.new(id:, name: from_rows[id]["name"]) }
     end
 
     private def changed

--- a/app/views/api/v1/sc_data/compare.jbuilder
+++ b/app/views/api/v1/sc_data/compare.jbuilder
@@ -21,8 +21,19 @@ json.catalogues do
 
       json.counts result.counts
 
-      json.appeared result.appeared
-      json.vanished result.vanished
+      json.appeared do
+        json.array! result.appeared do |entry|
+          json.id entry.id
+          json.name entry.name
+        end
+      end
+
+      json.vanished do
+        json.array! result.vanished do |entry|
+          json.id entry.id
+          json.name entry.name
+        end
+      end
 
       # The changes carry the fields that differ, so a reader can pick the ones
       # it cares about -- a rename is the interesting one, and it is a change on

--- a/swagger/v1/oasdiff-ignore.txt
+++ b/swagger/v1/oasdiff-ignore.txt
@@ -991,3 +991,11 @@ POST /vehicles/{vehicle_id}/loadouts removed the request property `fromDefaults`
 POST /vehicles/{vehicle_id}/loadouts removed the request property `vehicleLoadoutHardpointsAttributes`
 PUT /vehicles/{vehicle_id}/loadouts/{id} removed the request property `fromDefaults`
 PUT /vehicles/{vehicle_id}/loadouts/{id} removed the request property `vehicleLoadoutHardpointsAttributes`
+GET /sc-data/compare the `catalogues/commodities/appeared/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
+GET /sc-data/compare the `catalogues/commodities/vanished/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
+GET /sc-data/compare the `catalogues/components/appeared/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
+GET /sc-data/compare the `catalogues/components/vanished/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
+GET /sc-data/compare the `catalogues/equipment/appeared/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
+GET /sc-data/compare the `catalogues/equipment/vanished/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
+GET /sc-data/compare the `catalogues/models/appeared/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
+GET /sc-data/compare the `catalogues/models/vanished/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -19758,13 +19758,33 @@ components:
                 appeared:
                   type: array
                   items:
-                    type: string
-                    format: uuid
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                    additionalProperties: false
+                    required:
+                    - id
                 vanished:
                   type: array
                   items:
-                    type: string
-                    format: uuid
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                    additionalProperties: false
+                    required:
+                    - id
                 changed:
                   type: array
                   items:
@@ -19814,13 +19834,33 @@ components:
                 appeared:
                   type: array
                   items:
-                    type: string
-                    format: uuid
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                    additionalProperties: false
+                    required:
+                    - id
                 vanished:
                   type: array
                   items:
-                    type: string
-                    format: uuid
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                    additionalProperties: false
+                    required:
+                    - id
                 changed:
                   type: array
                   items:
@@ -19870,13 +19910,33 @@ components:
                 appeared:
                   type: array
                   items:
-                    type: string
-                    format: uuid
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                    additionalProperties: false
+                    required:
+                    - id
                 vanished:
                   type: array
                   items:
-                    type: string
-                    format: uuid
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                    additionalProperties: false
+                    required:
+                    - id
                 changed:
                   type: array
                   items:
@@ -19926,13 +19986,33 @@ components:
                 appeared:
                   type: array
                   items:
-                    type: string
-                    format: uuid
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                    additionalProperties: false
+                    required:
+                    - id
                 vanished:
                   type: array
                   items:
-                    type: string
-                    format: uuid
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      name:
+                        type:
+                        - string
+                        - 'null'
+                    additionalProperties: false
+                    required:
+                    - id
                 changed:
                   type: array
                   items:

--- a/test/integration/api/v1/sc_data_compare_test.rb
+++ b/test/integration/api/v1/sc_data_compare_test.rb
@@ -73,8 +73,8 @@ class Api::V1::ScDataCompareTest < ActionDispatch::IntegrationTest
     assert_api_response :get, 200, api_path: "/sc-data/compare", params: {from: OLD, to: NEW} do
       components = parsed_body.dig("catalogues", "components")
 
-      assert_equal [arrived.id], components["appeared"]
-      assert_equal [gone.id], components["vanished"]
+      assert_equal [arrived.id], components["appeared"].map { |entry| entry["id"] }
+      assert_equal [gone.id], components["vanished"].map { |entry| entry["id"] }
       assert_equal({"appeared" => 1, "vanished" => 1, "changed" => 0}, components["counts"])
     end
   end
@@ -100,7 +100,9 @@ class Api::V1::ScDataCompareTest < ActionDispatch::IntegrationTest
     build_for(NEW, "live")
 
     assert_api_response :get, 200, api_path: "/sc-data/compare", params: {from: NEW, to: PTU} do
-      assert_equal [only_in_ptu.id], parsed_body.dig("catalogues", "components", "appeared")
+      appeared = parsed_body.dig("catalogues", "components", "appeared")
+
+      assert_equal [only_in_ptu.id], appeared.map { |entry| entry["id"] }
     end
   end
 

--- a/test/lib/sc_data/build_compare_test.rb
+++ b/test/lib/sc_data/build_compare_test.rb
@@ -24,7 +24,7 @@ module ScData
       arrived = build_for(NEW).component
       build_for(OLD)
 
-      assert_equal [arrived.id], compare.appeared
+      assert_equal [arrived.id], compare.appeared.map(&:id)
     end
 
     # "Vanished" means the newer build has no row for it, not that anything was
@@ -35,8 +35,26 @@ module ScData
       # recorded on either side and the rule below is the one under test.
       build_for(NEW, component: build_for(OLD).component)
 
-      assert_equal [gone.id], compare.vanished
+      assert_equal [gone.id], compare.vanished.map(&:id)
       assert Component.exists?(gone.id), "the record itself is still there"
+    end
+
+    # Both lists are a column of identifiers without this, which nobody can read
+    # and nothing can act on.
+    test "#call names what appeared, from the build that describes it" do
+      build_for(NEW, name: "Arrived")
+      build_for(OLD)
+
+      assert_equal ["Arrived"], compare.appeared.map(&:name)
+    end
+
+    # The newer build has no row for a vanished record, so the older one is the
+    # only side left that can name it.
+    test "#call names what vanished, from the build that still describes it" do
+      build_for(OLD, name: "Departed")
+      build_for(NEW, component: build_for(OLD).component)
+
+      assert_equal ["Departed"], compare.vanished.map(&:name)
     end
 
     test "#call names the facts that differ on a record both builds describe" do
@@ -70,7 +88,7 @@ module ScData
 
       result = compare(from: NEW, to: PTU)
 
-      assert_equal [only_in_ptu.id], result.appeared
+      assert_equal [only_in_ptu.id], result.appeared.map(&:id)
     end
 
     # --- What a comparison looks at --------------------------------------------


### PR DESCRIPTION
The reader for the comparison #4795 and #4797 built. Two build pickers, then a
panel per catalogue with counts, what appeared, what vanished, and what changed
with the fields that differ.

Branches from `main`, not stacked on anything.

## One thing had to change first

`changed` already carried a name. `appeared` and `vanished` were bare UUID
arrays — so the two lists a reader most wants to scan were the two nothing could
display. Both now carry `{id, name}`, taken from whichever build still describes
the record: the newer one for `appeared`, the older one for `vanished`. The name
costs nothing to produce, because `rows_for` already plucks it for the change
diff.

**This changes a response shape, and `oasdiff` says so eight times over** — once
per list per catalogue. I added the ignore entries rather than working around
it, and the reason is narrow: the endpoint merged in #4797, is not in any
released tag (production is on `v7.12.0`), and has therefore never been
consumed. The alternative is a permanent UUID-only list plus a second round trip
per row to make it readable. The entries protect nothing once `main` carries the
new shape and can be deleted in a follow-up.

## Decisions worth naming

**Behind the `imports` privilege**, not a new one. The page reads what an import
wrote, and nobody who may not see the ledger has a use for a diff of two of its
results. Inventing a privilege would also mean touching
`AdminUserPrivilegesTest`'s drift list for no gain.

**The two newest builds are preselected** — the patch diff for whichever
environment loaded last. That is a starting point, not the interesting question:
a preview is live-against-ptu, and the list is ordered by build rather than
grouped by environment, so no default can pick that pair on its own.

**Lists cap at 25 and say what they left out.** The pair this was built against
has 359 changed components; a page that renders all of them is a page nobody
reaches the bottom of. A silent truncation would read as "that's all there is".

**Four identical types, one shape.** orval generates
`ScDataCompareCatalogues{Components,Equipment,Commodities,Models}` separately, so
the page spells the shared shape out once rather than picking one arbitrarily.

## Verification

I could not check this against a live server: the running dev server belongs to
the main checkout, and starting one for this worktree needs a 1Password unlock I
cannot answer from here. So the page is verified by **four component tests**
instead, which cover the logic rather than the styling:

- names are shown for `appeared` and `vanished`, not identifiers
- a record with no name falls back to its id — an empty row would give a reader
  nothing to look up
- `recorded: false` renders the "not recorded" note and no lists, so the
  distinction the endpoint exists to make survives into the UI
- a 40-item list renders 25 rows and reports 15 more

Also green: 20 Ruby tests across `BuildCompare` and the endpoint (two new ones
covering the names), `bin/ruby-lint`, `pnpm lint:ts`, `pnpm lint:js`, prettier,
and `oasdiff` with the entries in place.

Translated in all seven locales by hand — Crowdin is not in use here, so an
en-only key never reaches the other six.

🤖
