### PR TITLE
fix(btn): dim the label while a button is loading

### DIFF
--- a/app/frontend/shared/components/base/Btn/index.vue
+++ b/app/frontend/shared/components/base/Btn/index.vue
@@ -758,12 +758,12 @@ const handleClick = (event: MouseEvent) => {
 }
 
 /*
- * Busy is not unavailable. The disabled rule dims the content to 45%, which for
- * a working button says the wrong thing - it reads as a control you cannot use
- * rather than one that is already doing what you asked. The caps say it instead.
+ * The label dims with the disabled rule, because a loading button is not
+ * takeable: it already refuses the click, and a full-strength label invited one.
+ * Only the caps stay lit - the surface goes quiet and the run around the outside
+ * is the one thing still moving, which is what says busy rather than dead.
  */
 .btn.is-loading .btn__content {
-  @apply opacity-100;
   /* Above the wash below. Both are positioned boxes at z-index auto, and the
      pseudo-element comes after the label in tree order, so without this the
      wash paints over the text and tints it. */

--- a/test/playwright/e2e/Buttons.spec.ts
+++ b/test/playwright/e2e/Buttons.spec.ts
@@ -121,17 +121,16 @@ test.describe("Buttons", () => {
     expect(caps[1].animationName).toMatch(/^btn-fill-leftward/);
   });
 
-  test("a loading button keeps its label at full strength", async ({
-    page,
-  }) => {
-    // Busy is not unavailable: the disabled rule dims content to 45%, which on a
-    // working button reads as one that cannot be used.
+  test("a loading button dims its label", async ({ page }) => {
+    // A loading button renders disabled and already refuses the click, so the
+    // label takes the disabled dim with everything else - at full strength it
+    // read as takeable. The caps are what say busy, and they stay lit.
     const content = page
       .getByTestId("loading-variants")
       .locator(".is-loading .btn__content")
       .first();
 
-    expect(await style(content, "opacity")).toBe("1");
+    expect(await style(content, "opacity")).toBe("0.45");
   });
 
   test("a loading group member fills its surface, not a cap", async ({


### PR DESCRIPTION
## What

While a button is loading it renders `disabled`, but the loading rules explicitly pushed the label back to full opacity — so a busy button looked just as takeable as an idle one.

Now the disabled dim applies to the content as well. Only the caps stay at full strength, so the run travelling around the outside is the one thing still moving: the surface goes quiet, the motion says busy.

## Change

- `app/frontend/shared/components/base/Btn/index.vue`: drop the `opacity-100` override on `.btn.is-loading .btn__content`. The `position: relative` / `z-index: 1` stay — they keep the label above the surface wash that the cap-less contexts (xs, bare, grouped, menu item) paint.

Nothing else changes: the caps rule already pins `opacity: 1` against the disabled dim, so the animation and the fill are untouched.

## Verification

Screenshotted `/visual-tests/buttons` against the running dev server — labels dimmed across all tone/variant combinations, caps still lit and animating.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated loading buttons so their labels appear subtly dimmed while loading indicators remain highlighted.
  * Preserved the button’s disabled-state visual treatment during loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->