### PR TITLE
fix(api): stop a malformed page parameter from 500ing

### DIFF
--- a/app/controllers/concerns/pagination.rb
+++ b/app/controllers/concerns/pagination.rb
@@ -38,7 +38,7 @@ module Pagination
     if per_page_params == "all"
       result.all
     else
-      result.page(params[:page])
+      result.page(page_params)
         .per(per_page)
     end
   end
@@ -61,7 +61,23 @@ module Pagination
     )
   end
 
+  private def page_params
+    scalar_param(:page)
+  end
+
   private def per_page_params
-    @per_page_params ||= params[:per_page] || params[:perPage]
+    @per_page_params ||= scalar_param(:per_page) || scalar_param(:perPage)
+  end
+
+  # `?page[x]=1` and `?page[]=1` arrive as Parameters and as an Array, and both
+  # kaminari and `per_page` above call `to_i` on whatever they are handed --
+  # which is a 500 for a malformed query string. Only the camelCase `perPage` is
+  # covered by request validation, so the snake_case spellings reach here raw.
+  # Dropping the value rather than rejecting it matches what already happens to
+  # `?page=abc`, where `to_i` yields 0 and kaminari serves page 1.
+  private def scalar_param(name)
+    value = params[name]
+
+    (value.is_a?(String) || value.is_a?(Numeric)) ? value : nil
   end
 end

--- a/test/integration/api/v1/models_index_test.rb
+++ b/test/integration/api/v1/models_index_test.rb
@@ -63,6 +63,26 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
     assert_response :bad_request
   end
 
+  # `page` and `per_page` were handed straight to kaminari, which calls `to_i`
+  # on them -- so a query string that made either a hash or an array was a 500.
+  # Same treatment as `?page=abc`: the value is dropped and the first page is
+  # served. Covers 19 controllers through the Pagination concern.
+  [
+    ["a nested page", {page: {"x" => 1}}],
+    ["an array page", {page: [1]}],
+    ["a nested per_page", {per_page: {"x" => 1}}],
+    ["an array per_page", {per_page: [1]}]
+  ].each do |label, params|
+    test "GET /models serves the first page given #{label}" do
+      create(:model)
+
+      get "/api/v1/models", params: params
+
+      assert_response :success
+      assert_equal 1, parsed_body["items"].count
+    end
+  end
+
   test "GET /models honours perPage" do
     create_list(:model, 6)
 


### PR DESCRIPTION
Fixes incident #310, `NoMethodError: undefined method 'to_i' for an instance of ActionController::Parameters`, **437 occurrences** — open since **Oct 13, 2021**.

## The cause

`Pagination#result_with_pagination` handed `params[:page]` straight to kaminari, which calls `to_i` on it. A query string that makes `page` a hash or an array therefore raises instead of paginating.

```
app/controllers/concerns/pagination.rb:41   result.page(params[:page])
kaminari/active_record_model_extension.rb:17   ApplicationRecord.page   ← to_i
```

`per_page` has it twice over: `per_page_params.to_i` runs in `per_page`, in the `MaxPerPageReached` guard, and again in `page_link`.

## Measured, not assumed

All five shapes against `GET /api/v1/models`:

| Query | Result |
|---|---|
| `?page[x]=1` | **NoMethodError** (Parameters) |
| `?page[]=1` | **NoMethodError** (Array) |
| `?per_page[x]=1` | **NoMethodError** (Parameters) |
| `?per_page[]=1` | **NoMethodError** (Array) |
| `?perPage[x]=1` | 400 |

The last row is the interesting one: only the **camelCase** `perPage` is declared for request validation, so that spelling gets a clean 400 while the snake_case spellings and both array forms reach the concern raw. The 400 was hiding how exposed the other four were.

## The change

A non-scalar value is dropped rather than rejected, which is exactly what already happens to `?page=abc` — `to_i` yields 0 and kaminari serves the first page. Rejecting instead would be a behaviour change for garbage input that is currently tolerated.

The concern is included by **19 controllers**, so this covers every paginated endpoint, not just the one that happened to get reported.

## Verification

Four tests in the existing `models_index_test.rb`, following the plain-`get` pattern already used there for the `containerFit` case — declaring a 400 in the DSL would replace the auto-injected `SchemaValidationError` response and move the schema, which is not wanted here.

With the concern reverted, all four fail with the production error verbatim:

```
NoMethodError: undefined method 'to_i' for an instance of ActionController::Parameters
NoMethodError: undefined method 'to_i' for an instance of Array
NoMethodError: undefined method 'to_i' for an instance of Array
NoMethodError: undefined method 'to_i' for an instance of ActionController::Parameters
11 tests, 14 assertions, 0 failures, 4 errors
```

With the fix: 11/11, and 28/28 across five paginated endpoints (models index/latest/embed, fleet vehicles, vehicle inventory items). `bin/ruby-lint` clean over 2,505 files. No schema change, so nothing to regenerate.

## Checked and left alone

`params[:limit].to_i` in `api/v1/images`, `api/v1/fleet_stats` and `api/v1/public/fleet_stats` coerces the same way, but no shape I tried reaches it — nested and array `limit` both answer 200 on `GET /api/v1/images`. Not fixing what I could not make fail.

The other `params[...].downcase` hits from the same grep are all **path** segments (`:slug`, `:username`), which the router always delivers as strings.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed pagination query parameters.
  - Requests using array- or object-shaped values for page-related parameters now return the first page instead of causing a server error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->