### PR TITLE
docs: correct the plans that still build on the dropped hardpoint tables

### DIFF
--- a/docs/exec-plans/fleet-soft-delete-and-restore.md
+++ b/docs/exec-plans/fleet-soft-delete-and-restore.md
@@ -10,7 +10,7 @@ A fleet was hard-destroyed and there is currently no way to:
 
 ## Current State
 
-- `paper_trail` 17.0.0 is present; `discard` is **not**. No soft-delete gem anywhere (one model, `ModelHardpoint`, hand-rolls `deleted_at` + scopes).
+- `paper_trail` 17.0.0 is present; `discard` is **not**. No soft-delete gem anywhere. (The one model that hand-rolled `deleted_at` + scopes, `ModelHardpoint`, was removed in #4772 and its table dropped in #4798, so there is now no hand-rolled example either.)
 - `Fleet` and `FleetMembership` both `has_paper_trail meta: { author_id:, reason:, reason_description: }`, but those `attr_accessor`s are **never assigned anywhere** — the custom meta is dead, those version columns are always nil.
 - `set_paper_trail_whodunnit` runs only in `Admin::ApplicationController` (the server-rendered admin). Neither `Api::BaseController` nor `Admin::Api::BaseController` set whodunnit, so **API/admin-API destroys record nil whodunnit**.
 - `versions.object` column is **`json`** → PaperTrail stores attribute snapshots as a JSON hash; we can query `object ->> 'fid'` / `object ->> 'name'` in SQL.

--- a/docs/exec-plans/hardpoints-v2-flag-cleanup.md
+++ b/docs/exec-plans/hardpoints-v2-flag-cleanup.md
@@ -1,5 +1,12 @@
 # Exec Plan: Remove the `hardpoints-v2` feature flag and dead legacy code path
 
+> **Done, and its out-of-scope note is now history.** This plan deliberately kept
+> the `ModelHardpoint` model and the `model_hardpoints` table. Both are gone:
+> #4772 removed the code, #4798 dropped `model_hardpoints`,
+> `model_hardpoint_loadouts` and `vehicle_loadout_hardpoints`. Read the
+> "Explicitly out of scope" section below as the decision it was on 2026-06-25,
+> not as the current shape of the schema.
+
 ## Goal & scope
 
 Make the **v2 hardpoints** implementation (`Hardpoint` model → `model.hardpoints`)

--- a/docs/exec-plans/loadout-dps-calculator.md
+++ b/docs/exec-plans/loadout-dps-calculator.md
@@ -64,7 +64,13 @@ Branch: `feat/loadout-dps-readonly`.
 3. **Sustained DPS** — model power draw vs power-plant output and heat vs cooler
    capacity to derive erkul's throttled sustained DPS (currently burst only).
 4. **Interactive per-hardpoint picker + persistence** — swap components per slot and
-   recompute; persist to the existing `VehicleLoadoutHardpoint` table (schema ready).
+   recompute. **There is no table to persist to any more:**
+   `vehicle_loadout_hardpoints` was dropped in #4798 — it never held a row, and it
+   hung off `model_hardpoints`, which is also gone. A saved selection needs a new
+   store keyed on `hardpoints`; the shape it should take is set out under "What
+   it makes possible later" in
+   [sc-data-hardpoints-per-build.md](sc-data-hardpoints-per-build.md), including
+   why validity has to be checked per source rather than once on write.
 5. **Loadout-vs-loadout / ship-vs-ship combat comparison** — extend `compare.vue`.
 6. **Weapon detail gaps** — spread/recoil and projectile falloff aren't imported, so
    effective-DPS-at-range can't be computed yet. Missiles and gimbal/convergence

--- a/docs/exec-plans/sc-data-hardpoints-per-build.md
+++ b/docs/exec-plans/sc-data-hardpoints-per-build.md
@@ -95,11 +95,13 @@ separate and unblocked.
 
 ## Order
 
-**Status, 2026-09-08.** (1)–(4) are on `main`: #4761 the table and the backfill,
-#4773 the transition clause the backfill needed, #4772 the legacy code removal,
-#4779 dual-write and the reads, #4781 stop destroying, #4782 / #4785 the admin
-view, #4798 the legacy tables themselves. **(5) is the only step still open**,
-and it folds into item 5 of the parent plan.
+**Status, 2026-09-09.** (1)–(4) are on `main`: #4759 the table and the slot's
+natural key, #4761 reading a hardpoint's facts through its build, #4762 retiring
+a build instead of destroying the slot, #4773 the transition clause `in_build`
+needed, #4779 deriving a model's facts from this build's slots only, #4772 the
+legacy code removal and #4798 the legacy tables, #4782 / #4785 the admin view.
+**(5) is the only step still open**, and it folds into item 5 of the parent
+plan, where the 10 dual-held hardpoint columns are counted.
 
 
 1. **The table and the backfill.** `hardpoint_builds` with

--- a/docs/exec-plans/sc-data-live-and-ptu.md
+++ b/docs/exec-plans/sc-data-live-and-ptu.md
@@ -45,10 +45,12 @@ filters:
 
 **Hardpoints per build** — the loadout stopped being one set of rows whichever
 load ran last owns:
-- #4761 the table and the backfill, #4772 remove the legacy code, #4773 the
-  transition clause, #4779 dual-write and move the reads, #4781 stop destroying
+- #4759 the table and the slot's natural key, #4761 read a hardpoint's facts
+  through its build, #4762 retire a build instead of destroying the slot
+- #4773 let `in_build` tolerate an environment with no builds yet, #4779 derive a
+  model's facts from this build's slots only
+- #4772 remove the legacy code, #4798 drop the legacy tables themselves
 - #4782 / #4785 the admin view the rebuild had left without one
-- #4798 drop the legacy tables themselves
 
 **Model modules per build**
 - #4780 existence per build, and production status following live
@@ -302,24 +304,47 @@ Two things deliberately left alone:
   load-versus-curation conflict that predates the table and wants deciding on
   its own rather than being quietly settled by moving it.
 
-### 5. Contract phase — 73 columns still held twice
+### 5. Contract phase — 87 columns still held twice
 
-Measured against the current schema:
+Re-measured 2026-09-09, by intersecting each build class's `FACTS` with its
+row's `column_names`:
 
 | Catalogue | Facts on both tables |
 | --------- | -------------------- |
-| Model     | 28 |
+| Model     | 30 |
 | Equipment | 23 |
 | Component | 19 |
+| Hardpoint | 10 |
 | Commodity | 3  |
+| ModelModule | 2 |
+| **Total** | **87** |
+
+An earlier revision of this file said 73, counting only the four catalogues and
+predating two facts. Model has since gained `main_acceleration` and
+`retro_acceleration`; `Hardpoint` and `ModelModule` became dual-held when they
+got build rows, and belong to the same contract phase — hardpoints via step (5)
+of [sc-data-hardpoints-per-build.md](sc-data-hardpoints-per-build.md), which
+folds into this item.
 
 Model, in full: `cargo_holds`, `external_fuel_tanks`, `fuel_consumption`,
 `ground`, `ground_acceleration`, `ground_decceleration`, `ground_max_speed`,
 `ground_reverse_speed`, `hull_doors`, `hull_health`, `hull_parts`,
-`hydrogen_fuel_tanks`, `mass`, `max_speed`, `personal_inventory`, `pitch`,
-`pitch_boosted`, `quantum_fuel_tanks`, `refuel_boom`, `reverse_speed_boosted`,
-`roll`, `roll_boosted`, `scm_speed`, `scm_speed_boosted`,
-`signature_cross_section`, `weapon_pool_size`, `yaw`, `yaw_boosted`.
+`hydrogen_fuel_tanks`, `main_acceleration`, `mass`, `max_speed`,
+`personal_inventory`, `pitch`, `pitch_boosted`, `quantum_fuel_tanks`,
+`refuel_boom`, `retro_acceleration`, `reverse_speed_boosted`, `roll`,
+`roll_boosted`, `scm_speed`, `scm_speed_boosted`, `signature_cross_section`,
+`weapon_pool_size`, `yaw`, `yaw_boosted`.
+
+Hardpoint: `category`, `component_id`, `flags`, `group`, `group_key`,
+`max_size`, `min_size`, `port_tags`, `required_tags`, `types`.
+
+ModelModule: `cargo_holds`, `description`.
+
+The count is derivable, so it should be re-measured rather than trusted:
+
+```ruby
+build::FACTS.map(&:to_s).select { |fact| row.column_names.include?(fact) }
+```
 
 Every one is a place a row and its build can drift. Reads already go through the
 build, so dropping them is mechanical — but it is one-way, and the PTU load that

--- a/docs/exec-plans/sc-data-live-and-ptu.md
+++ b/docs/exec-plans/sc-data-live-and-ptu.md
@@ -366,11 +366,19 @@ wrong control for.
 
 ### 7. Out of the model work
 
-- The bulk action on `sc_data_unlisted_models`, so a patch's new entries can be
-  triaged in one pass rather than row by row. **Still open.**
+- The bulk action on `sc_data_unlisted_models` — **done, #4661, shipped in
+  v7.10.0**, the same release as the detector itself. `ignore_bulk`,
+  `mark_as_paint_bulk` and `reset_bulk` on the controller, and a selection with
+  two bulk buttons on `admin/pages/models/unlisted.vue`. `link` and
+  `create_model` stay per row on purpose: each needs a target a person picks.
+  (An earlier revision of this file listed it as open. It never was.)
 
-  Its prerequisite was not: the table was empty in production because its only
-  writer had no caller. The report sat in `Loaders::ScData::ModelsJob`, which
+  The one loose end: `reset_bulk` has a route and no button. Reset is for a
+  decision made in error, which is a per-row thing, so that may be right — but it
+  is an accident rather than a decision.
+
+  What kept the feature from being usable was elsewhere: the table was empty in
+  production because its only writer had no caller. The report sat in `Loaders::ScData::ModelsJob`, which
   nothing enqueues — the scheduled `Loaders::ModelsJob` is the RSI ship matrix
   loader, one namespace away. #4808 moved it to `Loaders::ScData::AllJob`, which
   `CheckJob` and the admin trigger actually run, and scoped the sweep to

--- a/docs/exec-plans/vehicle-loadouts.md
+++ b/docs/exec-plans/vehicle-loadouts.md
@@ -1,5 +1,16 @@
 # Vehicle Loadout System
 
+> **Partly shipped, and the schema below is out of date.** What went live is the
+> bookmark half: `vehicle_loadouts` carries a name and a URL to erkul or
+> spviewer, and all 342 rows have one. The internal half never held a single row
+> and is gone — #4798 dropped `vehicle_loadout_hardpoints` along with
+> `model_hardpoints` and `model_hardpoint_loadouts`, so `ModelHardpointLoadout`
+> and `VehicleLoadoutHardpoint` no longer exist. Slot identity is `hardpoints`
+> now. Read the schema and model sections below as the 2026 design, not as the
+> current tables; a future loadout editor is sketched under "What it makes
+> possible later" in
+> [sc-data-hardpoints-per-build.md](sc-data-hardpoints-per-build.md).
+
 ## Context
 
 Fleetyards tracks ships and their hardpoints from Star Citizen game data, but weapon stats are not extracted (commented out since implementation) and there's no way for users to store custom loadout configurations on their vehicles. The mission builder needs loadout data to let organizers specify equipment requirements and members to show what they're bringing.


### PR DESCRIPTION
Follow-up to #4815, which brought the sc_data plans up to date and missed
everything outside that set.

#4798 dropped `model_hardpoints`, `model_hardpoint_loadouts` and
`vehicle_loadout_hardpoints`. Four other plans still describe them as present.

## The one that would have cost someone an afternoon

`loadout-dps-calculator.md` is forward-looking, and its per-hardpoint
persistence step read:

> persist to the existing `VehicleLoadoutHardpoint` table (schema ready)

There is no such table, and "schema ready" is exactly the sentence that stops a
reader checking. It now says a new store keyed on `hardpoints` is needed, and
points at the section of `sc-data-hardpoints-per-build.md` that already worked
out the shape — including why a saved selection has to be validated per source
rather than once on write, since `min_size`, `types` and `port_tags` are build
facts.

## The three that are records, not instructions

These keep their text and gain a note saying it is history. Rewriting a decision
to match what happened later destroys the reason it was taken.

- **`hardpoints-v2-flag-cleanup.md`** explicitly resolved on 2026-06-25 to keep
  the model and the table. Without a note, "Explicitly out of scope" reads as
  current schema.
- **`vehicle-loadouts.md`** documents a three-part design whose internal half
  never held a row. The bookmark half did ship — 342 rows, every one with a URL.
- **`fleet-soft-delete-and-restore.md`** cited `ModelHardpoint` as the codebase's
  one hand-rolled `deleted_at`, as evidence for "no soft-delete gem anywhere".
  The claim survives; the example does not.

Docs only.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated execution plans to reflect the current status of fleet deletion, restoration, hardpoints, and vehicle loadouts.
  - Clarified that the vehicle loadout bookmark functionality is live, while internal hardpoint loadout functionality is not currently available.
  - Updated planning notes to identify future requirements for saved hardpoint selections and per-source validity checks.
  - Added completion and historical-context notes to distinguish current behavior from earlier design decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->