### PR TITLE
chore(deps): force js-yaml 4.3.2 for orval (CVE-2026-84375)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   ajv@5: '>=6.14.0 <7'
   ajv@6: '>=6.14.0 <7'
   jsonpath-plus@7: '>=10.3.0'
+  js-yaml@4: '>=4.3.2 <5'
 
 patchedDependencies:
   '@tresjs/core@5.8.1':
@@ -4487,10 +4488,6 @@ packages:
 
   js-yaml@3.15.2:
     resolution: {integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==}
-    hasBin: true
-
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   js-yaml@4.3.2:
@@ -11129,10 +11126,6 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
@@ -11682,7 +11675,7 @@ snapshots:
       fs-extra: 11.4.0
       get-tsconfig: 4.14.3
       jiti: 2.7.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       remeda: 2.45.0
       string-argv: 0.3.2
       typedoc: 0.28.20(typescript@6.0.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,5 +10,6 @@ overrides:
   ajv@5: '>=6.14.0 <7'
   ajv@6: '>=6.14.0 <7'
   jsonpath-plus@7: '>=10.3.0'
+  js-yaml@4: '>=4.3.2 <5'
 patchedDependencies:
   '@tresjs/core@5.8.1': patches/@tresjs__core@5.8.1.patch


### PR DESCRIPTION
Closes the open high-severity Dependabot alert (431) on `main`.

## The advisory

`CVE-2026-84375` / `GHSA-2883-xcg3-v3hh`, js-yaml, CVSS 7.5. `maxTotalMergeKeys` does not count empty mappings, so a sequence of them can be merged repeatedly for `O(N * K)` work while the configured limit stays untouched — roughly 500 KB of input for 13 s of CPU. Pure resource exhaustion (`C:N/I:N/A:H`), fixed in 4.3.2.

## Scope in our tree

Four copies of js-yaml, only one in the vulnerable range:

| Version | Status | Pulled by |
|---|---|---|
| 3.15.2 | patched (the 3.x fix) | `ramldt2jsonschema` |
| **4.3.1** | **vulnerable** | **`orval`** |
| 4.3.2 | patched | 7 packages |
| 5.4.1 | outside both ranges | `mocha` |

So the exposure is `orval`, our OpenAPI client generator — `scope: development`, `relationship: transitive`. It runs at build time against schemas committed in this repo, so there is no path by which untrusted YAML reaches it. Worth fixing because it is cheap, not because it is reachable.

## Why Dependabot can't offer this

`orval` pins js-yaml to an **exact** version rather than a range, so `pnpm update` has nothing to do — the pin is already satisfied. Bumping orval does not help either: **8.30.0** still pins `4.3.1`. js-yaml 4.3.2 has been out since Aug 26, two weeks before the advisory. Nothing moves this without an override.

## The change

```yaml
js-yaml@4: '>=4.3.2 <5'
```

Scoped to the 4.x major and bounded below 5, matching the existing `ajv@6: '>=6.14.0 <7'` entries. Both bounds matter: an unbounded `>=4.3.2` would pull the `mocha` and `ramldt2jsonschema` copies across a major, and those are already fine.

The lockfile diff is 2 insertions and 9 deletions — the 4.3.1 entry and snapshot drop out, orval's edge repoints to the 4.3.2 entry that 7 other packages already share. No new package enters the tree. `pnpm why js-yaml` now reports three versions, all patched or unaffected.

## Verification

orval reads committed schemas (`swagger/*/schema.yaml`), not a live server, so this is checkable offline. I generated the client **before** the override to establish that the committed output was already in sync, then again after:

- baseline with 4.3.1 → working tree clean
- with 4.3.2 → working tree clean

Byte-identical output both ways, so the bump changes nothing about how our schemas parse. `pnpm install` clean; the postinstall cable-client regeneration produced no diff either. Test suites left to CI, since only a build-time tool's transitive dependency moved and its output is unchanged.

🤖
