### PR TITLE
fix(appsignal): stop reporting the nightly Sidekiq Redis read timeout

### DIFF
--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -10,6 +10,12 @@ production:
       - ActionDispatch::Http::MimeNegotiation::InvalidType
       - ActionController::BadRequest
       - ActionDispatch::Http::Parameters::ParseError
+      # Sidekiq's fetch loop blocks on Redis with a 5s read timeout, and the
+      # nightly db-backup (03:00 UTC) runs on the same host as the Redis
+      # accessory. The timeouts that follow are handled by Sidekiq itself --
+      # the processor sleeps a second and fetches again, no job is lost -- so
+      # they are noise rather than a failure. AppSignal incident #15724.
+      - RedisClient::ReadTimeoutError
 
 staging:
   push_api_key: "<%= Rails.application.credentials.dig(:appsignal, :push_api_key) rescue nil %>"
@@ -24,6 +30,12 @@ staging:
       - ActionDispatch::Http::MimeNegotiation::InvalidType
       - ActionController::BadRequest
       - ActionDispatch::Http::Parameters::ParseError
+      # Sidekiq's fetch loop blocks on Redis with a 5s read timeout, and the
+      # nightly db-backup (03:00 UTC) runs on the same host as the Redis
+      # accessory. The timeouts that follow are handled by Sidekiq itself --
+      # the processor sleeps a second and fetches again, no job is lost -- so
+      # they are noise rather than a failure. AppSignal incident #15724.
+      - RedisClient::ReadTimeoutError
 
 development:
   active: false


### PR DESCRIPTION
## What

Adds `RedisClient::ReadTimeoutError` to `ignore_errors` in `config/appsignal.yml`, for production and staging.

## Why

AppSignal incident [#15724](https://appsignal.com/fleetyards-dot-net/sites/608dbe8374782022a091f36d/exceptions/incidents/15724) has been open since 2023 and still fires. The time pattern is the whole answer: **all 11 traces fall between 04:02 and 04:57 UTC**, across six different days and both hosts. That is not network flakiness.

`config/deploy.yml` explains it — `db`, `redis` and `db-backup` all resolve to `acc_ips.first`, and the backup runs at `SCHEDULE: "0 3 * * *"`. Sidekiq's fetch loop blocks on Redis with a 5s read timeout and trips in the window that follows.

## Why ignoring is the right call, not fixing

Sidekiq already handles this. `launcher.rb:195` rescues Redis and network errors explicitly, and the processor sleeps a second and fetches again. **No job is lost and none is delayed beyond that second.** There is no code path to fix — only an unactionable condition that is currently one of the louder things in the error stream.

Scope check: no other `RedisClient::ReadTimeoutError` incident exists in the last three months, so this entry suppresses this failure mode and nothing else in practice. A genuine Redis outage presents as a connection error, not a read timeout.

## Follow-up

Incident #15724 can be closed once this is deployed — until then it keeps arriving. The reasoning is recorded as a note on the incident itself.

The related infrastructure work is separate: #4334 / #4335 (Redis 8.2 upgrade and the instance-wide eviction policy).

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error alerts by excluding Redis read timeout events that are handled automatically by background processing in staging and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->