### PR TITLE
docs(sc_data): say which plan steps are done and which are not

### DIFF
--- a/docs/exec-plans/sc-data-build-compare.md
+++ b/docs/exec-plans/sc-data-build-compare.md
@@ -27,6 +27,15 @@ altitude, not four more copies of it.
 
 ## What is missing, in the order worth doing it
 
+**Status, 2026-09-08: all three are on `main`.** #4795 the comparer (1),
+#4797 `/sc-data/builds` and `/sc-data/compare` (2, and (3) with it — the
+comparer derives its facts per build class rather than needing a recorder each),
+#4799 the admin page, #4800 its padding. Two findings from running it against
+real data are recorded in item 6 of
+[sc-data-live-and-ptu.md](sc-data-live-and-ptu.md): the `recorded` flag, and that
+the oldest retained build is a backfill rather than a record of that build.
+
+
 ### 1. The cross-environment axis
 
 `ModelBuildChange.for_build(environment, version)` and its `previous_build` are

--- a/docs/exec-plans/sc-data-hardpoints-per-build.md
+++ b/docs/exec-plans/sc-data-hardpoints-per-build.md
@@ -95,6 +95,13 @@ separate and unblocked.
 
 ## Order
 
+**Status, 2026-09-08.** (1)–(4) are on `main`: #4761 the table and the backfill,
+#4773 the transition clause the backfill needed, #4772 the legacy code removal,
+#4779 dual-write and the reads, #4781 stop destroying, #4782 / #4785 the admin
+view, #4798 the legacy tables themselves. **(5) is the only step still open**,
+and it folds into item 5 of the parent plan.
+
+
 1. **The table and the backfill.** `hardpoint_builds` with
    `(hardpoint_id, environment, version)` unique, `BUILDS_RETAINED` and
    `retained_versions` mirroring `ComponentBuild`, and a backfill writing the
@@ -139,8 +146,10 @@ separate and unblocked.
 4. **Stop destroying.** `persist_loadout` retires build rows instead of
    destroying slots, and *this* is the PR that fixes the bug and the one item 3
    of the parent plan is gated on.
-5. **Drop the columns**, after (4) has been on `main` long enough to trust — and
-   this folds into item 4 of the parent plan rather than standing alone.
+5. **Drop the columns** — *open*. After (4) has been on `main` long enough to
+   trust, and this folds into item 5 of the parent plan rather than standing
+   alone. What it is waiting on now is a PTU load having run in production: the
+   columns are the fallback that makes a bad load survivable.
 
 **The order of (3) and (4) is not interchangeable, and an earlier version of
 this plan had them the other way round.** `Api::V1::ModelsController#hardpoints`

--- a/docs/exec-plans/sc-data-live-and-ptu.md
+++ b/docs/exec-plans/sc-data-live-and-ptu.md
@@ -43,6 +43,27 @@ filters:
   in the game
 - #4754 refetch the parsed tree after re-parsing live
 
+**Hardpoints per build** — the loadout stopped being one set of rows whichever
+load ran last owns:
+- #4761 the table and the backfill, #4772 remove the legacy code, #4773 the
+  transition clause, #4779 dual-write and move the reads, #4781 stop destroying
+- #4782 / #4785 the admin view the rebuild had left without one
+- #4798 drop the legacy tables themselves
+
+**Model modules per build**
+- #4780 existence per build, and production status following live
+
+**A production load path for a second environment**
+- #4774 load every configured source, not only the default
+
+**Patch-by-patch compare**
+- #4795 the comparer, #4797 the endpoints, #4799 the admin page, #4800 its
+  padding
+
+**Retention and reporting**
+- #4801 retention is a property of the environment: live 3, ptu 2
+- #4808 the unlisted-models report, from the load that actually runs
+
 Four catalogues carry builds. `ScData::Source` answers which one is in force,
 `ScData::Current` scopes it per request and per job, and the switch appears in
 the header only when more than one source is on offer. Since 2026-09-07 that is
@@ -173,7 +194,7 @@ not list it. It also has no guard for a module the export stopped shipping:
 `resolve_loadout` indexes it immediately. All six keys were present in this
 build, so it did not fire.
 
-### 2. Hardpoints per build — before anything else
+### 2. Hardpoints per build — done except (5), 2026-09-08
 
 The loadout has to stop being a single set of rows that the last load to run
 owns. That is the whole reason, and it needs no other: the shape is the one the
@@ -224,7 +245,13 @@ carry anything else — so it reads no hardpoints and knows nothing about builds
 The two share the word "loadout" and nothing else. Deleting the legacy pair,
 `vehicle_loadout_hardpoints` included, is separate and unblocked.
 
-### 3. A production load path for a second environment
+### 3. A production load path for a second environment — done, 2026-09-08
+
+Landed as #4774. `ScData::CheckJob` iterates `ScData::Source.configured`,
+`Loaders::ScData::AllJob` takes an environment and runs its whole load inside
+`ScData::Source.with`, and the coverage check reads the build rows. The
+description below is what was built.
+
 
 `ScData::CheckJob` iterating `ScData::Source.configured` rather than asking only
 the default, `Loaders::ScData::AllJob` taking an environment and running its
@@ -296,15 +323,40 @@ Model, in full: `cargo_holds`, `external_fuel_tanks`, `fuel_consumption`,
 
 Every one is a place a row and its build can drift. Reads already go through the
 build, so dropping them is mechanical — but it is one-way, and the PTU load that
-(1) was gating it on has now happened. What it should wait on instead is (2):
-the columns are the fallback that makes a bad load survivable, and a load is not
-yet survivable while it rewrites the other environment's loadouts.
+(1) was gating it on has now happened.
 
-### 6. Patch-by-patch compare
+**Still open, and now the largest thing left.** It was waiting on (2), which
+landed on 2026-09-08: the loadout carries a build, so a load no longer rewrites
+the other environment's ship pages. What it should wait on now is a PTU load
+having run *in production* — the columns are the fallback that makes a bad load
+survivable, and no second environment has been loaded there yet. #4774 gave
+production the ability; nothing has exercised it.
+
+### 6. Patch-by-patch compare — done, 2026-09-08
+
+Landed as #4795 (the comparer), #4797 (`/sc-data/builds` and `/sc-data/compare`),
+#4799 (the admin page) and #4800. Planned in
+[sc-data-build-compare.md](sc-data-build-compare.md), which carries the
+measurements behind computing rather than recording.
+
+Two things the real data taught, both worth keeping:
+
+- **A catalogue with no rows on one side was never recorded for that build**, and
+  saying "everything appeared" instead is a wrong answer, not a rough one.
+  Comparing live 4.9.0 with 4.10.0 announced all 232 commodities and all 215
+  models as new until the endpoint learned to say so. Production confirms it on
+  the first day: two of four catalogues answer `recorded: false`.
+- **The oldest retained build is a backfill, not a record of that build.** Every
+  `*_builds` backfill stamped the then-current column values with the current
+  version label, so any comparison whose older side is that build measures the
+  backfill. Decided 2026-09-08: leave it, since it ages out of the retention
+  window. Do not read the first comparison against the oldest build as a patch
+  diff.
 
 What appeared, changed and vanished between two builds — live→PTU, or version N
-against N-1. Now cheap, because each catalogue retains `BUILDS_RETAINED = 3`
-builds per environment rather than deleting the old ones.
+against N-1. Cheap because each catalogue retains several builds per environment
+rather than deleting the old ones — see `ScData::Source::BUILDS_RETAINED`, which
+since #4801 keeps 3 for live and 2 for ptu.
 
 **It cannot reuse `ScData::Source.available`.** That list deliberately hides
 everything behind the default, which is exactly what a comparison needs. This
@@ -315,7 +367,19 @@ wrong control for.
 ### 7. Out of the model work
 
 - The bulk action on `sc_data_unlisted_models`, so a patch's new entries can be
-  triaged in one pass rather than row by row.
+  triaged in one pass rather than row by row. **Still open.**
+
+  Its prerequisite was not: the table was empty in production because its only
+  writer had no caller. The report sat in `Loaders::ScData::ModelsJob`, which
+  nothing enqueues — the scheduled `Loaders::ModelsJob` is the RSI ship matrix
+  loader, one namespace away. #4808 moved it to `Loaders::ScData::AllJob`, which
+  `CheckJob` and the admin trigger actually run, and scoped the sweep to
+  `last_seen_environment` so a per-source load does not delete the other
+  environment's rows. Expect rows to appear after the first load following that
+  deploy; if none do, the caller analysis was incomplete.
+
+  `Loaders::ScData::ModelsJob` still has no caller and is now a plain
+  single-catalogue loader. Deleting it and its tests is undecided.
 - The five vendor component sets behind the `collector_*` and `exec_*` variants
   (`collector_military`, `collector_stealth`, `collector_indust`,
   `exec_military`, `exec_stealth`) are reusable product lines, not per-ship


### PR DESCRIPTION
The plans recorded the work but not its state, so I could answer "what is still
open" only from memory. Now the page answers it.

## What was stale

- **`Where it stands` stopped at #4754** — fourteen PRs had landed since.
- **Four of the seven items carried no marker**, including item 6, which shipped
  in full last week. The convention already existed (`— done, <date>`, used on
  items 1 and 4); it just was not kept up.
- **Item 5's gate was wrong.** It said it was waiting on item 2. Item 2 landed on
  2026-09-08.

## What it says now

| Item | |
| --- | --- |
| 2. Hardpoints per build | done except (5) — #4761, #4772, #4773, #4779, #4781, #4782, #4785, #4798 |
| 3. Production load path | done — #4774 |
| 6. Patch-by-patch compare | done — #4795, #4797, #4799, #4800 |
| 5. Contract phase, 73 columns | **open, and the largest thing left** |
| 7. Bulk action on unlisted models | **open** |

Item 5 now waits on the right thing: a PTU load having run **in production**.
#4774 gave production the ability and nothing has exercised it, and the columns
are the fallback that makes a bad load survivable.

Item 7 keeps the bulk action open and records that its prerequisite was not: the
table was empty because its only writer had no caller, fixed in #4808. It also
notes the expected evidence — rows should appear after the first load following
that deploy, and if none do, the caller analysis was incomplete.

## Two findings that change how the comparison should be read

Both go into item 6, because a reader who does not know them will misread the
numbers:

- **A catalogue with no rows on one side was never recorded for that build.**
  Saying "everything appeared" instead is a wrong answer, not a rough one — live
  4.9.0 against 4.10.0 announced all 232 commodities and all 215 models as new
  until the endpoint learned to say so. Production confirms it: two of four
  catalogues answer `recorded: false`.
- **The oldest retained build is a backfill.** Every `*_builds` backfill stamped
  the then-current column values with the current version label, so a comparison
  whose older side is that build measures the backfill. Decided: leave it, it
  ages out.

Docs only — no code, no tests, no schema.

🤖
