### PR TITLE
fix(cable): resubscribe after a reconnect, and resync the admin notification list

### DIFF
--- a/app/frontend/admin/composables/useAdminNotificationUpdates.ts
+++ b/app/frontend/admin/composables/useAdminNotificationUpdates.ts
@@ -92,9 +92,26 @@ export const useAdminNotificationUpdates = (enabled: Ref<boolean>) => {
     announce(notification);
   };
 
+  // Whatever was broadcast while the socket was down is gone - the channel has
+  // no replay - so a reconnect has to resync rather than carry on. Without it a
+  // notification that arrives while the tab sits in the background is missing
+  // from the list until something else refetches it, and the unread count, on
+  // its own interval, is the only sign it ever happened. Not on the first
+  // connect: the queries have only just loaded.
+  let seenConnect = false;
+
+  const connected = () => {
+    if (seenConnect) {
+      invalidate();
+    }
+
+    seenConnect = true;
+  };
+
   useSubscription({
     channelName: ChannelsEnum.ADMIN_NOTIFICATIONS_CHANNEL,
     received,
+    connected,
     enabled,
   });
 

--- a/app/frontend/shared/composables/useSubscription.spec.ts
+++ b/app/frontend/shared/composables/useSubscription.spec.ts
@@ -55,6 +55,32 @@ describe("useSubscription", () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
+  /*
+   * actioncable reopens the socket by itself and resubscribes everything still
+   * in its registry -- returning to a backgrounded tab is enough to trigger it.
+   * Dropping the subscription when the socket goes down takes it out of that
+   * registry, and the channel stays quiet for good.
+   */
+  it("keeps the subscription when the socket drops", () => {
+    const unsubscribe = vi.fn();
+    create.mockReturnValue({ unsubscribe });
+    vi.spyOn(console, "info").mockImplementation(() => {});
+
+    const disconnected = vi.fn();
+
+    const { subscribe } = useSubscription({
+      channelName: "ShipsChannel",
+      disconnected,
+    });
+
+    subscribe();
+
+    create.mock.calls[0][1].disconnected();
+
+    expect(disconnected).toHaveBeenCalled();
+    expect(unsubscribe).not.toHaveBeenCalled();
+  });
+
   it("does nothing when there is no consumer at all", () => {
     consumer = undefined;
 

--- a/app/frontend/shared/composables/useSubscription.ts
+++ b/app/frontend/shared/composables/useSubscription.ts
@@ -55,9 +55,12 @@ export const useSubscription = <T = unknown>({
               connected();
             }
           },
+          // No `unsubscribe()` here: actioncable reopens the socket by
+          // itself -- returning to a backgrounded tab is enough -- and
+          // resubscribes everything it still knows about. Dropping the
+          // subscription on the way down takes it out of that list, so the
+          // channel goes quiet for good after the first reconnect.
           disconnected: () => {
-            unsubscribe();
-
             console.info("Disconnected from Channel:", channelName);
 
             if (disconnected) {


### PR DESCRIPTION
On the admin notifications page, a notification that arrives while the tab sits in the background shows up in the badge but never as a row in the list.

## Why

The badge and the list are fed by different things. `useAdminNotificationsUnreadCount` polls (`refetchInterval: 60_000`), so the count catches up on its own. The list refreshes off nothing but the `AdminNotificationsChannel` broadcast — so "the badge counts it, the row is missing" is the signature of a broadcast that never arrived, not of a missed render.

Two things dropped it:

1. **The subscription unsubscribed itself.** actioncable's `ConnectionMonitor` listens on `visibilitychange` and calls `connection.reopen()` when the connection looks stale — coming back to a backgrounded tab is enough. That fires `disconnected` on every subscription, and `useSubscription` called `unsubscribe()` there, which `forget()`s the subscription. The `subscriptions.reload()` that follows the reconnect then has nothing left to resubscribe, and the channel is quiet for good.
2. **The channel has no replay.** Anything broadcast while the socket was down is gone even once the subscription survives the reconnect.

## What changed

- `useSubscription` no longer unsubscribes from its own `disconnected` callback — actioncable owns the reconnect. This covers all 20 subscriptions in the app, not just the admin notifications.
- `useAdminNotificationUpdates` invalidates on `connected`, skipping the first one (the queries have only just loaded), so a reconnect resyncs instead of carrying on from a gap.

## Verification

- New spec in `useSubscription.spec.ts` pins the regression: a socket drop must not tear the subscription down. Checked that it fails against the old `unsubscribe()` and passes with the fix.
- `lint:ts` and eslint clean.

🤖
