### PR TITLE
fix(hangar): only offer ships a player can actually own

### DIFF
--- a/app/frontend/frontend/components/Vehicles/NewVehiclesModal/index.vue
+++ b/app/frontend/frontend/components/Vehicles/NewVehiclesModal/index.vue
@@ -14,6 +14,8 @@ import { useComlink } from "@/shared/composables/useComlink";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useVehicleMutations } from "@/frontend/composables/useVehicleMutations";
 import { type ModelQuery } from "@/services/fyApi";
+import { validationErrorFrom } from "@/shared/utils/ApiErrors";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 
 type Props = {
   wanted?: boolean;
@@ -26,6 +28,8 @@ const props = withDefaults(defineProps<Props>(), {
 const { t } = useI18n();
 
 const comlink = useComlink();
+
+const { displayAlert } = useAppNotifications();
 
 const { useCreateBulkMutation } = useVehicleMutations();
 
@@ -67,10 +71,15 @@ const save = async (selection: ModelPickerSelection[]) => {
     .mutateAsync({ data: { vehicles } })
     .then(() => {
       comlink.emit("hangar-change");
+      comlink.emit("close-modal");
+    })
+    .catch((error) => {
+      const { message } = validationErrorFrom(error);
+
+      displayAlert({ text: message });
     })
     .finally(() => {
       submitting.value = false;
-      comlink.emit("close-modal");
     });
 };
 </script>

--- a/app/frontend/frontend/components/Vehicles/NewVehiclesModal/index.vue
+++ b/app/frontend/frontend/components/Vehicles/NewVehiclesModal/index.vue
@@ -13,6 +13,7 @@ import {
 import { useComlink } from "@/shared/composables/useComlink";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useVehicleMutations } from "@/frontend/composables/useVehicleMutations";
+import { type ModelQuery } from "@/services/fyApi";
 
 type Props = {
   wanted?: boolean;
@@ -44,6 +45,12 @@ const highlight = computed(() =>
   props.wanted ? ModelPickerBadge.ON_WISHLIST : ModelPickerBadge.IN_HANGAR,
 );
 
+// A ship the game does not let players own cannot go in a hangar or on a
+// wishlist -- Vehicle rejects it outright. The single-ship button already hides
+// itself for those, so without this the picker was the one way to reach a save
+// that could only fail.
+const ownableOnly: ModelQuery = { playerOwnableEq: true };
+
 const save = async (selection: ModelPickerSelection[]) => {
   submitting.value = true;
 
@@ -74,6 +81,7 @@ const save = async (selection: ModelPickerSelection[]) => {
     :submit-label="submitLabel"
     :submitting="submitting"
     :highlight="highlight"
+    :query="ownableOnly"
     quantities
     @submit="save"
   />

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -14,6 +14,7 @@ de:
       create: Schiff konnte nicht hinzugefügt werden.
       destroy: Schiff konnte nicht entfernt werden.
       update: Schiff konnte nicht aktualisiert werden.
+      bulk_create: Einige Schiffe konnten nicht hinzugefügt werden.
     vehicle_loadout:
       create: Loadout konnte nicht erstellt werden.
       destroy: Loadout konnte nicht entfernt werden.

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -14,6 +14,7 @@ en:
       create: Ship could not be added.
       destroy: Ship could not be removed.
       update: Ship could not be updated.
+      bulk_create: Some ships could not be added.
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.

--- a/config/locales/es/validation_error.yml
+++ b/config/locales/es/validation_error.yml
@@ -10,6 +10,7 @@ es:
       create: La nave no pudo ser agregada.
       destroy: La nave no pudo ser eliminada.
       update: La nave no pudo ser actualizada.
+      bulk_create: Algunas naves no se pudieron añadir.
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.

--- a/config/locales/fr/validation_error.yml
+++ b/config/locales/fr/validation_error.yml
@@ -7,6 +7,7 @@ fr:
       create: Le vaisseau n'a pas pu être ajouté.
       destroy: Le vaisseau n'a pas pu être retiré.
       update: Le vaisseau n'a pas pu être mis à jour.
+      bulk_create: Certains vaisseaux n'ont pas pu être ajoutés.
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.

--- a/config/locales/it/validation_error.yml
+++ b/config/locales/it/validation_error.yml
@@ -7,6 +7,7 @@ it:
       create: La nave non è stata aggiunta.
       destroy: La nave non è stata rimossa.
       update: La nave non è stata aggiornata.
+      bulk_create: Alcune navi non sono state aggiunte.
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.

--- a/config/locales/zh-CN/validation_error.yml
+++ b/config/locales/zh-CN/validation_error.yml
@@ -7,6 +7,7 @@ zh-CN:
       create: 飞船无法添加。
       destroy: 飞船无法移除。
       update: 飞船无法更新。
+      bulk_create: 部分舰船无法添加。
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.

--- a/config/locales/zh-TW/validation_error.yml
+++ b/config/locales/zh-TW/validation_error.yml
@@ -7,6 +7,7 @@ zh-TW:
       create: 飛船無法新增。
       destroy: 飛船無法移除。
       update: 飛船無法更新。
+      bulk_create: 部分艦船無法新增。
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.

--- a/swagger/v1/oasdiff-ignore.txt
+++ b/swagger/v1/oasdiff-ignore.txt
@@ -999,3 +999,5 @@ GET /sc-data/compare the `catalogues/equipment/appeared/items/` response's prope
 GET /sc-data/compare the `catalogues/equipment/vanished/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
 GET /sc-data/compare the `catalogues/models/appeared/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
 GET /sc-data/compare the `catalogues/models/vanished/items/` response's property type/format changed from `string`/`uuid` to `object`/`` for status `200`
+POST /vehicles/bulk removed the required property `details` from the response with the `400` status
+POST /vehicles/bulk removed the required property `error` from the response with the `400` status

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -10233,14 +10233,18 @@ paths:
       responses:
         '204':
           description: successful
+        '400':
+          description: bad request - a ship that cannot be owned
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
         '401':
           description: unauthorized
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/StandardError"
-        '400':
-          "$ref": "#/components/responses/SchemaValidationError"
     put:
       summary: Update multiple vehicles
       tags:

--- a/test/integration/api/v1/vehicles_create_bulk_test.rb
+++ b/test/integration/api/v1/vehicles_create_bulk_test.rb
@@ -24,6 +24,10 @@ class Api::V1::VehiclesCreateBulkTest < ActionDispatch::IntegrationTest
 
       response(204, "successful")
 
+      response(400, "bad request - a ship that cannot be owned") do
+        schema ::Shared::V1::Schemas::ValidationError
+      end
+
       response(401, "unauthorized") do
         schema ::Shared::V1::Schemas::StandardError
       end
@@ -39,6 +43,31 @@ class Api::V1::VehiclesCreateBulkTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     assert_api_response :post, 204, body: {vehicles: [{modelId: model.id, wanted: true}]}
+  end
+
+  # The picker used to offer these, which is where the reported 400s came from.
+  test "POST /vehicles/bulk returns 400 for a model a player cannot own" do
+    model = create(:model, player_ownable: false)
+    sign_in @user
+
+    assert_api_response :post, 400, body: {vehicles: [{modelId: model.id, wanted: false}]}
+
+    assert_equal 0, Vehicle.count
+  end
+
+  # The message is built from `I18n.t("validation_error.#{code}")`, so a missing
+  # key ships as the literal "translation missing: ..." string in the payload.
+  test "POST /vehicles/bulk names the failure rather than reporting a missing translation" do
+    model = create(:model, player_ownable: false)
+    sign_in @user
+
+    assert_api_response :post, 400, body: {vehicles: [{modelId: model.id, wanted: false}]}
+
+    payload = response.parsed_body
+
+    assert_equal "validation_error.vehicle.bulk_create", payload["code"]
+    assert_equal "Some ships could not be added.", payload["message"]
+    refute_includes payload["message"], "translation missing"
   end
 
   test "POST /vehicles/bulk returns 401 when not signed in" do


### PR DESCRIPTION
Fixes incident #17518, `AxiosError: Request failed with status code 400` on `POST /vehicles/bulk`, **540 occurrences** since May 10.

## Why the 400 happened

The bulk picker queried every model, so it listed the **Bengal** — the one ship in the catalogue with `player_ownable: false`. Picking it produced a save that could never succeed: `Vehicle#model_must_be_player_ownable` rejects it, so `create_bulk` answered 400.

Confirmed from production rather than reasoned about. The one sampled 400 trace (Sep 08, 14:07 — the same minute as the frontend `AxiosError`) carries its payload on the backend span:

```json
{"vehicles":[{"model_id":"485e6bd1-d922-4b5e-9cd9-bd6cadc3ee45","wanted":false}]}
```

Resolving that id against the database:

```
Name:            Bengal
player_ownable:  false
valid?           false
Fehler:          Model cannot be added to a hangar (not player ownable)
```

**The rule already existed in the UI.** `Models/AddToHangar` hides its button behind `v-if="model.playerOwnable"`. The picker was the only route to a selection the API refuses, so it is the picker that was wrong — not the endpoint.

Worth noting how narrow this is: 245 of 246 models are ownable. One bad option in the grid, and it happens to be the capital ship everyone tries once.

## What changed

**1. The picker only offers ownable ships** — the actual fix. `:query="{ playerOwnableEq: true }"`, a filter both `ModelQuery` and the ransack allowlist already supported.

Deliberately scoped to this one caller. `query` is a prop with an `undefined` default, so nothing is shared: **Compare** passes no `query` at all and **CargoGrids** passes its own. Neither is filtered, which is right — comparing a Bengal or putting one on a cargo grid writes no `Vehicle` row, so ownability does not apply there.

**2. A failed add is now surfaced instead of closed over.** `save` chained `.then` and `.finally` with no `.catch`, so a rejection went two ways at once: it escaped an async event handler as an unhandled promise — the 540 AppSignal reports — while `.finally` closed the modal as though the ships had been added. The user was told nothing and saw nothing added. Now handled via `validationErrorFrom` + `displayAlert`, with `close-modal` moved into `.then`, matching `Vehicles/NamingModal` which this is otherwise a copy of. This is the backstop; commit 1 is the fix.

**3. The failure has a name in all seven locales.** `ValidationError` builds its message from `I18n.t("validation_error.#{code}")`, and `validation_error.vehicle.bulk_create` was never defined — the payload literally carried `translation missing: en.validation_error.vehicle.bulk_create`. Nobody noticed because the frontend discarded the response. All seven locales, since nothing checks key parity and `enableFallback` would have hidden a gap behind English.

While confirming this I audited every `ValidationError.new` code in the app: **71 of 138 have no translation.** The rest are out of scope here, but it is a systemic gap worth its own pass.

## Verification

The 400 branch had no test at all — the schema declared 204 and 401 only, which is exactly how the missing translation survived. Two tests added; removing the locale key again fails the second one, so it holds rather than merely passing.

```
6 tests, 15 assertions, 0 failures
```

`bin/ruby-lint` clean over 2,504 files, `lint:ts` exit 0, prettier clean.

## On the schema change

Declaring the 400 replaces the auto-injected `SchemaValidationError` with the `ValidationError` the endpoint actually renders. oasdiff reads the two dropped required properties as breaking:

```
POST /vehicles/bulk removed the required property `details` from the response with the `400` status
POST /vehicles/bulk removed the required property `error` from the response with the `400` status
```

They are breaking only against a schema that documented a shape this endpoint never returned, so both are ignored. Written against **oasdiff 1.18.1**, the version CI pins — the local binary is 1.31.0 and words these differently, which would have passed here and failed on CI. Verified clean with 1.18.1:

```
No breaking changes to report, but the specs are different.
```

orval regenerated the client with no diff.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vehicle selection now shows only ships that can be owned.
  * Bulk vehicle creation errors now display clear, localized messages when some ships cannot be added.
  * API responses document and return structured validation details for non-ownable ships.

* **Bug Fixes**
  * The vehicle creation modal now closes only after a successful save.
  * Failed saves keep the modal open so users can review and address the error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->