### PR TITLE
fix(storage): answer 404 when a representation's original is gone

### DIFF
--- a/app/controllers/active_storage/representations/redirect_controller.rb
+++ b/app/controllers/active_storage/representations/redirect_controller.rb
@@ -10,7 +10,7 @@ class ActiveStorage::Representations::RedirectController < ActiveStorage::Repres
     "Seahorse::Client::NetworkingError"
   ].freeze
 
-  rescue_from ActiveStorage::FileNotFoundError, with: :reprocess_representation
+  rescue_from ActiveStorage::FileNotFoundError, with: :representation_not_found
 
   def show
     reprocess_representation unless representation_exists?
@@ -45,9 +45,22 @@ class ActiveStorage::Representations::RedirectController < ActiveStorage::Repres
     end
   end
 
+  # Reached from `show` when the probe reports the variant's own object missing:
+  # dropping the records and processing again rebuilds it from the original,
+  # after which `show` redirects to it.
   def reprocess_representation
     @blob.variant_records.destroy_all
     set_representation
+  end
+
+  # Not the same situation, despite looking like it. `set_representation` is a
+  # before_action and processing downloads the *original*, so this error means
+  # the original object is confirmed absent -- s3_service raises it only
+  # `unless object.exists?`. Reprocessing would download that same missing
+  # object again, which is what the handler used to do before letting the second
+  # raise escape as a 500. Nothing here is broken; the file is gone.
+  def representation_not_found
+    head :not_found
   end
 
   def url_with_origin_param(url)

--- a/test/integration/representation_missing_original_test.rb
+++ b/test/integration/representation_missing_original_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Processing a variant downloads the original, so a blob whose original object
+# has gone missing raises `FileNotFoundError` out of the `set_representation`
+# before_action. Reprocessing cannot repair that -- it downloads the same
+# missing object -- so the request has to end as a 404 rather than as a retry.
+class RepresentationMissingOriginalTest < ActionDispatch::IntegrationTest
+  setup do
+    @blob = ActiveStorage::Blob.create_and_upload!(
+      io: file_fixture("test.png").open,
+      filename: "view.png"
+    )
+    @variant = @blob.variant(resize_to_limit: [100, 100])
+  end
+
+  test "a representation whose original is gone is not found" do
+    ActiveStorage::Blob.service.delete(@blob.key)
+
+    get representation_path
+
+    assert_response :not_found
+  end
+
+  # The same method still repairs the case it was written for, so replacing the
+  # handler must not take that with it.
+  test "a representation whose own object is gone is rebuilt and served" do
+    @variant.processed
+    ActiveStorage::Blob.service.delete(@blob.reload.variant_records.sole.image.key)
+
+    get representation_path
+
+    assert_response :redirect
+  end
+
+  private def representation_path
+    rails_blob_representation_path(
+      signed_blob_id: @blob.signed_id,
+      variation_key: @variant.variation.key,
+      filename: @blob.filename
+    )
+  end
+end


### PR DESCRIPTION
> Was stacked on #4807, which has since merged as `c9542241e`. Rebased onto `main` with my copy of that commit dropped, so this is now a single commit against `main` and the earlier merge conflict is gone.

Fixes incident #17318, `ActiveStorage::FileNotFoundError`, **226 occurrences** since Apr 20.

## The retry could never have worked

`set_representation` is a before_action, and processing a variant downloads the original. So a blob whose original object has gone missing raises before `show` is ever reached. The handler answered that by calling `reprocess_representation` — which runs `set_representation` again and downloads the same missing object. It raised a second time and escaped as a 500.

The production backtrace shows precisely this: the reported frame **is** the second raise, inside our own handler.

```
s3_service.rb:174           #stream         ← raise FileNotFoundError unless object.exists?
blob.rb:310                 Blob#open       ← downloads the ORIGINAL
variant_with_record.rb:44   #process
base_controller.rb:14       #set_representation
redirect_controller.rb:21   #reprocess_representation      ← ours
rescuable.rb:110            handler_for_rescue
rescue.rb:39                Rescue#process_action
```

Two details make the futility structural rather than incidental:

- `s3_service` raises this error only `unless object.exists?` — a confirmed absence, never a transient failure, so retrying cannot change the outcome.
- `processed?` is `record.present?`, so reaching `process` means no variant record existed. The handler's `variant_records.destroy_all` therefore had nothing to drop either.

## The change

A file that is gone is a **404**. That is the honest status, and it lets browsers and the CDN treat the image as missing instead of hammering a 500.

`reprocess_representation` stays exactly where it does real work: `show` calls it when the probe reports the *variant's own* object missing, which rebuilds it from an original that is still present. Only the `rescue_from` hook changes.

## Verification

Two tests, and the pair is the point — with the handler reverted to its current form:

```
test "a representation whose original is gone is not found"
  → ActiveStorage::FileNotFoundError    (incident #17318, verbatim)

test "a representation whose own object is gone is rebuilt and served"
  → passes
```

The first reproduces the production error; the second passes *both* with and without the change, which is what demonstrates the working repair path is untouched rather than merely asserted to be.

With the fix: 2/2, and 5/5 across both storage test files together. `bin/ruby-lint` clean over 2,505 files.

## Correction to what I reported earlier

I had described this as an empty `200` based on a probe that stubbed `service.exist?` to raise `FileNotFoundError`. The real `S3Service#exist?` never raises it, so that measurement exercised a path that does not occur. The production backtrace shows the actual outcome is a 500 from the second raise. The defect is real either way, but it is a doomed retry, not a silent empty response.

🤖
