### PR TITLE
fix(storage): keep serving representations when the store cannot answer

### DIFF
--- a/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/app/controllers/active_storage/representations/redirect_controller.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 class ActiveStorage::Representations::RedirectController < ActiveStorage::Representations::BaseController
+  # The store's error classes only exist once aws-sdk-s3 has been required, which
+  # ActiveStorage does lazily when it builds the S3 service. Naming them in a
+  # `rescue` clause would raise NameError on a Disk-backed environment and bury
+  # whatever actually went wrong.
+  UNAVAILABLE_ERRORS = [
+    "Aws::S3::Errors::ServiceError",
+    "Seahorse::Client::NetworkingError"
+  ].freeze
+
   rescue_from ActiveStorage::FileNotFoundError, with: :reprocess_representation
 
   def show
@@ -12,8 +21,28 @@ class ActiveStorage::Representations::RedirectController < ActiveStorage::Repres
 
   private
 
+  # Only decides whether to repair a variant record whose object is gone, so a
+  # store that cannot answer must not take the request with it. Redirecting on a
+  # failed probe costs nothing -- signing the URL needs no round trip, and a
+  # client fetching a genuinely missing object gets a 404 from the store rather
+  # than a 500 from us. Answering false instead would send variant processing at
+  # a store that is already failing.
   def representation_exists?
     @blob.service.exist?(@representation.key)
+  rescue => error
+    raise unless store_unavailable?(error)
+
+    Rails.logger.warn("representation probe skipped, #{error.class}: #{error.message}")
+
+    true
+  end
+
+  def store_unavailable?(error)
+    UNAVAILABLE_ERRORS.any? do |name|
+      klass = name.safe_constantize
+
+      klass && error.is_a?(klass)
+    end
   end
 
   def reprocess_representation

--- a/test/integration/representation_store_outage_test.rb
+++ b/test/integration/representation_store_outage_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "aws-sdk-s3"
+
+# `show` probes the store for the variant's object so it can rebuild a variant
+# record whose object has gone missing. That probe is a repair mechanism, not a
+# gate: when the store cannot answer, redirecting is strictly better than
+# failing, because signing the URL needs no round trip of its own.
+class RepresentationStoreOutageTest < ActionDispatch::IntegrationTest
+  setup do
+    @blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("test.png").open,
+      filename: "view.png"
+    )
+    @variant = @blob.variant(resize_to_limit: [100, 100])
+  end
+
+  test "a representation is still redirected when the store cannot answer the probe" do
+    ActiveStorage::Blob.service.stubs(:exist?)
+      .raises(Aws::S3::Errors::Http503Error.new(nil, "Service Unavailable"))
+
+    get representation_path
+
+    assert_response :redirect
+  end
+
+  test "a networking failure against the store is treated the same way" do
+    ActiveStorage::Blob.service.stubs(:exist?)
+      .raises(Seahorse::Client::NetworkingError.new(Net::ReadTimeout.new))
+
+    get representation_path
+
+    assert_response :redirect
+  end
+
+  # The rescue is there for a store that cannot answer, not as a blanket guard
+  # over the probe.
+  test "an error the store did not raise is left alone" do
+    ActiveStorage::Blob.service.stubs(:exist?)
+      .raises(RuntimeError, "something we actually broke")
+
+    assert_raises(RuntimeError) { get representation_path }
+  end
+
+  private def representation_path
+    rails_blob_representation_path(
+      signed_blob_id: @blob.signed_id,
+      variation_key: @variant.variation.key,
+      filename: @blob.filename
+    )
+  end
+end


### PR DESCRIPTION
Removes the largest single error source in production: incident #17113, `Aws::S3::Errors::Http503Error`, **19,977 occurrences** (4,062 in the last week), plus #17132 (504, 299), #17115 (BadRequest, 20) and #17164 (`Seahorse::Client::NetworkingError`, 22).

## The cause is ours, not Hetzner's

The failing frame points into this repo, not the gem:

```
aws-sdk-s3/object.rb:651                                  Aws::S3::Object#exists?
active_storage/service/s3_service.rb:77                   S3Service#exist?
app/controllers/.../redirect_controller.rb:16             representation_exists?
app/controllers/.../redirect_controller.rb:7              show
```

`show` probes the store for the variant's object so it can rebuild a variant record whose object has gone missing. That is a **repair mechanism**, but it sat in front of the redirect as though it were a gate, so every failure of the probe failed the request.

Two consequences: a synchronous S3 `HeadObject` on the hottest endpoint on the site, and — whenever the store degrades — a 500 for every image on the page. The sibling `Blobs::RedirectController` does no such probe; it signs and redirects. So this is an addition on one path, not a house pattern.

## Why the redirect never needed the store

`@representation.url` only *signs* a URL — no round trip. The client fetches the object itself afterwards. So a probe that cannot answer can safely assume the object is there and redirect: worst case the client gets a 404 from the store, where today it gets a 500 from us. That is strictly better.

Answering `false` on failure would be worse than either — it would aim variant processing at a store that is already failing.

## Retry tuning would not have fixed it

`config/storage.yml` sets none, so aws-sdk defaults apply, and `Http503Error` is already `server_error?` and retried three times. 20,000 failures getting through means the degradation windows outlast the retries. This is not a knob problem.

## Why the error classes are strings

`aws-sdk-s3` is in the Gemfile as `require: false`. It is loaded only once ActiveStorage builds the S3 service, so on a Disk-backed environment the constants do not exist:

```
!!! Aws::S3::Errors::ServiceError fehlt
!!! Seahorse::Client::NetworkingError fehlt
service in test: ActiveStorage::Service::DiskService
```

Naming them directly in a `rescue` clause would raise `NameError` while resolving the clause and bury whatever actually went wrong. `safe_constantize` degrades to "not one of ours, re-raise", which is the safe default.

## Verification

Three tests, and they earn their keep — with the controller change stashed, the two store-failure cases error out with exactly the production exception classes:

```
Minitest::UnexpectedError:  Aws::S3::Errors::Http503Error: Service Unavailable
Minitest::UnexpectedError:  Seahorse::Client::NetworkingError: Net::ReadTimeout
3 tests, 1 assertions, 0 failures, 2 errors
```

The third test — a `RuntimeError` from the probe must still propagate — passes both with and without the fix, which is the point: it pins the rescue as narrow rather than a blanket guard over the probe.

With the fix: 3/3, `bin/ruby-lint` clean across 2,504 files.

## Two things deliberately left out

**A confirmed separate bug in the same file.** The `rescue_from ActiveStorage::FileNotFoundError, with: :reprocess_representation` handler reprocesses but never renders, so the client gets nothing. Measured, not assumed:

```
STATUS: 200  body=0B  location=nil
```

That is incident #17318 (`ActiveStorage::FileNotFoundError`, 226 occurrences): the variant is rebuilt server-side, but the browser receives an empty 200 instead of a redirect to it — a broken image, every time. It wants a redirect after `set_representation`, but it is a different defect on a path I have not explored, so it should be its own change rather than a rider on this one.

**Caching the probe.** Keeping the `exist?` result briefly would take the round trip off the hot path entirely. That is a performance change with its own staleness trade-off and does not belong in a fix that only establishes resilience.

🤖
