### PR TITLE
chore(appsignal): stop reporting exceptions Rails already answers

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -7,6 +7,9 @@ production:
       - ActiveRecord::RecordNotFound
       - ActionController::RoutingError
       - ActionController::InvalidAuthenticityToken
+      - ActionDispatch::Http::MimeNegotiation::InvalidType
+      - ActionController::BadRequest
+      - ActionDispatch::Http::Parameters::ParseError
 
 staging:
   push_api_key: "<%= Rails.application.credentials.dig(:appsignal, :push_api_key) rescue nil %>"
@@ -18,6 +21,9 @@ staging:
       - ActiveRecord::RecordNotFound
       - ActionController::RoutingError
       - ActionController::InvalidAuthenticityToken
+      - ActionDispatch::Http::MimeNegotiation::InvalidType
+      - ActionController::BadRequest
+      - ActionDispatch::Http::Parameters::ParseError
 
 development:
   active: false


### PR DESCRIPTION
Three of the largest open AppSignal incidents are not failures at all. Adding them to `ignore_errors` takes roughly **12,400 non-events** out of the error stream.

## They are already handled

All three are mapped in `ActionDispatch::ExceptionWrapper.rescue_responses` (`actionpack-8.1.3.1/lib/action_dispatch/middleware/exception_wrapper.rb:19`), so the client gets a correct status and nothing is broken:

| Incident | Exception | Status Rails returns | Occurrences |
|---|---|---|---|
| #229, #328, #17480, #17477, #17474, #17473, #17760 | `MimeNegotiation::InvalidType` | **406** | ~8,000 |
| #16166 | `ActionController::BadRequest` | **400** | ~4,400 |
| #16349 | `Parameters::ParseError` | **400** | ~70 |

Rails goes further on the first one: it also lists `MimeNegotiation::InvalidType` in `silent_exceptions` — a list with exactly two members, the other being `ActionController::RoutingError`. Rails declines to even log the pair.

We already ignore `ActionController::RoutingError` here. This completes a list that was inconsistent, rather than establishing a new policy. `ActionController::InvalidAuthenticityToken`, also already in the list, is mapped the same way.

## Why it has to be config

A `rescue_from` in `ApplicationController` would not work. The trace puts the raise at `instrumentation.rb:68`, where instrumentation builds its payload and reads `request.format` — outside `ActionController::Rescue`. For contrast, the S3 incidents on the same app *do* show `rescue.rb:36` in their stack. Nothing inside the controller can intercept this one.

## What the traffic actually is

Scanners, essentially all of it. The recorded values speak for themselves:

```
"-1 OR 5*5=25 --" is not a valid MIME type
"../../../../../../../../../../etc/services{{" is not a valid MIME type
"if(now()=sysdate()" is not a valid MIME type
Invalid path parameters: Invalid encoding for parameter: json%2527%2522
```

#229 has been open since **May 16, 2021**. Between them these three classes are the bulk of the error volume, which is what makes the incidents that do mean something hard to spot.

## Verification

Every class name resolves and maps to the expected status — a typo here would silently never match, so I checked rather than assumed:

```
OK  ActionController::RoutingError                       ->  :not_found
OK  ActionDispatch::Http::MimeNegotiation::InvalidType   ->  :not_acceptable
OK  ActionController::BadRequest                         ->  :bad_request
OK  ActionDispatch::Http::Parameters::ParseError         ->  :bad_request
OK  ActiveRecord::RecordNotFound
OK  ActionController::InvalidAuthenticityToken
```

`config/appsignal.yml` parses, and both `production` and `staging` were updated so the two lists stay identical.

## Note

This changes reporting only — no status code, response or behaviour moves. If these ever need to be visible again, they are one line each to restore.

🤖
