### PR TITLE
fix(auth): stop reporting the change-password redirect as an error

### DIFF
--- a/app/frontend/frontend/pages/change-password.vue
+++ b/app/frontend/frontend/pages/change-password.vue
@@ -43,7 +43,10 @@ const [passwordConfirmation, passwordConfirmationProps] = defineField(
 
 onMounted(async () => {
   if (isAuthenticated.value) {
-    await router.push({ name: "settings-change-password" });
+    // Nothing to do if this redirect loses a race with another navigation, and
+    // vue-router rejects on any navigation failure. Same guard as the push on
+    // success below.
+    await router.push({ name: "settings-change-password" }).catch(() => {});
   }
 });
 


### PR DESCRIPTION
Fixes incident #17267 — an `Error` on `ChangePasswordPage` with **no message at all**, 29 occurrences since Apr 16.

## Why the message was empty

The stack goes from `pages/change-password.vue:46` straight into vue-router internals:

```
vue-router/dist/useApi-CUgTH_jn.js:112
vue-router/dist/vue-router.js:675 / 1233 / 1297 / 1268
app/frontend/frontend/pages/change-password.vue:46
@vue/runtime-core ... (onMounted)
```

That is a **navigation failure**. vue-router rejects `router.push()` when a navigation is cancelled, aborted or duplicated, and it strips error messages in a production build — which is exactly why AppSignal had a bare `Error` with nothing in it and the incident looked unactionable.

The push sat unguarded inside an `async onMounted`, so the rejection escaped as an unhandled promise:

```js
onMounted(async () => {
  if (isAuthenticated.value) {
    await router.push({ name: "settings-change-password" });   // ← rejects
  }
});
```

An already-authenticated user opening a password-reset link gets redirected to the settings page. Lose a race with another navigation on the way — or hit a guard — and it reports.

## The change

`.catch(() => {})`, which is what **the same file already does 27 lines below** for its push on success. This was the one place the idiom was missed; the codebase uses it in `request-password.vue`, `confirm.vue`, `settings/account.vue`, `fleets/[slug]/settings.vue` and `ChangePasswordForm` too.

Ignoring is the right semantics here rather than a cop-out: it is a fire-and-forget redirect on mount, and there is nothing for the caller to do if it does not land.

## Scope

Ten other `await router.push/replace` calls are unguarded. Two share this shape exactly — `App.vue:117` (push to login from a `watch`) and `Hangar/SyncBtn/index.vue:46` (`router.replace` on mount to strip a query param). **Neither has an incident of its own**, so neither is currently failing, and adding catches there would be speculative hardening rather than a fix. Left alone.

The remaining seven are user-initiated navigations — search, a confirm handler, a filter update. Swallowing failures there would hide a real problem, so they should not get this treatment at all.

## On the absence of a test

Deliberate, not an oversight. There is no page-level spec anywhere in the repo to follow, and mounting this page pulls in vee-validate, the pinia session store, vue-query and i18n to assert that a one-line `.catch` swallows a rejection. The failure also only reproduces against a production build of vue-router, where the message is stripped. Disproportionate for this diff — I would rather say so than write a test that exercises vue-router's rejection behaviour and calls it coverage.

`lint:ts` exit 0, prettier and eslint clean.

🤖
