### PR TITLE
fix(base-select): treat a single filter value as a one-item selection

### DIFF
--- a/app/frontend/shared/components/base/Select/index.spec.ts
+++ b/app/frontend/shared/components/base/Select/index.spec.ts
@@ -136,6 +136,63 @@ describe("BaseSelect", () => {
         ["a", "c"],
       ]);
     });
+
+    /*
+     * A filter reads its value straight off `route.query`, which is a plain
+     * string when the param appears once and an array only when it repeats.
+     * So every one of these arrives at a `multiple` select in the wild.
+     */
+    describe("given a single value rather than a list", () => {
+      it("selects that one option instead of substring-matching the rest", async () => {
+        const wrapper = await mount({
+          multiple: true,
+          options: [
+            { value: "a", label: "Aurora" },
+            { value: "ab", label: "Aurora LX" },
+          ],
+          modelValue: "ab",
+        });
+
+        expect(labelsIn(wrapper, '[id^="ships-selected-"]')).toEqual([
+          "Aurora LX",
+        ]);
+      });
+
+      it("handles a value with no includes of its own", async () => {
+        const wrapper = await mount({
+          multiple: true,
+          options: [
+            { value: 3, label: "Three" },
+            { value: 7, label: "Seven" },
+          ],
+          modelValue: 3,
+        });
+
+        expect(labelsIn(wrapper, '[id^="ships-selected-"]')).toEqual(["Three"]);
+      });
+
+      it("adds to it rather than throwing", async () => {
+        const wrapper = await mount({ multiple: true, modelValue: "a" });
+
+        await wrapper
+          .findAll('[id^="ships-options-"] .base-select-item')[2]
+          .trigger("click");
+
+        expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([
+          ["a", "c"],
+        ]);
+      });
+
+      it("clears it when its own row is clicked again", async () => {
+        const wrapper = await mount({ multiple: true, modelValue: "a" });
+
+        await wrapper
+          .findAll('[id^="ships-options-"] .base-select-item')[0]
+          .trigger("click");
+
+        expect(wrapper.emitted("update:modelValue")?.at(-1)).toEqual([[]]);
+      });
+    });
   });
 
   describe("the imperative API four call sites depend on", () => {

--- a/app/frontend/shared/components/base/Select/index.vue
+++ b/app/frontend/shared/components/base/Select/index.vue
@@ -322,12 +322,35 @@ const availableOptions = computed<FilterOption[]>(() =>
   sort(internalOptions.value),
 );
 
+/*
+ * `ValueType` also covers a bare value and an option object, and the router
+ * hands us a plain string for a single-valued query param -- so `multiple`
+ * cannot assume the model value is already a list.
+ */
+const selectedValues = computed<FilterOptionValue[]>(() => {
+  const value = internalValue.value;
+
+  if (value === undefined || value === null) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) =>
+      typeof item === "object" && item !== null ? item.value : item,
+    );
+  }
+
+  if (typeof value === "object") {
+    return [value.value];
+  }
+
+  return [value as FilterOptionValue];
+});
+
 const selectedOptions = computed(() => {
   if (props.multiple) {
-    return availableOptions.value.filter(
-      (item) =>
-        internalValue.value &&
-        (internalValue.value as FilterOptionValue[]).includes(item.value),
+    return availableOptions.value.filter((item) =>
+      selectedValues.value.includes(item.value),
     );
   }
 
@@ -853,8 +876,7 @@ const fetchMissingOption = async () => {
   if (
     !internalValue.value ||
     (props.multiple &&
-      selectedOptions.value.length ===
-        (internalValue.value as string[]).length) ||
+      selectedOptions.value.length === selectedValues.value.length) ||
     (!props.multiple && selectedOptions.value[0]?.value === internalValue.value)
   ) {
     return;
@@ -885,9 +907,7 @@ const clearSearch = () => {
 
 const selected = (option: FilterOptionValue) => {
   if (props.multiple) {
-    return ((internalValue.value as FilterOptionValue[]) || []).includes(
-      option,
-    );
+    return selectedValues.value.includes(option);
   }
 
   return internalValue.value === option;
@@ -902,17 +922,13 @@ const select = async (optionValue: FilterOptionValue) => {
     if (props.multiple) {
       emits(
         "update:modelValue",
-        (internalValue.value as string[]).filter(
-          (item: string) => item !== optionValue,
-        ),
+        selectedValues.value.filter((item) => item !== optionValue),
       );
     } else if (props.nullable) {
       emits("update:modelValue", null);
     }
   } else if (props.multiple) {
-    const values: FilterOptionValue[] = JSON.parse(
-      JSON.stringify(internalValue.value || []),
-    );
+    const values: FilterOptionValue[] = [...selectedValues.value];
 
     values.push(optionValue);
 


### PR DESCRIPTION
Fixes the `BaseSelect` TypeErrors sitting open in AppSignal (`A.value.includes is not a function`, #17944 and #17540, 46 occurrences since Sep 2).

## The cause

`useFilters` returns `route.query` cast to `T` with no normalisation, and Vue Router gives a **plain string** for a param that appears once — an array only when it repeats. So `?classificationIn=combat` reaches a `multiple` select as `"combat"`, not `["combat"]`.

Five places in the `multiple` path cast that value to an array anyway. The cast was never guaranteed: `ValueType<T>` deliberately covers `string`, `number`, `boolean` and an option object alongside the array shapes.

The reported crash is the smaller half of it. A string *survives* `.includes` and goes quietly wrong — `"ab".includes("a")` is true, so a single-valued filter selected every option whose value was a substring of it. Only a non-string threw, which is what reached AppSignal.

## The change

One `selectedValues` computed normalises at the boundary; the five casts go away.

| Site | Was |
|---|---|
| `selectedOptions` | the reported `.includes` crash, plus the silent substring mis-selection |
| `selected()` | same crash on a second code path |
| `select()` deselecting | `.filter is not a function` — unreported |
| `select()` adding | `JSON.parse(JSON.stringify(3))` → `values.push is not a function` — unreported |
| `fetchMissingOption` | compared a string's **character count** against the number of loaded options, refetching for nothing |

Option object arrays now match as well, where comparing an object against an option value never did.

## Verification

Four regression tests in the existing spec. They earn their keep because I stashed the component fix and re-measured — without it, all four fail with the production error messages:

```
× selects that one option instead of substring-matching the rest
× handles a value with no includes of its own
× adds to it rather than throwing
× clears it when its own row is clicked again

TypeError: internalValue.value.includes is not a function
TypeError: values.push is not a function
TypeError: internalValue.value.filter is not a function
```

`internalValue.value.includes is not a function` is AppSignal's `A.value.includes` unminified — same line, so the cause is confirmed rather than merely plausible.

With the fix: 33/33 in the Select spec (29 before), `build-compare.spec.ts` 4/4, `lint:ts` exit 0, prettier and eslint clean. Full suite left to CI.

## Deliberately not in here

- `missing.value = internalValue.value as string` passes a string to `q.slugIn` where an array is expected. Ransack handles it (`IN ('combat')`), so it is inconsistent rather than broken.
- `Models/ClassLabels`, `Hangar/GroupLabels` and `Vehicles/HangarGroups` have each grown a private `toArray` helper against this same trap. Worth consolidating in its own PR.

🤖
