### PR TITLE
chore: wrap kamal accessory the way every other remote command is wrapped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ bin/logs-stage                    # View staging logs
 bin/logs-live                     # View production logs
 bin/setup-stage                   # Run Kamal setup for staging
 bin/setup-live                    # Run Kamal setup for production
+bin/accessory-stage <cmd> <name>  # Kamal accessory command on staging (e.g. bin/accessory-stage reboot db)
+bin/accessory-live <cmd> <name>   # Kamal accessory command on production
 ```
 
 ### Linting & Formatting

--- a/bin/accessory-live
+++ b/bin/accessory-live
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+export HCLOUD_TOKEN
 bundle exec kamal accessory "$@" -d live

--- a/bin/accessory-live
+++ b/bin/accessory-live
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+set +a
+export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+bundle exec kamal accessory "$@" -d live

--- a/bin/accessory-stage
+++ b/bin/accessory-stage
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+set +a
+export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+bundle exec kamal accessory "$@" -d stage

--- a/bin/accessory-stage
+++ b/bin/accessory-stage
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+export HCLOUD_TOKEN
 bundle exec kamal accessory "$@" -d stage

--- a/bin/backup-db
+++ b/bin/backup-db
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+export HCLOUD_TOKEN
 
 echo "Triggering on-demand database backup on live..."
 bundle exec kamal accessory exec db-backup -d live --reuse /backup.sh

--- a/bin/console-live
+++ b/bin/console-live
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+export HCLOUD_TOKEN
 
 ROLE="${1:-web}"
 shift 2>/dev/null || true

--- a/bin/console-live-danger
+++ b/bin/console-live-danger
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+export HCLOUD_TOKEN
 
 ROLE="${1:-web}"
 shift 2>/dev/null || true

--- a/bin/console-stage
+++ b/bin/console-stage
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+export HCLOUD_TOKEN
 
 ROLE="${1:-web}"
 shift 2>/dev/null || true

--- a/bin/deploy
+++ b/bin/deploy
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+export HCLOUD_TOKEN
 bundle exec kamal deploy -d live --skip-push "$@"

--- a/bin/deploy-stage
+++ b/bin/deploy-stage
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+export HCLOUD_TOKEN
 bundle exec kamal deploy -d stage --skip-push "$@"

--- a/bin/exec-live
+++ b/bin/exec-live
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+export HCLOUD_TOKEN
 
 ROLE="${1:-web}"
 shift 2>/dev/null || true

--- a/bin/exec-stage
+++ b/bin/exec-stage
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+export HCLOUD_TOKEN
 
 ROLE="${1:-web}"
 shift 2>/dev/null || true

--- a/bin/logs-live
+++ b/bin/logs-live
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+export HCLOUD_TOKEN
 
 ROLE="${1:-web}"
 shift 2>/dev/null || true

--- a/bin/logs-stage
+++ b/bin/logs-stage
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+export HCLOUD_TOKEN
 
 ROLE="${1:-web}"
 shift 2>/dev/null || true

--- a/bin/setup-live
+++ b/bin/setup-live
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_LIVE/credential")
+export HCLOUD_TOKEN
 bundle exec kamal setup -d live "$@"

--- a/bin/setup-stage
+++ b/bin/setup-stage
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 set +a
-export HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+HCLOUD_TOKEN=$(op read "op://Fleetyards/HCLOUD_STAGE/credential")
+export HCLOUD_TOKEN
 bundle exec kamal setup -d stage "$@"


### PR DESCRIPTION
`kamal accessory reboot db` fails:

```
ERROR (Kamal::ConfigurationError): accessories/db: specify one of `host`, `hosts`, `role`, `roles`, `tag` or `tags`
```

Not a misconfiguration — the accessory host lives in `deploy.live.yml`, not `deploy.yml`, so without `-d live` that file is never read. And reading it needs `HCLOUD_TOKEN`, because the host comes out of `bash .kamal/server-ips accessory live`.

Both are exactly what the `bin/` scripts exist to supply. `deploy`, `exec`, `console`, `logs` and `setup` all have a live and a stage variant; accessories were the gap.

```bash
bin/accessory-live reboot db
bin/accessory-live logs db --lines 50
bin/accessory-stage details db
```

Arguments pass straight through and `-d` is appended, so the whole subcommand surface is reachable. Verified with `op` and `bundle` stubbed out — no 1Password prompt, nothing touched on a server:

```
bin/accessory-live  reboot db          -> kamal accessory reboot db -d live
bin/accessory-stage reboot db          -> kamal accessory reboot db -d stage
bin/accessory-live  logs db --lines 50 -> kamal accessory logs db --lines 50 -d live
```

## Second commit: a real bug the review caught

CodeRabbit flagged `export HCLOUD_TOKEN=$(op read ...)`, and it is right. `export` returns its own exit status — always zero — so `set -e` never sees the failure underneath it:

```bash
set -euo pipefail
export TOKEN=$(false)   # keeps going, TOKEN='', exit 0
TOKEN=$(false)          # aborts, exit 1
```

A locked 1Password or a timed-out prompt therefore reads as success, and Kamal runs with an empty token. That lands in a particularly bad place here: no token means `.kamal/server-ips` returns nothing, `acc_ips.first` is nil, and Kamal reports **the same "specify one of `host`, `hosts`, …" error these scripts were written to prevent** — now pointing at the wrong thing entirely.

## Third commit: the other twelve

The pattern in the new scripts was copied from the twelve already in `bin/`, so `deploy`, `exec`, `console`, `logs`, `setup` and `backup-db` all carry it, on both destinations. Any of them would run against production with an empty token. Fixing only the new pair would have left the directory doing the same thing two different ways.

It is mechanical — the assignment moves off the `export` line and nothing else changes — and it is a separate commit, so it can be dropped if you would rather it went in on its own.

Verified with a stubbed failing `op`: `bin/logs-live` exits 1 without reaching Kamal, and every script still parses.

🤖
