### PR TITLE
fix(stats): give the stat tile icons their two tones back

### DIFF
--- a/app/frontend/admin/components/Dashboard/AttentionTile.vue
+++ b/app/frontend/admin/components/Dashboard/AttentionTile.vue
@@ -107,8 +107,8 @@ const link = computed(() =>
     transform: translateY(-50%);
     font-size: 34px;
     color: $gray-lighter;
-    opacity: 0.4;
-    --fa-secondary-opacity: 1;
+    opacity: 0.5;
+    --fa-secondary-opacity: 0.6;
     pointer-events: none;
   }
 

--- a/app/frontend/admin/components/Dashboard/LinkTile.vue
+++ b/app/frontend/admin/components/Dashboard/LinkTile.vue
@@ -101,8 +101,8 @@ withDefaults(defineProps<Props>(), {
     transform: translateY(-50%);
     font-size: 34px;
     color: $gray-lighter;
-    opacity: 0.4;
-    --fa-secondary-opacity: 1;
+    opacity: 0.5;
+    --fa-secondary-opacity: 0.6;
     pointer-events: none;
   }
 }

--- a/app/frontend/shared/components/MissingRolesPanel/index.vue
+++ b/app/frontend/shared/components/MissingRolesPanel/index.vue
@@ -98,8 +98,8 @@ const labels = computed(() =>
     transform: translateY(-50%);
     font-size: 34px;
     color: $gray-lighter;
-    opacity: 0.4;
-    --fa-secondary-opacity: 1;
+    opacity: 0.5;
+    --fa-secondary-opacity: 0.6;
     pointer-events: none;
   }
 

--- a/app/frontend/shared/components/StatsPanel/index.vue
+++ b/app/frontend/shared/components/StatsPanel/index.vue
@@ -96,11 +96,14 @@ const suffix = computed(() => {
   // The icon is decoration behind the figure, not a peer of it: quiet, and out of
   // the flow so a long value keeps the full width of the tile.
   //
-  // One flat tone rather than duotone's two: the secondary layer's default 0.4
-  // multiplied into the wrapper's opacity, so half of every glyph sat under 10%
-  // and the shape broke up against the page image showing through the 0.9-alpha
-  // panel. $gray-lighter at 0.4 is the same weight the old 0.22 was aiming for,
-  // now actually reached.
+  // The wrapper opacity dims both duotone layers as a group - per-layer alpha
+  // via rgba() would instead double up where the two paths overlap. It also
+  // multiplies into the secondary, and at that layer's 0.4 default the quieter
+  // half of every glyph fell to an effective 0.09 and vanished against the page
+  // image showing through the 0.9-alpha panel. Raising it to 0.6 and the wrapper
+  // to 0.5 keeps the two tones apart without the icon reading any fainter than
+  // the flat one it replaces: measured over $gray-black, 92 and 68 against a
+  // background of 32.
   .stats-panel__icon {
     position: absolute;
     top: 50%;
@@ -108,8 +111,8 @@ const suffix = computed(() => {
     transform: translateY(-50%);
     font-size: 34px;
     color: $gray-lighter;
-    opacity: 0.4;
-    --fa-secondary-opacity: 1;
+    opacity: 0.5;
+    --fa-secondary-opacity: 0.6;
     pointer-events: none;
   }
 }


### PR DESCRIPTION
The duotone icons behind the figures on the stats pages and the admin dashboard
render as one flat tone. The markup still asks for `fa-duotone`, but the tile
styles pin `--fa-secondary-opacity` to `1`, which puts both of the glyph's layers
on the same value.

That was deliberate, in 59808b2fd. The icon is dimmed as a group via the wrapper
`opacity`, and that multiplies into the secondary layer — at the layer's `0.4`
default the quieter half of each glyph fell to an effective `0.09` and broke up
against the page image showing through the `0.9`-alpha panel. Pinning the
secondary to `1` fixed the legibility and lost the second tone with it.

This raises the secondary to `0.6` and the wrapper to `0.5` instead. The wrapper
`opacity` stays, rather than moving to a per-layer `rgba()` alpha: it composites
the two layers as a group, where per-layer alpha would double up wherever the two
paths overlap.

Measured over `$gray-black` with the real webfont, the two layers land on **92**
and **68** against a background of **32** — distinct tones, with the quieter one
well clear of the background:

| | background | secondary (area) | primary (accent) |
|---|---|---|---|
| before 59808b2fd | 32 | 51 | 80 |
| current | 32 | 80 | 80 (collapsed) |
| this PR | 32 | 68 | 92 |

Raising only the secondary would have made the icons quieter overall, so the
wrapper moves with it: on most glyphs the secondary layer carries the large area
and the primary only the accent (on `fa-database`, 15,245px against 2,260px).
At `0.5/0.6` the tiles keep the presence they have today.

The tile icons stay deliberately duller than the nav's, which sit at full opacity
with FontAwesome's default `1/0.4` contrast. In a tile the icon is decoration
behind the figure and the number should read first; in the nav it is a peer of its
label.

### Affected

- `StatsPanel` — every stats page (global, hangar, public hangar, fleet)
- `MissingRolesPanel`
- admin dashboard `LinkTile` and `AttentionTile`

### Verified

- Rendered the real duotone webfont over a tile at `rgba($gray-black, .9)` and
  sampled the output with a canvas histogram for the numbers above
- `eslint` and `prettier` clean on all four files
- `AttentionTile.test.ts` green

🤖
