### PR TITLE
refactor(sc_data): make build retention a property of the environment

### DIFF
--- a/app/lib/sc_data/build_compare.rb
+++ b/app/lib/sc_data/build_compare.rb
@@ -5,8 +5,10 @@ module ScData
   # builds.
   #
   # Computed rather than recorded, and that is the point of doing this half
-  # first: every catalogue retains `BUILDS_RETAINED` builds per environment, so
-  # the two sides of a comparison are both present and the answer is a join. Only
+  # first: every catalogue retains several builds per environment -- see
+  # `ScData::Source::BUILDS_RETAINED` for how many, which differs per
+  # environment -- so the two sides of a comparison are both present and the
+  # answer is a join. Only
   # history that has to outlive those retained builds needs a table --
   # `ModelBuildChange` is that, for models, within one environment.
   #

--- a/app/lib/sc_data/source.rb
+++ b/app/lib/sc_data/source.rb
@@ -9,7 +9,33 @@ module ScData
   # rather than reaching into `Rails.configuration` from a model or a job is what
   # made that possible without touching the eighty-odd callers.
   class Source
+    # How many builds of an environment to keep. Retention is a property of the
+    # environment rather than of a catalogue, which is why it lives here rather
+    # than six times over as a constant on each build class.
+    #
+    # The two environments are asked different questions. Live carries the patch
+    # history a reader may cite, so it keeps enough to diff a patch against the
+    # one before it and still have the one before that to fall back on when a
+    # load goes wrong. A ptu build is only ever asked "what does this have that
+    # live does not" and "what changed since the last preview" -- both answered
+    # by the current build and one behind it -- and a ptu cycle produces builds
+    # several times a week, so a third would be paid for constantly and read
+    # never.
+    #
+    # Pruning is per environment, so this is genuinely independent: a week of
+    # ptu builds can never displace a live one.
+    BUILDS_RETAINED = {"live" => 3, "ptu" => 2}.freeze
+
+    # An environment nobody listed keeps the larger number. A pruned build row
+    # cannot be recovered, so a channel this policy has not considered errs
+    # towards keeping rather than towards tidiness.
+    BUILDS_RETAINED_DEFAULT = 3
+
     class << self
+      def builds_retained(environment)
+        BUILDS_RETAINED.fetch(environment.to_s, BUILDS_RETAINED_DEFAULT)
+      end
+
       # The source the work in hand is reading: what a request asked for, else
       # the configured default.
       #

--- a/app/models/commodity_build.rb
+++ b/app/models/commodity_build.rb
@@ -33,11 +33,6 @@
 class CommodityBuild < ApplicationRecord
   belongs_to :commodity
 
-  # How many builds of one environment are kept. Enough to diff a patch against
-  # the one before it, and to compare a bad load with what it replaced, without
-  # the table growing with every patch forever.
-  BUILDS_RETAINED = 3
-
   # Everything a build says, as opposed to what identifies the commodity. Three
   # facts -- this catalogue has no enums, no serialized columns and no
   # manufacturer, which is why it fits in one change rather than three.
@@ -76,7 +71,7 @@ class CommodityBuild < ApplicationRecord
   # The versions worth keeping for one environment, ordered by when they first
   # appeared. Re-loading a build updates its rows in place, so `created_at` is
   # when that build first landed rather than when it was last touched.
-  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+  def self.retained_versions(environment, keep: ::ScData::Source.builds_retained(environment))
     where(environment:)
       .group(:version)
       .minimum(:created_at)

--- a/app/models/component_build.rb
+++ b/app/models/component_build.rb
@@ -54,11 +54,6 @@ class ComponentBuild < ApplicationRecord
   belongs_to :component
   belongs_to :manufacturer, optional: true
 
-  # How many builds of one environment are kept. Enough to diff a patch against
-  # the one before it, and to compare a bad load with what it replaced, without
-  # the table growing with every patch forever.
-  BUILDS_RETAINED = 3
-
   # Everything a build says, as opposed to what identifies the component. Taken
   # from Component's own paper_trail list, which already named the specs that move
   # between builds, plus `category` -- the loader writes it and it decides
@@ -134,7 +129,7 @@ class ComponentBuild < ApplicationRecord
   # The versions worth keeping for one environment, ordered by when they first
   # appeared. Re-loading a build updates its rows in place, so `created_at` is
   # when that build first landed rather than when it was last touched.
-  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+  def self.retained_versions(environment, keep: ::ScData::Source.builds_retained(environment))
     where(environment:)
       .group(:version)
       .minimum(:created_at)

--- a/app/models/equipment_build.rb
+++ b/app/models/equipment_build.rb
@@ -56,11 +56,6 @@ class EquipmentBuild < ApplicationRecord
   belongs_to :equipment
   belongs_to :manufacturer, optional: true
 
-  # How many builds of one environment are kept. Enough to diff a patch against
-  # the one before it, and to compare a bad load with what it replaced, without
-  # the table growing with every patch forever.
-  BUILDS_RETAINED = 3
-
   # Everything a build says, as opposed to what identifies the item. The data
   # migration carries its own copy on purpose: a migration has to keep running
   # against the schema of its own moment, not this list as it later becomes.
@@ -123,7 +118,7 @@ class EquipmentBuild < ApplicationRecord
   # The versions worth keeping for one environment, ordered by when they first
   # appeared. Re-loading a build updates its rows in place, so `created_at` is
   # when that build first landed rather than when it was last touched.
-  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+  def self.retained_versions(environment, keep: ::ScData::Source.builds_retained(environment))
     where(environment:)
       .group(:version)
       .minimum(:created_at)

--- a/app/models/hardpoint_build.rb
+++ b/app/models/hardpoint_build.rb
@@ -48,10 +48,6 @@ class HardpointBuild < ApplicationRecord
   belongs_to :hardpoint
   belongs_to :component, optional: true
 
-  # How many builds of one environment are kept, matching the catalogues: enough
-  # to diff a patch against the one before it without the table growing forever.
-  BUILDS_RETAINED = 3
-
   # Everything a build says, as opposed to what identifies the slot. `parent`,
   # `sc_name` and `source` are the identity and stay on the row; `matrix_key` and
   # `details` stay too -- neither is written by a load.
@@ -109,7 +105,7 @@ class HardpointBuild < ApplicationRecord
   # The versions worth keeping for one environment, ordered by when they first
   # appeared. Re-loading a build updates its rows in place, so `created_at` is
   # when that build first landed rather than when it was last touched.
-  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+  def self.retained_versions(environment, keep: ::ScData::Source.builds_retained(environment))
     where(environment:)
       .group(:version)
       .minimum(:created_at)

--- a/app/models/model_build.rb
+++ b/app/models/model_build.rb
@@ -59,11 +59,6 @@
 class ModelBuild < ApplicationRecord
   belongs_to :model
 
-  # How many builds of one environment are kept. Enough to diff a patch against
-  # the one before it, and to compare a bad load with what it replaced, without
-  # the table growing with every patch forever.
-  BUILDS_RETAINED = 3
-
   # Everything a build says about a model's mechanics.
   #
   # The data migration carries its own copy on purpose: a migration has to keep
@@ -130,7 +125,7 @@ class ModelBuild < ApplicationRecord
   # The versions worth keeping for one environment, ordered by when they first
   # appeared. Re-loading a build updates its rows in place, so `created_at` is
   # when that build first landed rather than when it was last touched.
-  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+  def self.retained_versions(environment, keep: ::ScData::Source.builds_retained(environment))
     where(environment:)
       .group(:version)
       .minimum(:created_at)

--- a/app/models/model_module_build.rb
+++ b/app/models/model_module_build.rb
@@ -35,9 +35,6 @@
 class ModelModuleBuild < ApplicationRecord
   belongs_to :model_module
 
-  # How many builds of one environment are kept, matching the other catalogues.
-  BUILDS_RETAINED = 3
-
   # Everything a build says, as opposed to what identifies or curates the
   # module. `name`, `slug`, the prices, `manufacturer_id`, `active` and `hidden`
   # are Fleetyards' own and stay on the row.
@@ -82,7 +79,7 @@ class ModelModuleBuild < ApplicationRecord
 
   # The versions worth keeping for one environment, ordered by when they first
   # appeared.
-  def self.retained_versions(environment, keep: BUILDS_RETAINED)
+  def self.retained_versions(environment, keep: ::ScData::Source.builds_retained(environment))
     where(environment:)
       .group(:version)
       .minimum(:created_at)

--- a/test/lib/sc_data/source_test.rb
+++ b/test/lib/sc_data/source_test.rb
@@ -151,4 +151,23 @@ class ScData::SourceTest < ActiveSupport::TestCase
     assert_predicate ScData::Source.find("live"), :default?
     assert_not_predicate ScData::Source.find("ptu"), :default?
   end
+
+  # --- Retention --------------------------------------------------------------
+
+  # Live carries history a reader may cite; a preview is only ever asked what it
+  # has that live does not, and what changed since the last preview.
+  test "live keeps more builds than ptu" do
+    assert_equal 3, ScData::Source.builds_retained("live")
+    assert_equal 2, ScData::Source.builds_retained("ptu")
+  end
+
+  # A pruned build row cannot be recovered, so an environment this policy has
+  # not considered keeps the larger number rather than the smaller.
+  test "an environment the policy does not name keeps the larger number" do
+    assert_equal 3, ScData::Source.builds_retained("eptu")
+  end
+
+  test "the environment may be named as a symbol" do
+    assert_equal 2, ScData::Source.builds_retained(:ptu)
+  end
 end

--- a/test/loaders/sc_data/base_loader_apply_build_test.rb
+++ b/test/loaders/sc_data/base_loader_apply_build_test.rb
@@ -90,7 +90,7 @@ module ScData
       # Bounded on purpose: history is worth a couple of patches, not every patch
       # ever shipped.
       test "#prune_builds keeps the retained builds and drops the rest" do
-        keep = EquipmentBuild::BUILDS_RETAINED
+        keep = ::ScData::Source.builds_retained(::ScData::Source.environment)
 
         (keep + 2).times do |index|
           create(
@@ -105,6 +105,35 @@ module ScData
         @loader.prune_builds(EquipmentBuild)
 
         assert_equal keep, EquipmentBuild.distinct.count(:version)
+      end
+
+      # The number is the environment's, not the catalogue's: a ptu build is a
+      # preview and keeps one fewer than live. Pruning is per environment, so a
+      # week of ptu builds can never displace a live one either.
+      test "#prune_builds keeps ptu to its own smaller number" do
+        @loader.sc_environment = "ptu"
+
+        4.times do |index|
+          create(
+            :equipment_build,
+            equipment: create(:equipment, :without_build),
+            environment: "ptu",
+            version: "4.#{index}.0-ptu.#{index}",
+            created_at: index.days.from_now
+          )
+        end
+
+        live = create(
+          :equipment_build,
+          equipment: create(:equipment, :without_build),
+          environment: "live",
+          version: "4.9.0-live.1"
+        )
+
+        @loader.prune_builds(EquipmentBuild)
+
+        assert_equal 2, EquipmentBuild.where(environment: "ptu").distinct.count(:version)
+        assert EquipmentBuild.exists?(live.id), "live is pruned on its own terms, not ptu's"
       end
 
       # `where.not(version: [])` is `1=1`, so an environment with nothing loaded


### PR DESCRIPTION
Live keeps 3 builds, ptu keeps 2.

## One half of this was already true

"At least 3 live builds even when many ptu builds appear in between" needed no
change: pruning has always been per environment.

```ruby
build_class.where(environment: sc_environment).where.not(version: retained).delete_all
```

`retained_versions(environment, …)` filters by environment too, so a week of ptu
builds could never displace a live one. There is now a test pinning it, because
the property held by construction rather than by intent.

## The other half was real

`BUILDS_RETAINED = 3` sat as a constant on all **six** build classes — so every
environment kept the same number, and the number was stated six times. Retention
is a property of the environment, not of a catalogue, so it moves to
`ScData::Source` where the environments already live:

```ruby
BUILDS_RETAINED = {"live" => 3, "ptu" => 2}.freeze
BUILDS_RETAINED_DEFAULT = 3
```

The two environments are asked different questions. Live carries the patch
history a reader may cite, and keeps enough to diff a patch against the one
before it *and* still have the one before that when a load goes wrong. A ptu
build is only ever asked what it has that live does not, and what changed since
the last preview — both answered by the current build and one behind it — while
a ptu cycle ships builds several times a week. A third would be paid for
constantly and read never.

**An unlisted environment keeps 3, not 2.** A pruned row cannot be recovered, so
a channel this policy has not considered errs towards keeping rather than
towards tidiness.

## What this deletes

**Nothing today.** No database has ptu build rows at all — every catalogue reads
`{"live" => 2}` locally, and production is on v7.12.0, before any of this
shipped. The 2 only bites once a third ptu build would otherwise have been kept,
and at that point one row set is `delete_all`-ed by the load that creates the
third. Worth knowing before merging rather than after.

## Verification

279 tests across `test/lib/sc_data/` and `test/loaders/` green, `bin/ruby-lint`
clean. New tests cover the numbers, the symbol/string form of the argument, the
unlisted-environment default, and — the behavioural one — that a prune with four
ptu builds present keeps two of them and leaves a live build standing.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build retention is now configured by environment.
  * Live environments retain three builds, while PTU environments retain two.
  * Unrecognized environments default to retaining three builds.
  * Symbol-based environment values are supported.

* **Bug Fixes**
  * Build pruning now applies the correct retention policy independently to each environment.
  * PTU build cleanup no longer follows the live-environment retention count.

* **Tests**
  * Added coverage for environment-specific retention, fallback behavior, symbol inputs, and pruning results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->