### PR TITLE
fix(cable): keep rendering when the client cannot open a socket

### DIFF
--- a/app/frontend/shared/composables/useSubscription.spec.ts
+++ b/app/frontend/shared/composables/useSubscription.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const create = vi.fn();
+let consumer: unknown = { subscriptions: { create } };
+
+vi.mock("@/shared/composables/useCable", () => ({
+  useCable: () => ({ consumer, refresh: vi.fn() }),
+}));
+
+const { useSubscription } = await import("./useSubscription");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  create.mockReset();
+  consumer = { subscriptions: { create } };
+});
+
+describe("useSubscription", () => {
+  it("subscribes to the channel it was given", () => {
+    create.mockReturnValue({ unsubscribe: vi.fn() });
+
+    const { subscribe, channel } = useSubscription({
+      channelName: "ShipsChannel",
+    });
+
+    subscribe();
+
+    expect(create).toHaveBeenCalledWith(
+      { channel: "ShipsChannel" },
+      expect.objectContaining({ connected: expect.any(Function) }),
+    );
+    expect(channel.value).toBeDefined();
+  });
+
+  /*
+   * actioncable opens the WebSocket synchronously inside `create`, so a client
+   * that cannot open one -- a proxy rewriting the URL, a policy blocking wss --
+   * throws out of here. Nine components subscribe on mount; none of them should
+   * fail to render because live updates are unavailable.
+   */
+  it("survives a socket the client cannot open", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    create.mockImplementation(() => {
+      throw new SyntaxError(
+        "Failed to construct 'WebSocket': the provided URL is invalid.",
+      );
+    });
+
+    const { subscribe, channel } = useSubscription({
+      channelName: "ShipsChannel",
+    });
+
+    expect(() => subscribe()).not.toThrow();
+    expect(channel.value).toBeUndefined();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no consumer at all", () => {
+    consumer = undefined;
+
+    const { subscribe, channel } = useSubscription({
+      channelName: "ShipsChannel",
+    });
+
+    expect(() => subscribe()).not.toThrow();
+    expect(create).not.toHaveBeenCalled();
+    expect(channel.value).toBeUndefined();
+  });
+});

--- a/app/frontend/shared/composables/useSubscription.ts
+++ b/app/frontend/shared/composables/useSubscription.ts
@@ -36,30 +36,39 @@ export const useSubscription = <T = unknown>({
       return;
     }
 
-    channel.value = consumer.subscriptions.create(
-      {
-        channel: channelName,
-      },
-      {
-        received,
-        connected: () => {
-          console.info("Connected to Channel:", channelName);
-
-          if (connected) {
-            connected();
-          }
+    // actioncable opens the socket synchronously inside `create`, so a client
+    // that cannot open one at all -- a proxy rewriting the URL, an extension,
+    // a network policy blocking wss -- throws right here and used to take the
+    // mount with it. Live updates are an enhancement, so the page has to work
+    // without them.
+    try {
+      channel.value = consumer.subscriptions.create(
+        {
+          channel: channelName,
         },
-        disconnected: () => {
-          unsubscribe();
+        {
+          received,
+          connected: () => {
+            console.info("Connected to Channel:", channelName);
 
-          console.info("Disconnected from Channel:", channelName);
+            if (connected) {
+              connected();
+            }
+          },
+          disconnected: () => {
+            unsubscribe();
 
-          if (disconnected) {
-            disconnected();
-          }
+            console.info("Disconnected from Channel:", channelName);
+
+            if (disconnected) {
+              disconnected();
+            }
+          },
         },
-      },
-    );
+      );
+    } catch (error) {
+      console.warn("Subscriptions: could not subscribe to", channelName, error);
+    }
   };
 
   onMounted(() => {


### PR DESCRIPTION
Fixes incident #17100, `Failed to construct 'WebSocket': the provided URL is invalid.` — **1,163 occurrences**, the largest frontend error we have.

## It is not our URL

Worth establishing first, because the message points the finger at us:

- `CABLE_ENDPOINT` is a fixed deploy value (`wss://fleetyards.net/cable` in `config/deploy.live.yml`), rendered into a constant by `_app_env.html.erb`.
- `useCable` already refuses to build a consumer unless `window.CABLE_ENDPOINT` is set **and** parses as a URL.
- Of 15 sampled traces, **13 came from CN, HK and SG**, all Chrome, in tight bursts — six inside the same minute.

That is a middlebox rewriting the socket URL, not a bug in what we serve. The reports could never be acted on.

## What was ours

`subscriptions.create` opens the socket **synchronously**:

```
create → add → ensureActiveConnection → connection.open() → new WebSocket(...)
```

So the throw comes straight out of `subscribe()` — called from `onMounted` and from the `enabled` watcher. **Nine components** subscribe on mount, and each of them failed to render because live updates were unavailable.

Live updates are an enhancement. A client that cannot open a socket should lose the updates, not the page. `subscribe()` now warns and returns.

## Verification

Three tests on the composable, mocking `useCable` with the `vi.mock` + `await import` pattern already used in `useInventoryStockList.spec.ts`. With the guard removed, the relevant one fails with the production error verbatim:

```
× survives a socket the client cannot open
  "SyntaxError: Failed to construct 'WebSocket': the provided URL is invalid."
Tests  1 failed | 2 passed (3)
```

With the fix: 3/3, and the happy path is pinned alongside it so the guard cannot quietly swallow a working subscription. `lint:ts` exit 0, eslint clean.

## What this does and does not achieve

It will not reduce the count to zero by fixing the clients' networks — nothing here can. It stops those clients from losing the page, and it stops an unactionable client-environment condition from being the loudest thing in the error stream.

If it turns out worth tracking as a signal rather than an error, a metric would be the right instrument, not an exception.

🤖
