### PR TITLE
fix(viewer): stop the WebGL probe from spending the context it tests for

### DIFF
--- a/app/frontend/shared/components/HoloViewer/index.vue
+++ b/app/frontend/shared/components/HoloViewer/index.vue
@@ -13,6 +13,7 @@ import { type Camera, type Mesh, type Object3D, type Vector3 } from "three";
 import { useI18n } from "@/shared/composables/useI18n";
 
 import { TresCanvas } from "@tresjs/core";
+import { webglAvailable } from "@/shared/utils/Webgl";
 import { OrbitControls, TransformControls, Grid } from "@tresjs/cientos";
 import Model from "./Model/index.vue";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
@@ -53,15 +54,22 @@ const mobile = useMobile();
 const webglSupported = ref(true);
 
 onMounted(() => {
-  try {
-    const canvas = document.createElement("canvas");
-    const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
-    if (!gl) {
-      webglSupported.value = false;
-    }
-  } catch {
-    webglSupported.value = false;
+  webglSupported.value = webglAvailable();
+});
+
+// THREE throws while constructing the renderer, which TresCanvas's `on-error`
+// never sees: it comes out through Vue's error handler instead, which is how a
+// missing context got reported as an application error rather than showing the
+// fallback this component already has. Swallowing it is scoped to this
+// boundary, and a 3D viewer is the right place to decide that WebGL is absent.
+onErrorCaptured((error) => {
+  if (!(error instanceof Error) || !error.message.includes("WebGL")) {
+    return true;
   }
+
+  webglSupported.value = false;
+
+  return false;
 });
 
 const dpr = computed(() =>

--- a/app/frontend/shared/utils/Webgl.spec.ts
+++ b/app/frontend/shared/utils/Webgl.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { webglAvailable } from "./Webgl";
+
+const stubContext = (
+  context: unknown,
+  { throws = false }: { throws?: boolean } = {},
+) =>
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(() => {
+    if (throws) {
+      throw new Error("nope");
+    }
+
+    return context as ReturnType<HTMLCanvasElement["getContext"]>;
+  });
+
+const loseContext = () => {
+  const lose = vi.fn();
+
+  return {
+    lose,
+    context: { getExtension: vi.fn(() => ({ loseContext: lose })) },
+  };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("webglAvailable", () => {
+  it("reports a context it could get", () => {
+    stubContext(loseContext().context);
+
+    expect(webglAvailable()).toBe(true);
+  });
+
+  it("reports no context when the canvas gives none", () => {
+    stubContext(null);
+
+    expect(webglAvailable()).toBe(false);
+  });
+
+  it("reports no context when asking for one throws", () => {
+    stubContext(null, { throws: true });
+
+    expect(webglAvailable()).toBe(false);
+  });
+
+  /*
+   * The point of the whole function: a probe that keeps its context spends one
+   * of the few the browser allows, so the renderer built next is the one that
+   * fails.
+   */
+  it("hands the probe context back", () => {
+    const { lose, context } = loseContext();
+    stubContext(context);
+
+    webglAvailable();
+
+    expect(context.getExtension).toHaveBeenCalledWith("WEBGL_lose_context");
+    expect(lose).toHaveBeenCalledOnce();
+  });
+
+  it("survives a context that cannot be released", () => {
+    stubContext({ getExtension: vi.fn(() => null) });
+
+    expect(webglAvailable()).toBe(true);
+  });
+});

--- a/app/frontend/shared/utils/Webgl.ts
+++ b/app/frontend/shared/utils/Webgl.ts
@@ -1,0 +1,22 @@
+/*
+ * Probing for WebGL costs a WebGL context. Browsers cap how many can exist at
+ * once, so a probe that stays open spends a slot to find out whether a slot is
+ * free -- and the renderer built right after it is the one that runs out.
+ * `WEBGL_lose_context` is the only way to hand one back before GC.
+ */
+export const webglAvailable = (): boolean => {
+  try {
+    const canvas = document.createElement("canvas");
+    const context = canvas.getContext("webgl2") ?? canvas.getContext("webgl");
+
+    if (!context) {
+      return false;
+    }
+
+    context.getExtension("WEBGL_lose_context")?.loseContext();
+
+    return true;
+  } catch {
+    return false;
+  }
+};


### PR DESCRIPTION
Fixes incident #17151, `THREE.WebGLRenderer: Error creating WebGL context.` — **242 occurrences**.

The easy reading is "old machines without WebGL". It is not that, and the component already handled that case.

## The probe was spending the context it tested for

```js
const canvas = document.createElement("canvas");
const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
if (!gl) { webglSupported.value = false; }
```

That takes a **real** WebGL context and never gives it back. Browsers cap how many can exist simultaneously — single digits in practice — so every `HoloViewer` mount spent one of the few available to find out whether one was available. The renderer `TresCanvas` builds immediately afterwards is the one that runs out.

`WEBGL_lose_context` is the only way to release a context before garbage collection, so the probe now calls it. Moved into `shared/utils/Webgl.ts` so it is testable at all — the component itself cannot be mounted in jsdom without stubbing TresJS, which nothing in the repo does yet.

## Why the existing fallback never appeared

The component ships a `webglSupported` fallback and wires `:on-error="handleRenderError"` on `TresCanvas`, so this was anticipated. It just never fired: THREE throws **while constructing** the renderer, and `on-error` does not see a constructor throw. It surfaces through Vue's error handler instead — which is exactly what reported it to AppSignal, under the component name `Context`.

An `onErrorCaptured` at the HoloViewer boundary now flips to the fallback and stops propagation, so the user gets the "WebGL not supported" panel the component always had instead of a silent failure plus an error report.

The match is scoped to WebGL messages rather than swallowing everything, and the boundary is a 3D viewer — the right place in the app to conclude that WebGL is unavailable.

## Verification

Five unit tests on the util. The one that matters is the release; deleting that line again fails it:

```
× hands the probe context back
Tests  1 failed | 4 passed (5)
```

With the fix: 5/5. `lint:ts` exit 0, prettier and eslint clean.

The `onErrorCaptured` half is not covered, and I would rather say so than imply otherwise: reproducing it needs a TresCanvas that throws during construction inside a jsdom mount, and there is no TresJS stubbing pattern in the repo to build on. The probe fix is the part that should cut the volume; this half is what turns whatever remains into the fallback instead of a report.

🤖
