### PR TITLE
fix(oauth): answer 401 on userinfo instead of erroring

### DIFF
--- a/app/controllers/api/base_metal_controller.rb
+++ b/app/controllers/api/base_metal_controller.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Api
+  # Doorkeeper's metal endpoints -- userinfo, token info, discovery, dynamic
+  # client registration -- inherit whatever `base_metal_controller` names, and
+  # the gem's default is a bare `ActionController::API`. With
+  # `handle_auth_errors :raise` that leaves an invalid token raising out of the
+  # controller as a 500, where `Api::BaseController` turns the same errors into
+  # a 401 for our own endpoints.
+  #
+  # Kept to the default plus that one rescue on purpose: everything
+  # `Api::BaseController` adds -- cookies, caching, policies, ransack,
+  # pagination -- is for our API, not for Doorkeeper's own flows.
+  class BaseMetalController < ActionController::API
+    rescue_from Doorkeeper::Errors::TokenUnknown,
+      Doorkeeper::Errors::TokenExpired,
+      Doorkeeper::Errors::TokenForbidden do |exception|
+      render json: {code: "unauthorized", message: exception.message}, status: :unauthorized
+    end
+  end
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -113,6 +113,7 @@ Doorkeeper.configure do
   # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-controllers
   #
   base_controller "Api::BaseController"
+  base_metal_controller "Api::BaseMetalController"
 
   # Reuse access token for the same resource owner within an application (disabled by default).
   #

--- a/test/integration/oauth/userinfo_test.rb
+++ b/test/integration/oauth/userinfo_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "support/oauth_test_helpers"
+
+# Plain integration test rather than the openapi DSL: declaring these responses
+# would move the OAuth schema, and the point here is the status Doorkeeper's own
+# metal controller returns, not the documented contract.
+#
+# `handle_auth_errors :raise` means Doorkeeper raises instead of rendering, and
+# its metal endpoints inherit `base_metal_controller` -- so without one that
+# rescues, an invalid token left the controller as a 500 rather than a 401.
+class Oauth::UserinfoTest < ActionDispatch::IntegrationTest
+  test "GET /oauth/userinfo rejects an unknown token instead of erroring" do
+    get "/oauth/userinfo", headers: {"Authorization" => "Bearer totally-unknown-token"}
+
+    assert_response :unauthorized
+    assert_equal "unauthorized", response.parsed_body["code"]
+  end
+
+  test "GET /oauth/userinfo rejects a request with no token at all" do
+    get "/oauth/userinfo"
+
+    assert_response :unauthorized
+  end
+
+  test "GET /oauth/userinfo rejects a token without the openid scope" do
+    get "/oauth/userinfo", headers: oauth_headers_for(create(:user), scopes: ["hangar"])
+
+    assert_response :unauthorized
+  end
+
+  # The base controller swap reaches every Doorkeeper metal endpoint, so the
+  # working path needs pinning too.
+  test "GET /oauth/userinfo still answers a valid token" do
+    user = create(:user)
+
+    get "/oauth/userinfo", headers: oauth_headers_for(user, scopes: ["openid"])
+
+    assert_response :success
+
+    subject = response.parsed_body["sub"]
+
+    # `subject` is configured as a salted digest per application rather than the
+    # record id, so assert the shape and that the id did not leak.
+    assert_match(/\A[0-9a-f]{64}\z/, subject)
+    refute_equal user.id, subject
+  end
+end


### PR DESCRIPTION
Fixes incident #17281, `Doorkeeper::Errors::TokenUnknown` on `Doorkeeper::OpenidConnect::UserinfoController#show`, **21 occurrences**.

This one is worse than noise. An OAuth client watches for a **401** to know it should refresh; a 500 tells it nothing, so a client with an expired token had no way to recover.

## The cause is a half-applied configuration

`config/initializers/doorkeeper.rb` sets `handle_auth_errors :raise` — the gem's default is `:render` — so Doorkeeper raises and the app is expected to rescue. The app does, in `Api::BaseController`:

```ruby
rescue_from Doorkeeper::Errors::TokenUnknown,
  Doorkeeper::Errors::TokenExpired,
  Doorkeeper::Errors::TokenForbidden do |exception|
  render json: {code: "unauthorized", message: exception.message}, status: :unauthorized
end
```

and points Doorkeeper at it with `base_controller "Api::BaseController"`.

But **`base_metal_controller` was never set**, and its default is a bare `ActionController::API`. Doorkeeper's *metal* endpoints inherit that one, so they had no rescue whatsoever. The `:raise` decision was made and then only half the surface was covered.

Verified before the change:

```
GET /oauth/userinfo, Bearer totally-unknown-token
  → RAISED Doorkeeper::Errors::TokenUnknown: The access token is invalid
```

## A second error class in the same hole

A token that authenticates but lacks the `openid` scope raises `TokenForbidden`, which was equally unrescued — also a 500. It is covered here too, mapped to 401 to match what `Api::BaseController` already does with that class rather than introducing a different status on a parallel path.

## The change

A new `Api::BaseMetalController`: the gem default plus that one rescue, nothing more. Everything `Api::BaseController` adds — cookies, caching, ActionPolicy, ransack, pagination, the sc_data source concern — is for our API and has no business on Doorkeeper's own token flows.

## Verification

The base class swap reaches **every** Doorkeeper metal endpoint, so the working path is pinned alongside the failures. With the config line removed, three of the four tests error with the production exceptions verbatim:

```
Doorkeeper::Errors::TokenUnknown: The access token is invalid
Doorkeeper::Errors::TokenForbidden: Access to this resource requires scope "openid".
Doorkeeper::Errors::TokenUnknown: The access token is invalid
4 tests, 4 assertions, 0 failures, 3 errors
```

With it: 4/4, and 10/10 together with the existing `authorize_test.rb`. `bin/ruby-lint` clean over 2,507 files. No schema change — this is a plain integration test rather than the openapi DSL, since declaring these responses would move the OAuth schema and the point is the status the gem's controller returns, not the documented contract.

The `sub` assertion checks shape rather than value on purpose: `subject` is configured as a salted per-application SHA256, so the test pins that the digest is well-formed **and** that the record id did not leak.

## One dead end, noted so nobody repeats it

`/oauth/token/info` looked like a second exposed metal endpoint. It is not routed — the route is `/api/oauth/token/info` and it lands on one of our own controllers, already covered by `Api::BaseController`. A probe against the Doorkeeper path returns a routing error, which in the test environment surfaces as `ViteRuby::MissingEntrypointError` from the HTML error page and reads convincingly like a real failure. It is identical with and without this change.

🤖
