### PR TITLE
i18n: give every validation error a message, in every locale

### DIFF
--- a/app/controllers/api/v1/notification_preferences_controller.rb
+++ b/app/controllers/api/v1/notification_preferences_controller.rb
@@ -30,7 +30,7 @@ module Api
         if @notification_preference.update(notification_preference_params)
           render :show
         else
-          render json: ValidationError.new("notification_preference", @notification_preference.errors), status: :bad_request
+          render json: ValidationError.new("notification_preference", errors: @notification_preference.errors), status: :bad_request
         end
       end
 

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -15,6 +15,9 @@ de:
       destroy: Schiff konnte nicht entfernt werden.
       update: Schiff konnte nicht aktualisiert werden.
       bulk_create: Einige Schiffe konnten nicht hinzugefügt werden.
+      bulk_update: Einige Schiffe konnten nicht aktualisiert werden.
+      move_all_ingame_to_wish_list: Ingame-Schiffe konnten nicht auf die Wunschliste verschoben werden.
+      sync: Hangar konnte nicht synchronisiert werden.
     vehicle_loadout:
       create: Loadout konnte nicht erstellt werden.
       destroy: Loadout konnte nicht entfernt werden.
@@ -29,6 +32,7 @@ de:
       decline: Flottenmitglied konnte nicht abgelehnt werden.
       destroy: Flottenmitglied konnte nicht entfernt werden.
       update: Flottenmitglied konnte nicht aktualisiert werden.
+      demote: Flottenmitglied konnte nicht herabgestuft werden.
     fleet_memberships:
       create: Flotteneinladung konnte nicht verwendet werden
       destroy: Flotte konnte nicht verlassen werden.
@@ -36,6 +40,7 @@ de:
       decline: Flotteneinladung konnte nicht abgelehnt werden.
       demote_not_permitted: Sie können das letzte Mitglied einer permanenten Flottenrolle
         nicht degradieren.
+      update: Flottenmitgliedschaft konnte nicht aktualisiert werden.
     hangar_group:
       create: Gruppe konnte nicht erstellt werden
       destroy: Gruppe konnte nicht gelöscht werden
@@ -65,6 +70,8 @@ de:
     image:
       create: Bild konnte nicht erstellt werden
       update: Bild konnte nicht aktualisiert werden
+      bulk_update: Einige Bilder konnten nicht aktualisiert werden.
+      destroy: Bild konnte nicht gelöscht werden.
     request_password: Passwort-Anforderung fehlgeschlagen.
     signup: Registrierung fehlgeschlagen. Bitte beheben Sie alle Fehler und versuchen
       Sie es erneut.
@@ -76,9 +83,96 @@ de:
       create: OAuth-Anwendung konnte nicht erstellt werden.
       update: OAuth-Anwendung konnte nicht aktualisiert werden.
       destroy: OAuth-Anwendung konnte nicht gelöscht werden.
+      regenerate_secret: Secret konnte nicht neu erzeugt werden.
     user:
       destroy: Benutzer konnte nicht gelöscht werden.
+      update: Benutzer konnte nicht aktualisiert werden.
     current_user:
       destroy: Account konnte nicht gelöscht werden.
     hangar:
       import: Import fehlgeschlagen
+    cargo_hold:
+      update: Frachtraum konnte nicht aktualisiert werden.
+    compare:
+      share: Vergleich konnte nicht geteilt werden.
+    component:
+      create: Bauteil konnte nicht erstellt werden.
+      destroy: Bauteil konnte nicht gelöscht werden.
+      update: Bauteil konnte nicht aktualisiert werden.
+    dock:
+      create: Dock konnte nicht erstellt werden.
+      update: Dock konnte nicht aktualisiert werden.
+    fleet_events:
+      update_occurrence: Dieser Termin der Serie konnte nicht aktualisiert werden.
+    fleet_invite_urls:
+      create: Einladungslink konnte nicht erstellt werden.
+      destroy: Einladungslink konnte nicht gelöscht werden.
+    funding_goal:
+      create: Finanzierungsziel konnte nicht erstellt werden.
+      destroy: Finanzierungsziel konnte nicht gelöscht werden.
+      update: Finanzierungsziel konnte nicht aktualisiert werden.
+    hardpoint:
+      create: Hardpoint konnte nicht erstellt werden.
+      update: Hardpoint konnte nicht aktualisiert werden.
+    item_price:
+      create: Gegenstandspreis konnte nicht erstellt werden.
+      update: Gegenstandspreis konnte nicht aktualisiert werden.
+    manufacturer:
+      create: Hersteller konnte nicht erstellt werden.
+      destroy: Hersteller konnte nicht gelöscht werden.
+      update: Hersteller konnte nicht aktualisiert werden.
+    mission_ships:
+      create: Missionsschiff konnte nicht erstellt werden.
+      destroy: Missionsschiff konnte nicht gelöscht werden.
+      duplicate: Missionsschiff konnte nicht dupliziert werden.
+      update: Missionsschiff konnte nicht aktualisiert werden.
+    mission_slots:
+      create: Missionsplatz konnte nicht erstellt werden.
+      destroy: Missionsplatz konnte nicht gelöscht werden.
+      update: Missionsplatz konnte nicht aktualisiert werden.
+    mission_teams:
+      create: Missionsteam konnte nicht erstellt werden.
+      destroy: Missionsteam konnte nicht gelöscht werden.
+      update: Missionsteam konnte nicht aktualisiert werden.
+    missions:
+      create: Mission konnte nicht erstellt werden.
+      destroy: Mission konnte nicht gelöscht werden.
+      unarchive: Mission konnte nicht aus dem Archiv geholt werden.
+      update: Mission konnte nicht aktualisiert werden.
+    model:
+      create: Schiff konnte nicht erstellt werden.
+      destroy: Schiff konnte nicht gelöscht werden.
+      update: Schiff konnte nicht aktualisiert werden.
+      use_rsi_image: RSI-Bild konnte nicht übernommen werden.
+    model_loaner:
+      create: Leihschiff konnte nicht erstellt werden.
+      update: Leihschiff konnte nicht aktualisiert werden.
+    model_module:
+      bulk_update: Einige Module konnten nicht aktualisiert werden.
+      create: Modul konnte nicht erstellt werden.
+      update: Modul konnte nicht aktualisiert werden.
+    model_module_package:
+      create: Modulpaket konnte nicht erstellt werden.
+      update: Modulpaket konnte nicht aktualisiert werden.
+    model_paint:
+      create: Lackierung konnte nicht erstellt werden.
+      destroy: Lackierung konnte nicht gelöscht werden.
+      update: Lackierung konnte nicht aktualisiert werden.
+    model_position:
+      create: Modellposition konnte nicht erstellt werden.
+      update: Modellposition konnte nicht aktualisiert werden.
+    model_snub_craft:
+      create: Snub-Schiff konnte nicht erstellt werden.
+      update: Snub-Schiff konnte nicht aktualisiert werden.
+    model_upgrade:
+      create: Upgrade konnte nicht erstellt werden.
+      update: Upgrade konnte nicht aktualisiert werden.
+    notification_preference: Benachrichtigungseinstellung konnte nicht aktualisiert werden.
+    supporter_contribution:
+      create: Unterstützerbeitrag konnte nicht erstellt werden.
+      destroy: Unterstützerbeitrag konnte nicht gelöscht werden.
+      update: Unterstützerbeitrag konnte nicht aktualisiert werden.
+    update: Profil konnte nicht aktualisiert werden.
+    video:
+      create: Video konnte nicht erstellt werden.
+      update: Video konnte nicht aktualisiert werden.

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -104,6 +104,9 @@ de:
       update: Dock konnte nicht aktualisiert werden.
     fleet_events:
       update_occurrence: Dieser Termin der Serie konnte nicht aktualisiert werden.
+      create: Event konnte nicht erstellt werden.
+      destroy: Event konnte nicht gelöscht werden.
+      update: Event konnte nicht aktualisiert werden.
     fleet_invite_urls:
       create: Einladungslink konnte nicht erstellt werden.
       destroy: Einladungslink konnte nicht gelöscht werden.
@@ -176,3 +179,30 @@ de:
     video:
       create: Video konnte nicht erstellt werden.
       update: Video konnte nicht aktualisiert werden.
+    commodity:
+      create: Ware konnte nicht erstellt werden.
+      destroy: Ware konnte nicht gelöscht werden.
+      update: Ware konnte nicht aktualisiert werden.
+    equipment:
+      create: Ausrüstung konnte nicht erstellt werden.
+      destroy: Ausrüstung konnte nicht gelöscht werden.
+      update: Ausrüstung konnte nicht aktualisiert werden.
+    fleet_event_admins:
+      create: Event-Admin konnte nicht vergeben werden.
+    fleet_event_ships:
+      create: Event-Schiff konnte nicht erstellt werden.
+      destroy: Event-Schiff konnte nicht gelöscht werden.
+      update: Event-Schiff konnte nicht aktualisiert werden.
+    fleet_event_signups:
+      create: Anmeldung fehlgeschlagen.
+      update: Anmeldung konnte nicht aktualisiert werden.
+    fleet_event_slots:
+      create: Event-Slot konnte nicht erstellt werden.
+      destroy: Event-Slot konnte nicht gelöscht werden.
+      update: Event-Slot konnte nicht aktualisiert werden.
+    fleet_event_teams:
+      create: Event-Team konnte nicht erstellt werden.
+      destroy: Event-Team konnte nicht gelöscht werden.
+      update: Event-Team konnte nicht aktualisiert werden.
+    fleet_notification_settings:
+      update: Benachrichtigungseinstellungen konnten nicht aktualisiert werden.

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -15,6 +15,9 @@ en:
       destroy: Ship could not be removed.
       update: Ship could not be updated.
       bulk_create: Some ships could not be added.
+      bulk_update: Some ships could not be updated.
+      move_all_ingame_to_wish_list: In-game ships could not be moved to the wishlist.
+      sync: Hangar could not be synchronised.
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.
@@ -29,16 +32,19 @@ en:
       decline: Fleet Member could not be declined.
       destroy: Fleet Member could not be removed.
       update: Fleet Member could not be updated.
+      demote: Fleet member could not be demoted.
     fleet_memberships:
       create: Fleet Invitation could not be used
       destroy: Fleet could not be leaved.
       accept: Fleet Invitation could not be accepted.
       decline: Fleet Invitation could not be declined.
       demote_not_permitted: You can't demote the last Member of a permanent Fleet Role.
+      update: Fleet membership could not be updated.
     fleet_events:
       create: Event could not be created.
       update: Event could not be updated.
       destroy: Event could not be deleted.
+      update_occurrence: This occurrence of the event could not be updated.
     fleet_event_teams:
       create: Event team could not be created.
       update: Event team could not be updated.
@@ -89,6 +95,8 @@ en:
     image:
       create: Image could not be created
       update: Image could not be updated
+      bulk_update: Some images could not be updated.
+      destroy: Image could not be destroyed.
     request_password: Request Password failed.
     signup: Signup failed. Please resolve all Errors and try again.
     admin_user:
@@ -99,8 +107,10 @@ en:
       create: OAuth application could not be created.
       update: OAuth application could not be updated.
       destroy: OAuth application could not be destroyed.
+      regenerate_secret: Secret could not be regenerated.
     user:
       destroy: User could not be destroyed.
+      update: User could not be updated.
     current_user:
       destroy: Account could not be destroyed.
     hangar:
@@ -113,3 +123,86 @@ en:
       create: Commodity could not be created.
       update: Commodity could not be updated.
       destroy: Commodity could not be destroyed.
+    cargo_hold:
+      update: Cargo hold could not be updated.
+    compare:
+      share: Comparison could not be shared.
+    component:
+      create: Component could not be created.
+      destroy: Component could not be destroyed.
+      update: Component could not be updated.
+    dock:
+      create: Dock could not be created.
+      update: Dock could not be updated.
+    fleet_invite_urls:
+      create: Invite link could not be created.
+      destroy: Invite link could not be destroyed.
+    funding_goal:
+      create: Funding goal could not be created.
+      destroy: Funding goal could not be destroyed.
+      update: Funding goal could not be updated.
+    hardpoint:
+      create: Hardpoint could not be created.
+      update: Hardpoint could not be updated.
+    item_price:
+      create: Item price could not be created.
+      update: Item price could not be updated.
+    manufacturer:
+      create: Manufacturer could not be created.
+      destroy: Manufacturer could not be destroyed.
+      update: Manufacturer could not be updated.
+    mission_ships:
+      create: Mission ship could not be created.
+      destroy: Mission ship could not be destroyed.
+      duplicate: Mission ship could not be duplicated.
+      update: Mission ship could not be updated.
+    mission_slots:
+      create: Mission slot could not be created.
+      destroy: Mission slot could not be destroyed.
+      update: Mission slot could not be updated.
+    mission_teams:
+      create: Mission team could not be created.
+      destroy: Mission team could not be destroyed.
+      update: Mission team could not be updated.
+    missions:
+      create: Mission could not be created.
+      destroy: Mission could not be destroyed.
+      unarchive: Mission could not be unarchived.
+      update: Mission could not be updated.
+    model:
+      create: Ship could not be created.
+      destroy: Ship could not be destroyed.
+      update: Ship could not be updated.
+      use_rsi_image: RSI image could not be used.
+    model_loaner:
+      create: Loaner could not be created.
+      update: Loaner could not be updated.
+    model_module:
+      bulk_update: Some modules could not be updated.
+      create: Module could not be created.
+      update: Module could not be updated.
+    model_module_package:
+      create: Module package could not be created.
+      update: Module package could not be updated.
+    model_paint:
+      create: Paint could not be created.
+      destroy: Paint could not be destroyed.
+      update: Paint could not be updated.
+    model_position:
+      create: Model position could not be created.
+      update: Model position could not be updated.
+    model_snub_craft:
+      create: Snub craft could not be created.
+      update: Snub craft could not be updated.
+    model_upgrade:
+      create: Upgrade could not be created.
+      update: Upgrade could not be updated.
+    notification_preference: Notification preference could not be updated.
+    supporter_contribution:
+      create: Supporter contribution could not be created.
+      destroy: Supporter contribution could not be destroyed.
+      update: Supporter contribution could not be updated.
+    update: Profile could not be updated.
+    video:
+      create: Video could not be created.
+      update: Video could not be updated.

--- a/config/locales/es/validation_error.yml
+++ b/config/locales/es/validation_error.yml
@@ -99,6 +99,9 @@ es:
       update: No se pudo actualizar el dique.
     fleet_events:
       update_occurrence: No se pudo actualizar esta repetición del evento.
+      create: No se pudo crear el evento.
+      destroy: No se pudo eliminar el evento.
+      update: No se pudo actualizar el evento.
     fleet_invite_urls:
       create: No se pudo crear el enlace de invitación.
       destroy: No se pudo eliminar el enlace de invitación.
@@ -171,3 +174,32 @@ es:
     video:
       create: No se pudo crear el vídeo.
       update: No se pudo actualizar el vídeo.
+    commodity:
+      create: No se pudo crear la mercancía.
+      destroy: No se pudo eliminar la mercancía.
+      update: No se pudo actualizar la mercancía.
+    equipment:
+      create: No se pudo crear el equipamiento.
+      destroy: No se pudo eliminar el equipamiento.
+      update: No se pudo actualizar el equipamiento.
+    fleet_event_admins:
+      create: No se pudo conceder el rol de administrador del evento.
+    fleet_event_ships:
+      create: No se pudo crear la nave del evento.
+      destroy: No se pudo eliminar la nave del evento.
+      update: No se pudo actualizar la nave del evento.
+    fleet_event_signups:
+      create: La inscripción falló.
+      update: No se pudo actualizar la inscripción.
+    fleet_event_slots:
+      create: No se pudo crear el slot del evento.
+      destroy: No se pudo eliminar el slot del evento.
+      update: No se pudo actualizar el slot del evento.
+    fleet_event_teams:
+      create: No se pudo crear el equipo del evento.
+      destroy: No se pudo eliminar el equipo del evento.
+      update: No se pudo actualizar el equipo del evento.
+    fleet_notification_settings:
+      update: No se pudieron actualizar los ajustes de notificación.
+    version:
+      revert: No se pudo restaurar el campo.

--- a/config/locales/es/validation_error.yml
+++ b/config/locales/es/validation_error.yml
@@ -11,6 +11,9 @@ es:
       destroy: La nave no pudo ser eliminada.
       update: La nave no pudo ser actualizada.
       bulk_create: Algunas naves no se pudieron añadir.
+      bulk_update: No se pudieron actualizar algunas naves.
+      move_all_ingame_to_wish_list: No se pudieron mover las naves del juego a la lista de deseos.
+      sync: No se pudo sincronizar el hangar.
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.
@@ -25,6 +28,7 @@ es:
       decline: No se pudo rechazar al miembro de la flota.
       destroy: No se pudo eliminar al miembro de la flota.
       update: No se pudo actualizar al miembro de la flota.
+      demote: No se pudo degradar al miembro de la flota.
     fleet_memberships:
       create: La invitación de flota no pudo ser utilizada
       destroy: No se pudo abandonar la flota.
@@ -32,6 +36,7 @@ es:
       decline: La invitación de flota no pudo ser rechazada.
       demote_not_permitted: No puede degradar al último miembro de un rol de flota
         permanente.
+      update: No se pudo actualizar la membresía de la flota.
     hangar_group:
       create: No se pudo crear el grupo
       destroy: No se pudo destruir el grupo
@@ -61,6 +66,8 @@ es:
     image:
       create: No se pudo crear la imagen
       update: No se pudo actualizar la imagen
+      bulk_update: No se pudieron actualizar algunas imágenes.
+      destroy: No se pudo eliminar la imagen.
     request_password: Solicitud de contraseña fallida.
     signup: Registro fallido. Resuelva todos los errores e intente de nuevo.
     admin_user:
@@ -71,9 +78,96 @@ es:
       create: La aplicación OAuth no pudo ser creada.
       update: La aplicación OAuth no pudo ser actualizada.
       destroy: La aplicación OAuth no pudo ser eliminada.
+      regenerate_secret: No se pudo regenerar el secreto.
     user:
       destroy: El usuario no pudo ser eliminado.
+      update: No se pudo actualizar el usuario.
     current_user:
       destroy: La cuenta no pudo ser eliminada.
     hangar:
       import: Importación fallida
+    cargo_hold:
+      update: No se pudo actualizar la bodega de carga.
+    compare:
+      share: No se pudo compartir la comparación.
+    component:
+      create: No se pudo crear el componente.
+      destroy: No se pudo eliminar el componente.
+      update: No se pudo actualizar el componente.
+    dock:
+      create: No se pudo crear el dique.
+      update: No se pudo actualizar el dique.
+    fleet_events:
+      update_occurrence: No se pudo actualizar esta repetición del evento.
+    fleet_invite_urls:
+      create: No se pudo crear el enlace de invitación.
+      destroy: No se pudo eliminar el enlace de invitación.
+    funding_goal:
+      create: No se pudo crear el objetivo de financiación.
+      destroy: No se pudo eliminar el objetivo de financiación.
+      update: No se pudo actualizar el objetivo de financiación.
+    hardpoint:
+      create: No se pudo crear el anclaje.
+      update: No se pudo actualizar el anclaje.
+    item_price:
+      create: No se pudo crear el precio del objeto.
+      update: No se pudo actualizar el precio del objeto.
+    manufacturer:
+      create: No se pudo crear el fabricante.
+      destroy: No se pudo eliminar el fabricante.
+      update: No se pudo actualizar el fabricante.
+    mission_ships:
+      create: No se pudo crear la nave de la misión.
+      destroy: No se pudo eliminar la nave de la misión.
+      duplicate: No se pudo duplicar la nave de la misión.
+      update: No se pudo actualizar la nave de la misión.
+    mission_slots:
+      create: No se pudo crear el puesto de la misión.
+      destroy: No se pudo eliminar el puesto de la misión.
+      update: No se pudo actualizar el puesto de la misión.
+    mission_teams:
+      create: No se pudo crear el equipo de la misión.
+      destroy: No se pudo eliminar el equipo de la misión.
+      update: No se pudo actualizar el equipo de la misión.
+    missions:
+      create: No se pudo crear la misión.
+      destroy: No se pudo eliminar la misión.
+      unarchive: No se pudo desarchivar la misión.
+      update: No se pudo actualizar la misión.
+    model:
+      create: No se pudo crear la nave.
+      destroy: No se pudo eliminar la nave.
+      update: No se pudo actualizar la nave.
+      use_rsi_image: No se pudo usar la imagen de RSI.
+    model_loaner:
+      create: No se pudo crear la nave de préstamo.
+      update: No se pudo actualizar la nave de préstamo.
+    model_module:
+      bulk_update: No se pudieron actualizar algunos módulos.
+      create: No se pudo crear el módulo.
+      update: No se pudo actualizar el módulo.
+    model_module_package:
+      create: No se pudo crear el paquete de módulos.
+      update: No se pudo actualizar el paquete de módulos.
+    model_paint:
+      create: No se pudo crear la pintura.
+      destroy: No se pudo eliminar la pintura.
+      update: No se pudo actualizar la pintura.
+    model_position:
+      create: No se pudo crear la posición del modelo.
+      update: No se pudo actualizar la posición del modelo.
+    model_snub_craft:
+      create: No se pudo crear la nave snub.
+      update: No se pudo actualizar la nave snub.
+    model_upgrade:
+      create: No se pudo crear la mejora.
+      update: No se pudo actualizar la mejora.
+    notification_preference: No se pudo actualizar la preferencia de notificación.
+    supporter_contribution:
+      create: No se pudo crear la contribución del patrocinador.
+      destroy: No se pudo eliminar la contribución del patrocinador.
+      update: No se pudo actualizar la contribución del patrocinador.
+    update: No se pudo actualizar el perfil.
+    video:
+      create: No se pudo crear el vídeo.
+      update: No se pudo actualizar el vídeo.

--- a/config/locales/fr/validation_error.yml
+++ b/config/locales/fr/validation_error.yml
@@ -96,6 +96,9 @@ fr:
       update: Impossible de mettre à jour le dock.
     fleet_events:
       update_occurrence: Impossible de mettre à jour cette occurrence de l'événement.
+      create: Impossible de créer l'événement.
+      destroy: Impossible de supprimer l'événement.
+      update: Impossible de mettre à jour l'événement.
     fleet_invite_urls:
       create: Impossible de créer le lien d'invitation.
       destroy: Impossible de supprimer le lien d'invitation.
@@ -168,3 +171,32 @@ fr:
     video:
       create: Impossible de créer la vidéo.
       update: Impossible de mettre à jour la vidéo.
+    commodity:
+      create: Impossible de créer la marchandise.
+      destroy: Impossible de supprimer la marchandise.
+      update: Impossible de mettre à jour la marchandise.
+    equipment:
+      create: Impossible de créer l'équipement.
+      destroy: Impossible de supprimer l'équipement.
+      update: Impossible de mettre à jour l'équipement.
+    fleet_event_admins:
+      create: Impossible d'accorder le rôle d'administrateur de l'événement.
+    fleet_event_ships:
+      create: Impossible de créer le vaisseau de l'événement.
+      destroy: Impossible de supprimer le vaisseau de l'événement.
+      update: Impossible de mettre à jour le vaisseau de l'événement.
+    fleet_event_signups:
+      create: L'inscription a échoué.
+      update: Impossible de mettre à jour l'inscription.
+    fleet_event_slots:
+      create: Impossible de créer le slot de l'événement.
+      destroy: Impossible de supprimer le slot de l'événement.
+      update: Impossible de mettre à jour le slot de l'événement.
+    fleet_event_teams:
+      create: Impossible de créer l'équipe de l'événement.
+      destroy: Impossible de supprimer l'équipe de l'événement.
+      update: Impossible de mettre à jour l'équipe de l'événement.
+    fleet_notification_settings:
+      update: Impossible de mettre à jour les paramètres de notification.
+    version:
+      revert: Impossible de rétablir le champ.

--- a/config/locales/fr/validation_error.yml
+++ b/config/locales/fr/validation_error.yml
@@ -8,6 +8,9 @@ fr:
       destroy: Le vaisseau n'a pas pu être retiré.
       update: Le vaisseau n'a pas pu être mis à jour.
       bulk_create: Certains vaisseaux n'ont pas pu être ajoutés.
+      bulk_update: Impossible de mettre à jour certains vaisseaux.
+      move_all_ingame_to_wish_list: Impossible de déplacer les vaisseaux in-game vers la liste de souhaits.
+      sync: Impossible de synchroniser le hangar.
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.
@@ -22,6 +25,7 @@ fr:
       decline: Impossible de refuser le membre de la flotte.
       destroy: Impossible de retirer le membre de la flotte.
       update: Impossible de mettre à jour le membre de la flotte.
+      demote: Impossible de rétrograder le membre de la flotte.
     fleet_memberships:
       create: L'invitation à la flotte n'a pas pu être utilisée
       destroy: Impossible de quitter la flotte.
@@ -29,6 +33,7 @@ fr:
       decline: L'invitation à la flotte n'a pas pu être refusée.
       demote_not_permitted: Vous ne pouvez pas rétrograder le dernier membre d'un
         rôle de flotte permanent.
+      update: Impossible de mettre à jour l'adhésion à la flotte.
     hangar_group:
       create: Le groupe n'a pas pu être créé
       destroy: Le groupe n'a pas pu être détruit
@@ -58,6 +63,8 @@ fr:
     image:
       create: Impossible de créer l'image
       update: Impossible de mettre à jour l'image
+      bulk_update: Impossible de mettre à jour certaines images.
+      destroy: Impossible de supprimer l'image.
     request_password: La demande de mot de passe a échoué.
     signup: Échec de l'inscription. Veuillez résoudre toutes les erreurs et réessayer.
     admin_user:
@@ -68,9 +75,96 @@ fr:
       create: L'application OAuth n'a pas pu être créée.
       update: L'application OAuth n'a pas pu être mise à jour.
       destroy: L'application OAuth n'a pas pu être supprimée.
+      regenerate_secret: Impossible de régénérer le secret.
     user:
       destroy: L'utilisateur n'a pas pu être supprimé.
+      update: Impossible de mettre à jour l'utilisateur.
     current_user:
       destroy: Le compte n'a pas pu être supprimé.
     hangar:
       import: Échec de l'import
+    cargo_hold:
+      update: Impossible de mettre à jour la soute.
+    compare:
+      share: Impossible de partager la comparaison.
+    component:
+      create: Impossible de créer le composant.
+      destroy: Impossible de supprimer le composant.
+      update: Impossible de mettre à jour le composant.
+    dock:
+      create: Impossible de créer le dock.
+      update: Impossible de mettre à jour le dock.
+    fleet_events:
+      update_occurrence: Impossible de mettre à jour cette occurrence de l'événement.
+    fleet_invite_urls:
+      create: Impossible de créer le lien d'invitation.
+      destroy: Impossible de supprimer le lien d'invitation.
+    funding_goal:
+      create: Impossible de créer l'objectif de financement.
+      destroy: Impossible de supprimer l'objectif de financement.
+      update: Impossible de mettre à jour l'objectif de financement.
+    hardpoint:
+      create: Impossible de créer le point d'ancrage.
+      update: Impossible de mettre à jour le point d'ancrage.
+    item_price:
+      create: Impossible de créer le prix de l'objet.
+      update: Impossible de mettre à jour le prix de l'objet.
+    manufacturer:
+      create: Impossible de créer le fabricant.
+      destroy: Impossible de supprimer le fabricant.
+      update: Impossible de mettre à jour le fabricant.
+    mission_ships:
+      create: Impossible de créer le vaisseau de mission.
+      destroy: Impossible de supprimer le vaisseau de mission.
+      duplicate: Impossible de dupliquer le vaisseau de mission.
+      update: Impossible de mettre à jour le vaisseau de mission.
+    mission_slots:
+      create: Impossible de créer le poste de mission.
+      destroy: Impossible de supprimer le poste de mission.
+      update: Impossible de mettre à jour le poste de mission.
+    mission_teams:
+      create: Impossible de créer l'équipe de mission.
+      destroy: Impossible de supprimer l'équipe de mission.
+      update: Impossible de mettre à jour l'équipe de mission.
+    missions:
+      create: Impossible de créer la mission.
+      destroy: Impossible de supprimer la mission.
+      unarchive: Impossible de désarchiver la mission.
+      update: Impossible de mettre à jour la mission.
+    model:
+      create: Impossible de créer le vaisseau.
+      destroy: Impossible de supprimer le vaisseau.
+      update: Impossible de mettre à jour le vaisseau.
+      use_rsi_image: Impossible d'utiliser l'image RSI.
+    model_loaner:
+      create: Impossible de créer le vaisseau de prêt.
+      update: Impossible de mettre à jour le vaisseau de prêt.
+    model_module:
+      bulk_update: Impossible de mettre à jour certains modules.
+      create: Impossible de créer le module.
+      update: Impossible de mettre à jour le module.
+    model_module_package:
+      create: Impossible de créer le pack de modules.
+      update: Impossible de mettre à jour le pack de modules.
+    model_paint:
+      create: Impossible de créer la peinture.
+      destroy: Impossible de supprimer la peinture.
+      update: Impossible de mettre à jour la peinture.
+    model_position:
+      create: Impossible de créer la position du modèle.
+      update: Impossible de mettre à jour la position du modèle.
+    model_snub_craft:
+      create: Impossible de créer le vaisseau snub.
+      update: Impossible de mettre à jour le vaisseau snub.
+    model_upgrade:
+      create: Impossible de créer l'amélioration.
+      update: Impossible de mettre à jour l'amélioration.
+    notification_preference: Impossible de mettre à jour la préférence de notification.
+    supporter_contribution:
+      create: Impossible de créer la contribution du soutien.
+      destroy: Impossible de supprimer la contribution du soutien.
+      update: Impossible de mettre à jour la contribution du soutien.
+    update: Impossible de mettre à jour le profil.
+    video:
+      create: Impossible de créer la vidéo.
+      update: Impossible de mettre à jour la vidéo.

--- a/config/locales/it/validation_error.yml
+++ b/config/locales/it/validation_error.yml
@@ -8,6 +8,9 @@ it:
       destroy: La nave non è stata rimossa.
       update: La nave non è stata aggiornata.
       bulk_create: Alcune navi non sono state aggiunte.
+      bulk_update: Impossibile aggiornare alcune navi.
+      move_all_ingame_to_wish_list: Impossibile spostare le navi in-game nella lista dei desideri.
+      sync: Impossibile sincronizzare l'hangar.
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.
@@ -22,6 +25,7 @@ it:
       decline: Impossibile rifiutare il membro della flotta.
       destroy: Impossibile rimuovere il membro della flotta.
       update: Impossibile aggiornare il membro della flotta.
+      demote: Impossibile retrocedere il membro della flotta.
     fleet_memberships:
       create: L'invito alla flotta non è stato utilizzato
       destroy: Impossibile lasciare la flotta.
@@ -29,6 +33,7 @@ it:
       decline: L'invito alla flotta non è stato rifiutato.
       demote_not_permitted: Non puoi degradare l'ultimo membro di un ruolo flotta
         permanente.
+      update: Impossibile aggiornare l'iscrizione alla flotta.
     hangar_group:
       create: Impossibile creare il gruppo
       destroy: Impossibile eliminare il gruppo
@@ -58,6 +63,8 @@ it:
     image:
       create: Impossibile creare l'immagine
       update: Impossibile aggiornare l'immagine
+      bulk_update: Impossibile aggiornare alcune immagini.
+      destroy: Impossibile eliminare l'immagine.
     request_password: Richiesta password fallita.
     signup: Registrazione fallita. Risolvi tutti gli errori e riprova.
     admin_user:
@@ -68,9 +75,96 @@ it:
       create: L'applicazione OAuth non è stata creata.
       update: L'applicazione OAuth non è stata aggiornata.
       destroy: L'applicazione OAuth non è stata eliminata.
+      regenerate_secret: Impossibile rigenerare il secret.
     user:
       destroy: L'utente non è stato eliminato.
+      update: Impossibile aggiornare l'utente.
     current_user:
       destroy: Account non è stato eliminato.
     hangar:
       import: Importazione fallita
+    cargo_hold:
+      update: Impossibile aggiornare la stiva.
+    compare:
+      share: Impossibile condividere il confronto.
+    component:
+      create: Impossibile creare il componente.
+      destroy: Impossibile eliminare il componente.
+      update: Impossibile aggiornare il componente.
+    dock:
+      create: Impossibile creare il dock.
+      update: Impossibile aggiornare il dock.
+    fleet_events:
+      update_occurrence: Impossibile aggiornare questa ricorrenza dell'evento.
+    fleet_invite_urls:
+      create: Impossibile creare il link di invito.
+      destroy: Impossibile eliminare il link di invito.
+    funding_goal:
+      create: Impossibile creare l'obiettivo di finanziamento.
+      destroy: Impossibile eliminare l'obiettivo di finanziamento.
+      update: Impossibile aggiornare l'obiettivo di finanziamento.
+    hardpoint:
+      create: Impossibile creare l'attacco.
+      update: Impossibile aggiornare l'attacco.
+    item_price:
+      create: Impossibile creare il prezzo dell'oggetto.
+      update: Impossibile aggiornare il prezzo dell'oggetto.
+    manufacturer:
+      create: Impossibile creare il produttore.
+      destroy: Impossibile eliminare il produttore.
+      update: Impossibile aggiornare il produttore.
+    mission_ships:
+      create: Impossibile creare la nave della missione.
+      destroy: Impossibile eliminare la nave della missione.
+      duplicate: Impossibile duplicare la nave della missione.
+      update: Impossibile aggiornare la nave della missione.
+    mission_slots:
+      create: Impossibile creare il posto della missione.
+      destroy: Impossibile eliminare il posto della missione.
+      update: Impossibile aggiornare il posto della missione.
+    mission_teams:
+      create: Impossibile creare la squadra della missione.
+      destroy: Impossibile eliminare la squadra della missione.
+      update: Impossibile aggiornare la squadra della missione.
+    missions:
+      create: Impossibile creare la missione.
+      destroy: Impossibile eliminare la missione.
+      unarchive: Impossibile ripristinare la missione dall'archivio.
+      update: Impossibile aggiornare la missione.
+    model:
+      create: Impossibile creare la nave.
+      destroy: Impossibile eliminare la nave.
+      update: Impossibile aggiornare la nave.
+      use_rsi_image: Impossibile utilizzare l'immagine RSI.
+    model_loaner:
+      create: Impossibile creare la nave in prestito.
+      update: Impossibile aggiornare la nave in prestito.
+    model_module:
+      bulk_update: Impossibile aggiornare alcuni moduli.
+      create: Impossibile creare il modulo.
+      update: Impossibile aggiornare il modulo.
+    model_module_package:
+      create: Impossibile creare il pacchetto di moduli.
+      update: Impossibile aggiornare il pacchetto di moduli.
+    model_paint:
+      create: Impossibile creare la verniciatura.
+      destroy: Impossibile eliminare la verniciatura.
+      update: Impossibile aggiornare la verniciatura.
+    model_position:
+      create: Impossibile creare la posizione del modello.
+      update: Impossibile aggiornare la posizione del modello.
+    model_snub_craft:
+      create: Impossibile creare la nave snub.
+      update: Impossibile aggiornare la nave snub.
+    model_upgrade:
+      create: Impossibile creare il potenziamento.
+      update: Impossibile aggiornare il potenziamento.
+    notification_preference: Impossibile aggiornare la preferenza di notifica.
+    supporter_contribution:
+      create: Impossibile creare il contributo del sostenitore.
+      destroy: Impossibile eliminare il contributo del sostenitore.
+      update: Impossibile aggiornare il contributo del sostenitore.
+    update: Impossibile aggiornare il profilo.
+    video:
+      create: Impossibile creare il video.
+      update: Impossibile aggiornare il video.

--- a/config/locales/it/validation_error.yml
+++ b/config/locales/it/validation_error.yml
@@ -96,6 +96,9 @@ it:
       update: Impossibile aggiornare il dock.
     fleet_events:
       update_occurrence: Impossibile aggiornare questa ricorrenza dell'evento.
+      create: Impossibile creare l'evento.
+      destroy: Impossibile eliminare l'evento.
+      update: Impossibile aggiornare l'evento.
     fleet_invite_urls:
       create: Impossibile creare il link di invito.
       destroy: Impossibile eliminare il link di invito.
@@ -168,3 +171,32 @@ it:
     video:
       create: Impossibile creare il video.
       update: Impossibile aggiornare il video.
+    commodity:
+      create: Impossibile creare il prodotto.
+      destroy: Impossibile eliminare il prodotto.
+      update: Impossibile aggiornare il prodotto.
+    equipment:
+      create: Impossibile creare l'equipaggiamento.
+      destroy: Impossibile eliminare l'equipaggiamento.
+      update: Impossibile aggiornare l'equipaggiamento.
+    fleet_event_admins:
+      create: Impossibile assegnare il ruolo di amministratore dell'evento.
+    fleet_event_ships:
+      create: Impossibile creare la nave dell'evento.
+      destroy: Impossibile eliminare la nave dell'evento.
+      update: Impossibile aggiornare la nave dell'evento.
+    fleet_event_signups:
+      create: Iscrizione non riuscita.
+      update: Impossibile aggiornare l'iscrizione.
+    fleet_event_slots:
+      create: Impossibile creare lo slot dell'evento.
+      destroy: Impossibile eliminare lo slot dell'evento.
+      update: Impossibile aggiornare lo slot dell'evento.
+    fleet_event_teams:
+      create: Impossibile creare il team dell'evento.
+      destroy: Impossibile eliminare il team dell'evento.
+      update: Impossibile aggiornare il team dell'evento.
+    fleet_notification_settings:
+      update: Impossibile aggiornare le impostazioni di notifica.
+    version:
+      revert: Impossibile ripristinare il campo.

--- a/config/locales/zh-CN/validation_error.yml
+++ b/config/locales/zh-CN/validation_error.yml
@@ -8,6 +8,9 @@ zh-CN:
       destroy: 飞船无法移除。
       update: 飞船无法更新。
       bulk_create: 部分舰船无法添加。
+      bulk_update: 部分舰船无法更新。
+      move_all_ingame_to_wish_list: 无法将游戏内舰船移至愿望清单。
+      sync: 无法同步机库。
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.
@@ -22,12 +25,14 @@ zh-CN:
       decline: 无法拒绝舰队成员。
       destroy: 无法移除舰队成员。
       update: 无法更新舰队成员。
+      demote: 无法降级该舰队成员。
     fleet_memberships:
       create: 舰队邀请无法使用
       destroy: 无法离开舰队。
       accept: 舰队邀请无法接受。
       decline: 舰队邀请无法拒绝。
       demote_not_permitted: 您不能降级永久舰队角色的最后一个成员。
+      update: 无法更新舰队成员资格。
     hangar_group:
       create: 无法创建群组
       destroy: 无法删除群组
@@ -57,6 +62,8 @@ zh-CN:
     image:
       create: 无法创建图片
       update: 无法更新图片
+      bulk_update: 部分图片无法更新。
+      destroy: 无法删除图片。
     request_password: 密码请求失败。
     signup: 注册失败。请解决所有错误后重试。
     admin_user:
@@ -67,9 +74,96 @@ zh-CN:
       create: OAuth 应用无法创建。
       update: OAuth 应用无法更新。
       destroy: OAuth 应用无法删除。
+      regenerate_secret: 无法重新生成密钥。
     user:
       destroy: 无法删除用户。
+      update: 无法更新用户。
     current_user:
       destroy: 无法删除账户。
     hangar:
       import: 导入失败
+    cargo_hold:
+      update: 无法更新货舱。
+    compare:
+      share: 无法分享该对比。
+    component:
+      create: 无法创建组件。
+      destroy: 无法删除组件。
+      update: 无法更新组件。
+    dock:
+      create: 无法创建停机位。
+      update: 无法更新停机位。
+    fleet_events:
+      update_occurrence: 无法更新该活动场次。
+    fleet_invite_urls:
+      create: 无法创建邀请链接。
+      destroy: 无法删除邀请链接。
+    funding_goal:
+      create: 无法创建募资目标。
+      destroy: 无法删除募资目标。
+      update: 无法更新募资目标。
+    hardpoint:
+      create: 无法创建挂点。
+      update: 无法更新挂点。
+    item_price:
+      create: 无法创建物品价格。
+      update: 无法更新物品价格。
+    manufacturer:
+      create: 无法创建制造商。
+      destroy: 无法删除制造商。
+      update: 无法更新制造商。
+    mission_ships:
+      create: 无法创建任务舰船。
+      destroy: 无法删除任务舰船。
+      duplicate: 无法复制该任务舰船。
+      update: 无法更新任务舰船。
+    mission_slots:
+      create: 无法创建任务席位。
+      destroy: 无法删除任务席位。
+      update: 无法更新任务席位。
+    mission_teams:
+      create: 无法创建任务小队。
+      destroy: 无法删除任务小队。
+      update: 无法更新任务小队。
+    missions:
+      create: 无法创建任务。
+      destroy: 无法删除任务。
+      unarchive: 无法取消归档该任务。
+      update: 无法更新任务。
+    model:
+      create: 无法创建舰船。
+      destroy: 无法删除舰船。
+      update: 无法更新舰船。
+      use_rsi_image: 无法使用 RSI 图片。
+    model_loaner:
+      create: 无法创建借用舰船。
+      update: 无法更新借用舰船。
+    model_module:
+      bulk_update: 部分模块无法更新。
+      create: 无法创建模块。
+      update: 无法更新模块。
+    model_module_package:
+      create: 无法创建模块套件。
+      update: 无法更新模块套件。
+    model_paint:
+      create: 无法创建涂装。
+      destroy: 无法删除涂装。
+      update: 无法更新涂装。
+    model_position:
+      create: 无法创建模型位置。
+      update: 无法更新模型位置。
+    model_snub_craft:
+      create: 无法创建微型舰载机。
+      update: 无法更新微型舰载机。
+    model_upgrade:
+      create: 无法创建升级。
+      update: 无法更新升级。
+    notification_preference: 无法更新通知设置。
+    supporter_contribution:
+      create: 无法创建支持者贡献。
+      destroy: 无法删除支持者贡献。
+      update: 无法更新支持者贡献。
+    update: 无法更新个人资料。
+    video:
+      create: 无法创建视频。
+      update: 无法更新视频。

--- a/config/locales/zh-CN/validation_error.yml
+++ b/config/locales/zh-CN/validation_error.yml
@@ -95,6 +95,9 @@ zh-CN:
       update: 无法更新停机位。
     fleet_events:
       update_occurrence: 无法更新该活动场次。
+      create: 无法创建活动。
+      destroy: 无法删除活动。
+      update: 无法更新活动。
     fleet_invite_urls:
       create: 无法创建邀请链接。
       destroy: 无法删除邀请链接。
@@ -167,3 +170,32 @@ zh-CN:
     video:
       create: 无法创建视频。
       update: 无法更新视频。
+    commodity:
+      create: 无法创建商品。
+      destroy: 无法删除商品。
+      update: 无法更新商品。
+    equipment:
+      create: 无法创建装备。
+      destroy: 无法删除装备。
+      update: 无法更新装备。
+    fleet_event_admins:
+      create: 无法授予活动管理员权限。
+    fleet_event_ships:
+      create: 无法创建活动舰船。
+      destroy: 无法删除活动舰船。
+      update: 无法更新活动舰船。
+    fleet_event_signups:
+      create: 报名失败。
+      update: 无法更新报名。
+    fleet_event_slots:
+      create: 无法创建活动 Slot。
+      destroy: 无法删除活动 Slot。
+      update: 无法更新活动 Slot。
+    fleet_event_teams:
+      create: 无法创建活动小队。
+      destroy: 无法删除活动小队。
+      update: 无法更新活动小队。
+    fleet_notification_settings:
+      update: 无法更新通知设置。
+    version:
+      revert: 无法还原该字段。

--- a/config/locales/zh-TW/validation_error.yml
+++ b/config/locales/zh-TW/validation_error.yml
@@ -8,6 +8,9 @@ zh-TW:
       destroy: 飛船無法移除。
       update: 飛船無法更新。
       bulk_create: 部分艦船無法新增。
+      bulk_update: 部分艦船無法更新。
+      move_all_ingame_to_wish_list: 無法將遊戲內艦船移至願望清單。
+      sync: 無法同步機庫。
     vehicle_loadout:
       create: Loadout could not be created.
       destroy: Loadout could not be removed.
@@ -22,12 +25,14 @@ zh-TW:
       decline: 無法拒絕艦隊成員。
       destroy: 無法移除艦隊成員。
       update: 無法更新艦隊成員。
+      demote: 無法降級該艦隊成員。
     fleet_memberships:
       create: 艦隊邀請無法使用
       destroy: 無法離開艦隊。
       accept: 艦隊邀請無法接受。
       decline: 艦隊邀請無法拒絕。
       demote_not_permitted: 您不能降級永久艦隊角色的最後一個成員。
+      update: 無法更新艦隊成員資格。
     hangar_group:
       create: 無法建立群組
       destroy: 無法刪除群組
@@ -57,6 +62,8 @@ zh-TW:
     image:
       create: 無法建立圖片
       update: 無法更新圖片
+      bulk_update: 部分圖片無法更新。
+      destroy: 無法刪除圖片。
     request_password: 密碼請求失敗。
     signup: 註冊失敗。請解決所有錯誤後重試。
     admin_user:
@@ -67,9 +74,96 @@ zh-TW:
       create: OAuth 應用程式無法建立。
       update: OAuth 應用程式無法更新。
       destroy: OAuth 應用程式無法刪除。
+      regenerate_secret: 無法重新產生密鑰。
     user:
       destroy: 無法刪除使用者。
+      update: 無法更新使用者。
     current_user:
       destroy: 無法刪除帳戶。
     hangar:
       import: 匯入失敗
+    cargo_hold:
+      update: 無法更新貨艙。
+    compare:
+      share: 無法分享該對比。
+    component:
+      create: 無法建立元件。
+      destroy: 無法刪除元件。
+      update: 無法更新元件。
+    dock:
+      create: 無法建立停機位。
+      update: 無法更新停機位。
+    fleet_events:
+      update_occurrence: 無法更新該活動場次。
+    fleet_invite_urls:
+      create: 無法建立邀請連結。
+      destroy: 無法刪除邀請連結。
+    funding_goal:
+      create: 無法建立募資目標。
+      destroy: 無法刪除募資目標。
+      update: 無法更新募資目標。
+    hardpoint:
+      create: 無法建立掛點。
+      update: 無法更新掛點。
+    item_price:
+      create: 無法建立物品價格。
+      update: 無法更新物品價格。
+    manufacturer:
+      create: 無法建立製造商。
+      destroy: 無法刪除製造商。
+      update: 無法更新製造商。
+    mission_ships:
+      create: 無法建立任務艦船。
+      destroy: 無法刪除任務艦船。
+      duplicate: 無法複製該任務艦船。
+      update: 無法更新任務艦船。
+    mission_slots:
+      create: 無法建立任務席位。
+      destroy: 無法刪除任務席位。
+      update: 無法更新任務席位。
+    mission_teams:
+      create: 無法建立任務小隊。
+      destroy: 無法刪除任務小隊。
+      update: 無法更新任務小隊。
+    missions:
+      create: 無法建立任務。
+      destroy: 無法刪除任務。
+      unarchive: 無法取消封存該任務。
+      update: 無法更新任務。
+    model:
+      create: 無法建立艦船。
+      destroy: 無法刪除艦船。
+      update: 無法更新艦船。
+      use_rsi_image: 無法使用 RSI 圖片。
+    model_loaner:
+      create: 無法建立借用艦船。
+      update: 無法更新借用艦船。
+    model_module:
+      bulk_update: 部分模組無法更新。
+      create: 無法建立模組。
+      update: 無法更新模組。
+    model_module_package:
+      create: 無法建立模組套件。
+      update: 無法更新模組套件。
+    model_paint:
+      create: 無法建立塗裝。
+      destroy: 無法刪除塗裝。
+      update: 無法更新塗裝。
+    model_position:
+      create: 無法建立模型位置。
+      update: 無法更新模型位置。
+    model_snub_craft:
+      create: 無法建立微型艦載機。
+      update: 無法更新微型艦載機。
+    model_upgrade:
+      create: 無法建立升級。
+      update: 無法更新升級。
+    notification_preference: 無法更新通知設定。
+    supporter_contribution:
+      create: 無法建立支持者貢獻。
+      destroy: 無法刪除支持者貢獻。
+      update: 無法更新支持者貢獻。
+    update: 無法更新個人資料。
+    video:
+      create: 無法建立影片。
+      update: 無法更新影片。

--- a/config/locales/zh-TW/validation_error.yml
+++ b/config/locales/zh-TW/validation_error.yml
@@ -95,6 +95,9 @@ zh-TW:
       update: 無法更新停機位。
     fleet_events:
       update_occurrence: 無法更新該活動場次。
+      create: 無法建立活動。
+      destroy: 無法刪除活動。
+      update: 無法更新活動。
     fleet_invite_urls:
       create: 無法建立邀請連結。
       destroy: 無法刪除邀請連結。
@@ -167,3 +170,32 @@ zh-TW:
     video:
       create: 無法建立影片。
       update: 無法更新影片。
+    commodity:
+      create: 無法建立商品。
+      destroy: 無法刪除商品。
+      update: 無法更新商品。
+    equipment:
+      create: 無法建立裝備。
+      destroy: 無法刪除裝備。
+      update: 無法更新裝備。
+    fleet_event_admins:
+      create: 無法授予活動管理員權限。
+    fleet_event_ships:
+      create: 無法建立活動艦船。
+      destroy: 無法刪除活動艦船。
+      update: 無法更新活動艦船。
+    fleet_event_signups:
+      create: 報名失敗。
+      update: 無法更新報名。
+    fleet_event_slots:
+      create: 無法建立活動 Slot。
+      destroy: 無法刪除活動 Slot。
+      update: 無法更新活動 Slot。
+    fleet_event_teams:
+      create: 無法建立活動隊伍。
+      destroy: 無法刪除活動隊伍。
+      update: 無法更新活動隊伍。
+    fleet_notification_settings:
+      update: 無法更新通知設定。
+    version:
+      revert: 無法還原該欄位。

--- a/test/models/validation_error_test.rb
+++ b/test/models/validation_error_test.rb
@@ -26,4 +26,36 @@ class ValidationErrorTest < ActiveSupport::TestCase
 
     assert_equal %i[code message], payload.keys
   end
+
+  # Every code falls back to `I18n.t("validation_error.#{code}")`, and a missing
+  # key does not fail loudly: production renders the literal
+  # "translation missing: ..." string into the payload, and only development
+  # raises. 71 of 138 codes had no translation at all before this was checked.
+  CODES = Dir[Rails.root.join("app/**/*.rb")]
+    .flat_map { |file| File.read(file).scan(/ValidationError\.new\("([a-z0-9_.]+)"/) }
+    .flatten
+    .uniq
+    .sort
+    .freeze
+
+  test "every code in the app is a code we can scan for" do
+    # A regexp that silently matches nothing would make the check below vacuous.
+    assert_operator CODES.size, :>, 100
+    assert_includes CODES, "vehicle.bulk_create"
+  end
+
+  I18n.available_locales.each do |locale|
+    test "every validation error code is translated in #{locale}" do
+      # `fallback: false` is what makes this check mean anything: with
+      # `config.i18n.fallbacks = [:en]` a plain lookup returns the English
+      # string for every locale, and `I18n.exists?` walks the fallbacks too --
+      # both report a translation that is not there.
+      untranslated = CODES.reject do |code|
+        I18n.t(:"validation_error.#{code}", locale:, default: nil, fallback: false)
+      end
+
+      assert_empty untranslated,
+        "#{untranslated.size} of #{CODES.size} codes have no #{locale} translation: #{untranslated.join(", ")}"
+    end
+  end
 end


### PR DESCRIPTION
> Was stacked on #4810, which has since merged as `1cd90b7a6`. Rebased onto `main` with my copies of those commits dropped, so this stands alone against `main`.

Follow-up to the audit in #4810, which turned up 71 of 138 `ValidationError` codes with no translation. Closing that turned out to mean closing **two** gaps, and adding the check that keeps them closed.

## Gap A — 70 codes with no key in any locale

`ValidationError` derives its message from `I18n.t("validation_error.#{code}")` unless an explicit one is passed. Where the key was absent the payload carried the literal string:

```
translation missing: en.validation_error.model.create
```

Except in development, where `config.i18n.raise_on_missing_translations = true` turns the intended 400 into a **500**. So every one of these paths was broken locally and merely ugly in production.

Three codes are deliberately left out: `compare.share`, `fleet_members.demote` and `vehicle.sync` always pass an explicit `message:`, so their key is never read — I checked that those explicit messages resolve in all seven locales before excluding them. They still get a key here anyway, so the guard below can stay unconditional.

## Gap B — 23 codes that existed only in English

This one was invisible by construction. `config.i18n.fallbacks = [:en]` served the English string to the other six locales, so a German or Chinese user saw English and **no lookup ever came back empty**.

Only found because the first version of the guard test passed while I had deliberately deleted a German key. The measurement that actually works:

```ruby
I18n.t(key, locale: :de, default: nil)                   # => "Ship could not be created."  (English!)
I18n.exists?(key, :de)                                   # => true                          (also wrong)
I18n.t(key, locale: :de, default: nil, fallback: false)  # => nil                            (the truth)
```

`I18n.exists?` walking the fallbacks is the part worth remembering — it is the obvious tool for this and it lies.

## The guard

`test/models/validation_error_test.rb` now scans the app for `ValidationError.new` codes and asserts each resolves, once per locale, with `fallback: false`. Verified in both directions — deleting one German entry gives:

```
1 of 138 codes have no de translation: model.create.
```

There is also a size assertion on the scan itself, because a regexp that quietly matched nothing would make the whole check vacuous.

## Translation approach

Regular resource/action codes are generated from one noun per locale plus one sentence per action, so wording stays uniform across 93 codes rather than drifting. The irregular ones are written out.

fr, it and es use an infinitive construction — `Impossible de créer le composant.` — which is the form the existing `image` entries already use. The passive alternative needs participle agreement per noun, which is exactly how `hangar_group.update` came to read *"Le groupe n'a pas pu être **mise** à jour"* for a masculine noun. I did not touch that pre-existing entry, but it is wrong and there are a handful like it.

Nouns follow the vocabulary the frontend already ships in `app/frontend/translations/<locale>/labels.json` rather than new coinages: Ware / Marchandise / Prodotto / Mercancía / 商品 for a commodity, Ausrüstung / Équipement / Equipaggiamento / Equipamiento / 装备 for equipment, and "Slot" stays a loanword in every locale including both Chinese ones.

**English is untouched** — the insert skips a key that already exists, and the run against gap B reports `en +0`.

## Also in here

`ValidationError.new("notification_preference", @notification_preference.errors)` passed the errors **positionally**, into a signature that takes one positional argument:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
```

A 500 where a 400 was meant, and the only call site in the app with that shape. Latent rather than live — the branch needs a uniqueness race on `notification_type` and nothing in AppSignal matches it, so I have not added an integration test for a path that needs contriving. It surfaced during the audit precisely because a code whose `message` argument is occupied never reaches `I18n.t`, and so never looked untranslated.

## Verification

```
ALLE 138 CODES x 7 SPRACHEN ECHT VORHANDEN     (measured with fallback: false)
37 tests, 96 assertions, 0 failures            (guard + the endpoints that render these)
2504 files inspected, no offenses detected     (bin/ruby-lint)
```

All seven YAML files parse. Full suite left to CI.

🤖
