### PR TITLE
fix(sc_data): report unlisted models from the load that actually runs

### DIFF
--- a/app/jobs/loaders/sc_data/all_job.rb
+++ b/app/jobs/loaders/sc_data/all_job.rb
@@ -40,12 +40,39 @@ module Loaders
           record: import
         )
 
+        report_unlisted_models(source, import)
+
         import.finish!
       rescue => e
         import.fail!
         import.update!(info: e.message)
 
         raise e
+      end
+
+      # The load only ever iterates models that already exist, so a ship in the
+      # game files with no row is invisible to it. This is what says so.
+      #
+      # Here rather than in `Loaders::ScData::ModelsJob`, where it used to live:
+      # nothing enqueues that job. `CheckJob` -- the only thing that triggers a
+      # load, and only when a build has not been loaded yet -- enqueues this
+      # one, and the admin trigger does too. So the report ran for the first
+      # time in production only if somebody called it by hand.
+      #
+      # Inside the source, so a run reads the tree of the build it just loaded.
+      #
+      # Only a genuinely new entry is actionable, so the pile that has been
+      # sitting undecided does not reopen an issue on every patch.
+      private def report_unlisted_models(source, import)
+        result = ::ScData::Source.with(source) { ::ScData::UnlistedModels.new.run }
+
+        AdminReport.deliver(
+          task_type: "sc_data_unlisted_models",
+          title: "Ships in the game files with no model (#{result[:new].size} new)",
+          body: ::ScData::UnlistedModels.report_body(result, source),
+          actionable: ::ScData::UnlistedModels.actionable?(result),
+          record: import
+        )
       end
 
       # The build to load. A version and an environment name it exactly; either

--- a/app/jobs/loaders/sc_data/models_job.rb
+++ b/app/jobs/loaders/sc_data/models_job.rb
@@ -20,31 +20,12 @@ module Loaders
 
         import.update!(output: {"ModelsLoader" => loader.stats})
 
-        report_unlisted_models(import)
-
         import.finish!
       rescue => e
         import.fail!
         import.update!(info: e.message)
 
         raise e
-      end
-
-      # The load only ever iterates models that already exist, so a ship in the
-      # game files with no row is invisible to it. This is what says so.
-      #
-      # Only a genuinely new entry is actionable, so the pile that has been
-      # sitting undecided does not reopen an issue on every patch.
-      private def report_unlisted_models(import)
-        result = ::ScData::UnlistedModels.new.run
-
-        AdminReport.deliver(
-          task_type: "sc_data_unlisted_models",
-          title: "Ships in the game files with no model (#{result[:new].size} new)",
-          body: ::ScData::UnlistedModels.report_body(result),
-          actionable: ::ScData::UnlistedModels.actionable?(result),
-          record: import
-        )
       end
     end
   end

--- a/app/lib/sc_data/unlisted_models.rb
+++ b/app/lib/sc_data/unlisted_models.rb
@@ -52,9 +52,7 @@ module ScData
 
       identifiers.each { |identifier| record(identifier) }
 
-      # A row the rule now covers stops being reported. Only undecided ones go:
-      # a decision that was already made is the record of it.
-      ScDataUnlistedModel.undecided.where.not(identifier: identifiers).delete_all
+      retire_absent(identifiers)
 
       {
         seen: identifiers.size,
@@ -116,12 +114,48 @@ module ScData
 
     private
 
+    # A row the rule now covers stops being reported. Only undecided ones go: a
+    # decision that was already made is the record of it.
+    #
+    # Scoped to the environment that saw it last, because this runs once per
+    # source. One row serves both -- the unique index is on `identifier` alone,
+    # and an unlisted ship is a decision about the ship rather than about a
+    # build -- so an unscoped sweep under ptu would delete every identifier only
+    # live shows, and the next live run would recreate it with a fresh
+    # `first_seen_*` and announce it as new all over again. With `CheckJob`
+    # loading both sources that is a churn loop, not a one-off.
+    #
+    # A row last seen elsewhere is that environment's to retire. An identifier
+    # both still ship keeps being refreshed by whichever runs; one neither ships
+    # any more is swept by whichever runs second.
+    #
+    # `where.not(identifier: [])` is `1=1`, so an empty list sweeps everything --
+    # and that is right when the rules now cover every identifier, which is a
+    # state this actually reaches.
+    #
+    # What must not sweep is a tree that was never read: no export ships zero
+    # ships, so an empty glob is a missing or half-fetched tree rather than a
+    # catalogue that emptied itself. Guarded on the files rather than on the
+    # filtered list, which is the difference between those two.
+    def retire_absent(identifiers)
+      return 0 if parsed_identifiers.empty?
+
+      ScDataUnlistedModel
+        .undecided
+        .where(last_seen_environment: source.environment)
+        .where.not(identifier: identifiers)
+        .delete_all
+    end
+
     def export_path
       Pathname(@base_folder).join("parsed", source.environment.to_s)
     end
 
+    # Memoized because the sweep asks whether the tree was readable at all, and
+    # a second glob over a few thousand files to answer that is waste.
     def parsed_identifiers
-      Dir.glob(export_path.join("models", "*.json")).map { |file| File.basename(file, ".json") }
+      @parsed_identifiers ||=
+        Dir.glob(export_path.join("models", "*.json")).map { |file| File.basename(file, ".json") }
     end
 
     # Everything the export ships, less what the catalogue already has and less

--- a/test/jobs/loaders/sc_data/all_job_test.rb
+++ b/test/jobs/loaders/sc_data/all_job_test.rb
@@ -9,6 +9,13 @@ module Loaders
         Rails.configuration.stubs(:sc_data).returns({sources: {live: "3.24.0"}, default: "live"})
         @admin_user = create(:admin_user, resource_access: [:models])
         AdminNotificationsChannel.stubs(:broadcast_to)
+
+        # Otherwise every test here reads whatever parsed tree happens to be on
+        # disk -- 1109 model files locally, none on CI -- and the unlisted report
+        # decides whether a second issue is opened. The tests that are about that
+        # report stub it themselves.
+        ::ScData::UnlistedModels.any_instance.stubs(:run)
+          .returns({seen: 0, new: [], undecided: []})
       end
 
       def notification
@@ -111,6 +118,69 @@ module Loaders
         ::Loaders::ScData::AllJob.new.perform
 
         assert_equal "warning", notification.severity
+      end
+
+      # The load only iterates models that already exist, so a ship in the game
+      # files with no row is invisible to it. These moved here from
+      # `ModelsJobTest`: nothing enqueues that job, so the report never ran.
+      test "#perform reports the ships the game files describe and we have no model for" do
+        ::ScData::Loader::BaseLoader.stubs(:all).returns({})
+
+        entry = create(:sc_data_unlisted_model, identifier: "krig_s65_stingray", name: "Kruger S-65 Stingray")
+        ::ScData::UnlistedModels.any_instance.stubs(:run)
+          .returns({seen: 1, new: [entry], undecided: [entry]})
+
+        creator = mock("GithubIssueCreator")
+        creator.stubs(:run)
+        GithubIssueCreator.stubs(:new).returns(creator)
+
+        ::Loaders::ScData::AllJob.new.perform
+
+        unlisted = AdminNotification.find_by(
+          admin_user: @admin_user, notification_type: "sc_data_unlisted_models"
+        )
+        assert_not_nil unlisted
+        assert_equal "warning", unlisted.severity
+        assert_includes unlisted.body, "krig_s65_stingray"
+      end
+
+      # Only a genuinely new entry is worth an issue, or a pile that has been
+      # sitting undecided would reopen one on every patch.
+      test "#perform opens no issue for the unlisted pile when nothing is new" do
+        ::ScData::Loader::BaseLoader.stubs(:all).returns({
+          "ModelsLoader" => {"Model" => {created: 0, updated: 1, unchanged: 0}}
+        })
+
+        entry = create(:sc_data_unlisted_model)
+        ::ScData::UnlistedModels.any_instance.stubs(:run)
+          .returns({seen: 1, new: [], undecided: [entry]})
+        GithubIssueCreator.expects(:new).never
+
+        ::Loaders::ScData::AllJob.new.perform
+
+        unlisted = AdminNotification.find_by(
+          admin_user: @admin_user, notification_type: "sc_data_unlisted_models"
+        )
+        assert_equal "info", unlisted.severity
+      end
+
+      # The report reads the tree of the build the job just loaded, not the
+      # configured default -- otherwise a ptu load would report live's ships.
+      test "#perform reports the unlisted ships of the source it loaded" do
+        Rails.configuration.stubs(:sc_data).returns({
+          sources: {live: "3.24.0", ptu: "3.24.1-ptu.2"}, default: "live"
+        })
+        ::ScData::Loader::BaseLoader.stubs(:all).returns({})
+
+        seen = nil
+        ::ScData::UnlistedModels.any_instance.stubs(:run).with {
+          seen = ::ScData::Source.current.to_s
+          true
+        }.returns({seen: 0, new: [], undecided: []})
+
+        ::Loaders::ScData::AllJob.new.perform("3.24.1-ptu.2", nil, "ptu")
+
+        assert_equal "3.24.1-ptu.2 (ptu)", seen
       end
 
       test "#perform marks import as failed on error" do

--- a/test/jobs/loaders/sc_data/models_job_test.rb
+++ b/test/jobs/loaders/sc_data/models_job_test.rb
@@ -20,57 +20,6 @@ module Loaders
         )
       end
 
-      # The load only iterates models that already exist, so a ship in the game
-      # files with no row is invisible to it. These pin that the job says so.
-      test "#perform reports the ships the game files describe and we have no model for" do
-        @admin_user = create(:admin_user, resource_access: [:models])
-        AdminNotificationsChannel.stubs(:broadcast_to)
-        SC_DATA_STUB.call
-        ::ScData::Loader::ModelsLoader.any_instance.stubs(:all)
-        ::ScData::Loader::ModelsLoader.any_instance.stubs(:stats).returns({})
-        ::Loaders::ScData::ModelsJob.any_instance.stubs(:fetch_parsed_tree!)
-
-        entry = create(:sc_data_unlisted_model, identifier: "krig_s65_stingray", name: "Kruger S-65 Stingray")
-        ::ScData::UnlistedModels.any_instance.stubs(:run)
-          .returns({seen: 1, new: [entry], undecided: [entry]})
-
-        creator = mock("GithubIssueCreator")
-        creator.expects(:run)
-        GithubIssueCreator.stubs(:new).returns(creator)
-
-        ::Loaders::ScData::ModelsJob.new.perform
-
-        notification = AdminNotification.find_by(
-          admin_user: @admin_user, notification_type: "sc_data_unlisted_models"
-        )
-        assert_not_nil notification
-        assert_equal "warning", notification.severity
-        assert_includes notification.body, "krig_s65_stingray"
-      end
-
-      # Only a genuinely new entry is worth an issue, or a pile that has been
-      # sitting undecided would reopen one on every patch.
-      test "#perform opens no issue when nothing is new" do
-        @admin_user = create(:admin_user, resource_access: [:models])
-        AdminNotificationsChannel.stubs(:broadcast_to)
-        SC_DATA_STUB.call
-        ::ScData::Loader::ModelsLoader.any_instance.stubs(:all)
-        ::ScData::Loader::ModelsLoader.any_instance.stubs(:stats).returns({})
-        ::Loaders::ScData::ModelsJob.any_instance.stubs(:fetch_parsed_tree!)
-
-        entry = create(:sc_data_unlisted_model)
-        ::ScData::UnlistedModels.any_instance.stubs(:run)
-          .returns({seen: 1, new: [], undecided: [entry]})
-        GithubIssueCreator.expects(:new).never
-
-        ::Loaders::ScData::ModelsJob.new.perform
-
-        notification = AdminNotification.find_by(
-          admin_user: @admin_user, notification_type: "sc_data_unlisted_models"
-        )
-        assert_equal "info", notification.severity
-      end
-
       test "#perform marks import as failed on error" do
         assert_import_wrapping_job_failure(
           job_class: ::Loaders::ScData::ModelsJob,

--- a/test/lib/sc_data/unlisted_models_test.rb
+++ b/test/lib/sc_data/unlisted_models_test.rb
@@ -194,6 +194,58 @@ class ScData::UnlistedModelsTest < ActiveSupport::TestCase
     assert_equal 1, result[:undecided].size
   end
 
+  # The bug wiring this into a per-source load would have activated: one row
+  # serves both environments -- the unique index is on `identifier` alone -- so
+  # an unscoped sweep under ptu deleted every identifier only live shows, and the
+  # next live run recreated it with a fresh `first_seen_*` and announced it as
+  # new again. `CheckJob` loads both sources, so that is a churn loop.
+  test "a ptu run leaves an identifier only live shows alone" do
+    write_ship("drak_newhull")
+    run_detector
+
+    entry = ScDataUnlistedModel.sole
+    ptu_models = File.join(@dir, "parsed", "ptu", "models")
+    FileUtils.mkdir_p(ptu_models)
+    File.write(File.join(ptu_models, "drak_otherhull.json"), JSON.dump({"name" => "Other"}))
+
+    ScData::UnlistedModels.new(
+      ScData::Source.new(version: "1.0.1-ptu.1", environment: "ptu"), base_folder: @dir
+    ).run
+
+    assert ScDataUnlistedModel.exists?(entry.id), "live's row is not ptu's to retire"
+    assert_equal "1.0.0", ScDataUnlistedModel.find(entry.id).first_seen_version
+  end
+
+  # The other half of the same rule: what this environment saw last and no longer
+  # ships is this environment's to retire.
+  test "a run retires an identifier its own environment stopped shipping" do
+    write_ship("drak_newhull")
+    run_detector
+
+    File.delete(File.join(models_path, "drak_newhull.json"))
+    write_ship("drak_otherhull")
+
+    result = run_detector
+
+    assert_equal ["drak_otherhull"], ScDataUnlistedModel.pluck(:identifier)
+    assert_equal 1, result[:seen]
+  end
+
+  # `where.not(identifier: [])` is `1=1`. The live tree carries 894 unlisted
+  # files, so a run that found none failed to read a tree rather than watched a
+  # catalogue empty itself.
+  test "a run that found nothing sweeps nothing" do
+    write_ship("drak_newhull")
+    run_detector
+
+    File.delete(File.join(models_path, "drak_newhull.json"))
+
+    result = run_detector
+
+    assert_equal 0, result[:seen]
+    assert_equal 1, ScDataUnlistedModel.count, "an unreadable tree must not empty the table"
+  end
+
   test "a decided ship stops being reported" do
     write_ship("drak_newhull")
     run_detector


### PR DESCRIPTION
`sc_data_unlisted_models` has been empty in production since the feature shipped
in **v7.10.0** (#4570). Not because nothing qualified — because **its only writer
has no caller.**

## The trace

The report lived in `Loaders::ScData::ModelsJob#report_unlisted_models`, and
nothing enqueues that job:

- **Not the schedule.** `sidekiq_schedule.yml` has `Loaders::ModelsJob` daily at
  20:00 — the RSI ship matrix loader. Different class, one namespace apart, and
  it reads exactly like the entry that would cover this.
- **Not the admin button.** `reloadScData` enqueues `Loaders::ScData::AllJob`.
- **Not `bin/scdata`.** It calls `ScData::Loader::ModelsLoader.new.all` directly.
- **Not `CheckJob`**, the only automatic trigger — it enqueues `AllJob` too, once
  per configured source, and only when a build has not been loaded yet.

Outside its own tests, nothing in the repo names `ScData::ModelsJob`. And
`AllJob` runs every loader through `BaseLoader.all` — models included — but never
the unlisted step.

The data agrees: the last `Imports::ScData::ModelsImport` in the production dump
is **2026-05-24 on 4.8.0**, before the feature existed. The 161 rows in
`fleetyards_dev` were all written inside one second on 2026-08-28 — a single
hand-run of `UnlistedModels#run`.

## The fix, and the bug it would have introduced

The step moves to `AllJob`, inside `Source.with(source)` so it reads the tree of
the build it just loaded rather than the configured default.

That alone would have been wrong. `AllJob` runs **once per source**, and the
sweep was environment-blind while the unique index is on `identifier` alone:

```ruby
ScDataUnlistedModel.undecided.where.not(identifier: identifiers).delete_all
```

Under ptu that deletes every identifier only live shows. The next live run
recreates each one with a fresh `first_seen_*` and announces it as new again —
and since `CheckJob` loads both sources, that is a churn loop rather than a
one-off. It is now scoped to `last_seen_environment`: a row last seen elsewhere
is that environment's to retire; one neither environment ships any more is swept
by whichever runs second.

## One judgement call worth reading

My first guard was `return if identifiers.blank?`, on the reasoning that no
export ships zero ships. **An existing test proved that wrong** — "a row the
vendor rule now covers stops being reported" reaches exactly that state
legitimately, and the guard kept a row that should have gone.

So the guard is on the **parsed files** instead of the filtered identifiers.
Sweeping everything is correct when the rules now cover every identifier; what
must not sweep is a tree that was never read. That distinction is the whole
difference between the two lists.

## Verification

264 tests across `test/lib/sc_data/` and `test/jobs/` green, `bin/ruby-lint`
clean. New coverage:

- a ptu run leaves an identifier only live shows alone (the churn loop)
- a run retires what its own environment stopped shipping (the other half)
- a run that read no tree sweeps nothing
- the report reads the source the job loaded, not the default
- the two moved `ModelsJobTest` cases, now against `AllJob`

I also added a stub to the `AllJobTest` setup: without it those tests read
whatever parsed tree happens to sit on disk — 1109 model files locally, none on
CI — so whether a second GitHub issue got opened depended on the filesystem.

## Left alone deliberately

`Loaders::ScData::ModelsJob` still exists and still has no caller. It is now a
plain single-catalogue loader with no report. Deleting it and its tests is a
separate call — say the word.

🤖
