### PR TITLE
feat(admin): move unlisted ships from the nav to the ships list

### DIFF
--- a/app/frontend/admin/pages/models/index.vue
+++ b/app/frontend/admin/pages/models/index.vue
@@ -23,6 +23,7 @@ import { useComlink } from "@/shared/composables/useComlink";
 
 import {
   useModels as useModelsQuery,
+  useScDataUnlistedModels,
   getModelsQueryKey,
   type Model,
   type ModelSortEnum,
@@ -196,6 +197,26 @@ watch(
   },
   { immediate: true },
 );
+/*
+ * How many ships the game files describe that the catalogue has no model for.
+ * Asked for one record rather than none: the endpoint answers with a page and
+ * its pagination meta, and the count is what we are after -- there is no cheaper
+ * shape for it that does not mean a second endpoint.
+ *
+ * It matches what the target page shows because both leave `decision` unset, and
+ * the controller defaults that to undecided -- the same scope the dashboard
+ * tile counts.
+ */
+const { data: unlistedModels } = useScDataUnlistedModels({
+  // Strings, because that is what the generated params are: these go into a
+  // query string, and the schema types them as it receives them.
+  page: "1",
+  perPage: "1",
+});
+
+const unlistedCount = computed(
+  () => unlistedModels.value?.meta.pagination?.totalCount ?? 0,
+);
 </script>
 
 <template>
@@ -212,6 +233,25 @@ watch(
   </Heading>
 
   <Teleport to="#header-right">
+    <!--
+      Always rendered, never hidden on a zero count. The dashboard's attention
+      tile is the only other way in and it filters itself out at zero, so a
+      button that did the same would put the page out of reach exactly when
+      someone wants to confirm there is nothing waiting. The count is what
+      disappears instead.
+    -->
+    <Btn
+      :size="BtnSizesEnum.MD"
+      :to="{ name: 'admin-unlisted-models' }"
+      :aria-label="t('headlines.admin.unlistedModels.index')"
+      mobile-icon-only
+    >
+      <i class="fa-duotone fa-magnifying-glass-plus" />
+      {{ t("labels.admin.models.unlisted") }}
+      <span v-if="unlistedCount" class="unlisted-count">{{
+        unlistedCount
+      }}</span>
+    </Btn>
     <Btn
       :size="BtnSizesEnum.MD"
       :to="{ name: 'admin-model-modules' }"
@@ -441,3 +481,18 @@ watch(
     </template>
   </FilteredList>
 </template>
+
+<style lang="scss" scoped>
+/*
+ * Quieter than the label it follows, so the button reads as one control with a
+ * figure on it rather than as two things. Slot content carries this page's scope
+ * id, so the rule reaches inside Btn without a :deep - and it collapses with the
+ * label under `mobile-icon-only`, which zeroes the font size of the whole
+ * content row. A Pill would not: it would keep its own box and sit there as a
+ * blob beside the icon.
+ */
+.unlisted-count {
+  color: var(--color-primary, #428bca);
+  font-variant-numeric: tabular-nums;
+}
+</style>

--- a/app/frontend/admin/pages/models/routes.ts
+++ b/app/frontend/admin/pages/models/routes.ts
@@ -26,6 +26,10 @@ export const routes: RouteRecordRaw[] = [
       title: "admin.unlistedModels.index",
       icon: "fa-duotone fa-magnifying-glass-plus",
       activeRoute: "admin-models",
+      // Reached from the ships list, which is the only place the decision it
+      // asks for makes sense, and which carries the count of what is waiting.
+      // In the nav it was a permanent entry for a list that is empty most days.
+      nav: "hidden",
       access: ["models"],
     },
   },

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1687,6 +1687,9 @@
             "uex_price_sync": "UEX-Preisabgleich",
             "unknown": "Unbekannt"
           }
+        },
+        "models": {
+          "unlisted": "Ohne Model"
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1688,6 +1688,9 @@
             "uex_price_sync": "UEX Price Sync",
             "unknown": "Unknown"
           }
+        },
+        "models": {
+          "unlisted": "Unlisted"
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1687,6 +1687,9 @@
             "uex_price_sync": "Sincronización de precios UEX",
             "unknown": "Desconocido"
           }
+        },
+        "models": {
+          "unlisted": "Sin modelo"
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1687,6 +1687,9 @@
             "uex_price_sync": "Synchronisation des prix UEX",
             "unknown": "Inconnu"
           }
+        },
+        "models": {
+          "unlisted": "Sans modèle"
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1687,6 +1687,9 @@
             "uex_price_sync": "Sincronizzazione prezzi UEX",
             "unknown": "Sconosciuto"
           }
+        },
+        "models": {
+          "unlisted": "Senza modello"
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1683,6 +1683,9 @@
             "uex_price_sync": "UEX 价格同步",
             "unknown": "未知"
           }
+        },
+        "models": {
+          "unlisted": "未收录"
         }
       },
       "hangarTable": {

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1683,6 +1683,9 @@
             "uex_price_sync": "UEX 價格同步",
             "unknown": "未知"
           }
+        },
+        "models": {
+          "unlisted": "未收錄"
         }
       },
       "hangarTable": {


### PR DESCRIPTION
Unlisted ships had a permanent row in the main nav for a list that is empty most days. The decision it asks for — is this game-file ship one the catalogue should carry — only makes sense next to the catalogue, so it moves to a button on the ships list.

## What changed

- `admin-unlisted-models` gets `nav: "hidden"`, the same meta three sibling routes under `/models/` already use
- A button on the ships list, first in the existing `#header-right` teleport, beside the one to model modules that already fills this role for a sibling page
- The button carries the count of what is waiting

## The count

Read from the list endpoint's own pagination meta with `perPage: "1"`, rather than adding a second endpoint for a number. It matches what the page shows after the click because both leave `decision` unset and the controller defaults that to `undecided` — the same scope the dashboard tile counts.

## Two decisions worth flagging

**The button stays visible at zero**, and only the count disappears. The dashboard's attention tile is the only other way to the page and it filters itself out at zero, so a button that did the same would put the page out of reach exactly when someone wants to confirm there is nothing waiting.

**The count is plain text, not a pill.** `mobile-icon-only` zeroes the font size of the whole content row, so text collapses with the label; a pill would keep its own box and sit beside the icon as a blob.

## Verified

`pnpm lint:fix`, `pnpm lint:ts` and `vite build` clean. No test references the nav entry. Translated in all seven locales.

Not checked in a browser — this was verified structurally, not visually.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an always-visible admin navigation button for unlisted models.
  - The button displays the current number of unlisted models when the count is greater than zero.
  - Added localized labels for unlisted models in English, German, Spanish, French, Italian, Simplified Chinese, and Traditional Chinese.

- **Navigation**
  - The unlisted-models page no longer appears as a standalone navigation item and is accessed through the new button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->