### PR TITLE
chore(redis): upgrade to 8.2.9 and stop evicting Sidekiq's keyspace

### DIFF
--- a/.github/workflows/api-schema-check.job.yml
+++ b/.github/workflows/api-schema-check.job.yml
@@ -33,7 +33,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7.2.15-alpine
+        image: redis:8.2.9-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/e2e.job.yml
+++ b/.github/workflows/e2e.job.yml
@@ -41,7 +41,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7.2.15-alpine
+        image: redis:8.2.9-alpine
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -42,7 +42,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7.2.15-alpine
+        image: redis:8.2.9-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/seeds.job.yml
+++ b/.github/workflows/seeds.job.yml
@@ -28,7 +28,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       redis:
-        image: redis:7.2.15-alpine
+        image: redis:8.2.9-alpine
         ports:
           - 6379:6379
         options: >-

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -127,9 +127,16 @@ accessories:
       memory: 4g
 
   redis:
-    image: redis:7.2.15
+    image: redis:8.2.9
     port: "6379:6379"
-    cmd: redis-server --maxmemory 1536mb --maxmemory-policy allkeys-lru
+    # `maxmemory-policy` applies to the whole instance, not per database, so the
+    # policy the cache needs is also the policy Sidekiq's queues get. `volatile-lru`
+    # only ever evicts keys that carry a TTL: the cache, the API usage counters,
+    # the Rack::Attack throttles and the sessions all set one, while Sidekiq's
+    # `queue:*`, `retry` and `schedule` do not, and are therefore unreachable.
+    # Sidekiq still warns at boot because it compares the policy against
+    # `noeviction` verbatim — see docs/exec-plans/4334-redis-8-upgrade.md.
+    cmd: redis-server --maxmemory 1536mb --maxmemory-policy volatile-lru
     directories:
       - data:/data
     options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - postgres:/var/lib/postgresql/data
   redis:
-    image: redis:7.2.15-alpine
+    image: redis:8.2.9-alpine
     # Every worktree shares this container and keeps its Sidekiq queues, cache,
     # sessions and counters apart by database index — bin/setup gives each one a
     # band and config/redis.yml maps the offsets within it. Redis defaults to 16

--- a/docs/exec-plans/4334-redis-8-upgrade.md
+++ b/docs/exec-plans/4334-redis-8-upgrade.md
@@ -47,7 +47,21 @@ WARNING: Your Redis instance will evict Sidekiq data under heavy load.
 The 'noeviction' maxmemory policy is recommended (current policy: 'volatile-lru').
 ```
 
-The check is a string comparison against `noeviction`; it does not know that Sidekiq's own keys carry no TTL and are therefore unreachable by `volatile-lru`. The warning is a false positive here, and the `cmd:` line carries a comment saying so. Silencing it is what D2's rejected option costs.
+The check is a literal string comparison and nothing more; it knows nothing about which keys would actually be candidates. The warning is a false positive here, and the `cmd:` line carries a comment saying so. Silencing it is what D2's rejected option costs.
+
+Sidekiq is not entirely TTL-free, so the claim needs to be precise about which of its keys `volatile-lru` can reach:
+
+| Sidekiq key | TTL | Consequence if evicted |
+| --- | --- | --- |
+| `queue:*`, `retry`, `schedule`, `dead` | none | unreachable — this is the job data #4335 is about |
+| Heartbeat / process keys | 60s, rewritten every 10s (`BEAT_PAUSE`) | the worker drops out of the Web UI until the next beat; cosmetic |
+| `stat:processed:<date>`, `stat:failed:<date>` | 5 years | one day's counter in the stats |
+| Metrics histograms | 8 hours | a metric |
+| `Sidekiq::Job::Iterable` state | 30 days | **would be real damage** — an interrupted iterable job restarts from the beginning |
+
+Only the last row would hurt, and it does not apply: the app uses `Sidekiq::Job::Iterable` nowhere. The `JobIteration::ActiveRecordCursor` seen elsewhere is Shopify's gem behind `maintenance_tasks`, whose cursor is a Postgres column (`maintenance_tasks_runs.cursor`), not a Redis key.
+
+Worth noting what Sidekiq OSS does *not* do: it never recovers jobs from the process set — that is a Pro feature. An evicted heartbeat therefore cannot cause a job to be lost or replayed.
 
 ### D4 — Rollback means deleting `dump.rdb`
 
@@ -105,7 +119,7 @@ No gem gates on the server version except Sidekiq, and only from below: `sidekiq
 Rather than infer support from that, every Redis consumer in the app was exercised against a real `redis:8.2.9-alpine` started with the production `cmd` — 13 checks, all passing:
 
 - **Sidekiq** — enqueue / read back / delete on `queue:*`, `perform_in` onto the scheduled set, a retry-set round-trip, `Sidekiq::Stats` and the process set
-- **Sidekiq's keys carry no TTL** — asserted directly, since that is the premise `volatile-lru` rests on
+- **Sidekiq's `queue:*` keys carry no TTL** — asserted directly, since that is the premise `volatile-lru` rests on
 - **Rails cache** — `write`/`read`/`fetch`/`increment`/`delete_matched`, plus an assertion that a written key really does get a TTL
 - **Sessions** — `Redis::Store` round-trip with `expire_after`, TTL confirmed
 - **Action Cable** — redis pubsub across two connections with a `channel_prefix`

--- a/docs/exec-plans/4334-redis-8-upgrade.md
+++ b/docs/exec-plans/4334-redis-8-upgrade.md
@@ -96,6 +96,32 @@ RDB compatibility, both directions:
 - 8.2.9 writes `REDIS0012`; 7.2.15 refuses it with `# Can't handle RDB format version 12` / `# Fatal error loading the DB` and exits. D4's rollback step is required, not precautionary.
 - `MODULE LIST` on 8.2.9 with a custom `cmd`: `timeseries`, `search`, `bf`, `vectorset`, `ReJSON` — loaded, as the issue found.
 
+## Compatibility, verified against the installed gems
+
+`rails 8.1.3.1` / `actioncable 8.1.3.1`, `redis 5.4.1`, `redis-client 0.30.1`, `sidekiq 8.1.7`, `sidekiq-scheduler 6.0.2`, `redis-store 1.12.0`, `redis-actionpack 5.5.0`.
+
+No gem gates on the server version except Sidekiq, and only from below: `sidekiq/cli.rb:78` raises for anything under 7.0.0 and has no upper bound. `redis` and `redis-client` do not inspect the version at all.
+
+Rather than infer support from that, every Redis consumer in the app was exercised against a real `redis:8.2.9-alpine` started with the production `cmd` — 13 checks, all passing:
+
+- **Sidekiq** — enqueue / read back / delete on `queue:*`, `perform_in` onto the scheduled set, a retry-set round-trip, `Sidekiq::Stats` and the process set
+- **Sidekiq's keys carry no TTL** — asserted directly, since that is the premise `volatile-lru` rests on
+- **Rails cache** — `write`/`read`/`fetch`/`increment`/`delete_matched`, plus an assertion that a written key really does get a TTL
+- **Sessions** — `Redis::Store` round-trip with `expire_after`, TTL confirmed
+- **Action Cable** — redis pubsub across two connections with a `channel_prefix`
+- **Rack::Attack** — throttle counter through its Redis-backed store
+- **`ApiUsageTracker`** — `scan_each` over the namespaced keyspace
+- **RESP3** — explicit `HELLO 3` handshake and round-trip
+
+And a real `sidekiq` server booted against it, picked up a job and shut down cleanly. Its boot output is exactly D3's prediction, reproduced verbatim:
+
+```
+WARNING: Your Redis instance will evict Sidekiq data under heavy load.
+The 'noeviction' maxmemory policy is recommended (current policy: 'volatile-lru').
+```
+
+Followed, in the same run, by `class=ProbeJob: start` / `elapsed=0.0: done`.
+
 ## Intent Verification
 
 - [ ] **CI runs against 8.2.9** — all four workflows show the new image and pass, including the full Ruby suite

--- a/docs/exec-plans/4334-redis-8-upgrade.md
+++ b/docs/exec-plans/4334-redis-8-upgrade.md
@@ -1,0 +1,105 @@
+# Upgrade Redis 7.2 → 8.2 and stop the eviction policy from reaching Sidekiq
+
+## Goal
+
+Every environment runs a Redis from the 8.2 line, and the production instance can no longer evict a Sidekiq job under memory pressure.
+
+## Context
+
+`config/deploy.yml` pins the production accessory to `redis:7.2.15` and starts it with `redis-server --maxmemory 1536mb --maxmemory-policy allkeys-lru`. CI (×4 workflows) and `docker-compose.yml` pin `redis:7.2.15-alpine`.
+
+Two defects sit on that one `cmd:` line, which is why they are resolved together — one accessory restart instead of two, and the deploy already needs a drained-queue window, which is the safest moment to change an eviction policy.
+
+Neither is urgent. 7.2 is supported until 2029-12-01, and production reports `evicted_keys:0` / `total_eviction_exceeded_time:0`, so nothing is actively being dropped.
+
+Resolves #4334, resolves #4335
+
+## Decisions
+
+### D1 — Target 8.2.9, not the 8.2.8 named in the issue
+
+The 8.2 line is supported until 2030-09-01; 8.0 is nearly EOL and 8.4–8.10 have no committed support window. Within the line, take the newest patch: `8.2.9` was published 2026-08-20, a month after the `8.2.8` the issue researched, and is the same 27.8 MB compressed.
+
+### D2 — `volatile-lru`, not a second Redis accessory
+
+`maxmemory-policy` applies to the whole instance, not per database, so Sidekiq's DB 0 inherits whatever the cache needs. `volatile-lru` evicts **only keys that carry a TTL**, which splits the instance along exactly the line that matters here:
+
+| Keyspace | DB | TTL | Under `volatile-lru` |
+| --- | --- | --- | --- |
+| Sidekiq `queue:*`, `retry`, `schedule` | 0 | none | never evicted |
+| Rails cache | 1 | `expires_in: 1.day` store default, every call site passes its own | evictable |
+| API usage counters | 1 | `expires_in: 8.days` per write | evictable |
+| Rack::Attack throttles | 1 | period-based, set by Rack::Attack | evictable |
+| Sessions | 2 | `expire_after: 2.hours` | evictable |
+
+Verified: no call site writes to the cache with `expires_in: nil` or `0`, so the safety valve keeps a real keyspace to work on.
+
+- Rejected: **a second accessory with `noeviction`** (Sidekiq's own recommendation). Correct, but it costs a new accessory, a second URL threaded through `config/redis.yml` and the Kamal secrets, and a cutover for the queue data already in DB 0 — a large amount of moving parts for a failure mode that has never fired.
+- Rejected: **`noeviction` on the shared instance.** Safe for Sidekiq, but at the ceiling the cache starts returning write errors instead of quietly shedding old entries, so the cache would need its own bound or its own instance — which is the rejected option above by another route.
+- Rejected: **leaving the policy alone.** The line is being edited anyway.
+
+### D3 — Accept Sidekiq's boot warning
+
+`sidekiq/cli.rb:80-91` warns on any policy other than `noeviction`:
+
+```
+WARNING: Your Redis instance will evict Sidekiq data under heavy load.
+The 'noeviction' maxmemory policy is recommended (current policy: 'volatile-lru').
+```
+
+The check is a string comparison against `noeviction`; it does not know that Sidekiq's own keys carry no TTL and are therefore unreachable by `volatile-lru`. The warning is a false positive here, and the `cmd:` line carries a comment saying so. Silencing it is what D2's rejected option costs.
+
+### D4 — Rollback means deleting `dump.rdb`
+
+8.x writes RDB v12. 8.2.9 reads a 7.2.15 dump, but 7.2.15 refuses a v12 dump outright (`Can't handle RDB format version 12`) and exits during startup. Rolling the image back therefore requires deleting `dump.rdb` from the `data:/data` volume, which discards DB 0. Draining the queues before the cutover (Phase 3) is what makes that acceptable rather than destructive.
+
+## What changed
+
+### Phase 1 — CI and local on 8.2.9
+
+1. `.github/workflows/ruby-tests.job.yml`, `seeds.job.yml`, `api-schema-check.job.yml`, `e2e.job.yml`: service image `redis:7.2.15-alpine` → `redis:8.2.9-alpine`.
+2. `docker-compose.yml`: `redis:7.2.15-alpine` → `redis:8.2.9-alpine`. The `--databases 1024` command stays; it is what gives each worktree its own band.
+3. Push and let CI run the full Ruby suite, seeds, schema check and e2e against 8.2.9. This is the evidence for Phase 2 — production is not touched until it is green.
+
+### Phase 2 — Production accessory
+
+1. `config/deploy.yml`: `image: redis:7.2.15` → `redis:8.2.9`.
+2. Same file: `--maxmemory-policy allkeys-lru` → `--maxmemory-policy volatile-lru`, with a comment recording why (D2/D3).
+
+### Phase 3 — Cutover
+
+Nothing here is in the diff; it is the deploy procedure, and it needs a human at the terminal.
+
+1. **Before**: record the starting state — `bin/accessory-live exec redis -- redis-cli INFO memory | grep -E 'used_memory_human|maxmemory_human'`, `INFO keyspace`, and `INFO stats | grep evicted_keys`. If `used_memory` is anywhere near the 1536 MB ceiling, stop and reconsider the ceiling first.
+2. **Drain**: quiet the worker role and let in-flight jobs finish, so DB 0 is as close to empty as it gets. This bounds the rollback loss to nothing.
+3. **Deploy**: `bin/deploy` for the config, then `bin/accessory-live reboot redis` to recreate the container on the new image and `cmd`.
+4. **Verify**: `INFO server` reports `redis_version:8.2.9`; `CONFIG GET maxmemory-policy` returns `volatile-lru`; `INFO keyspace` still shows the databases from step 1.
+5. **Resume**: bring the worker role back and confirm jobs are being processed.
+6. **Rollback if needed**: revert the image pin, delete `dump.rdb` on the `data:/data` volume, redeploy — accepting the loss of whatever is in DB 0 (which step 2 made empty).
+
+Watch for: the 8.x images load modules (`search`, `ReJSON`, `timeseries`, `bf`, `vectorset`) even with a custom `cmd`. Measured at ~21 MB RSS idle in a 2 GB container, so `memory: 2g` and `maxmemory 1536mb` stay as they are.
+
+## Measured
+
+Against real containers, not from the docs. An isolated `redis:8.2.9-alpine` on port 63799, `maxmemory 3mb`, two TTL-less Sidekiq keys (`queue:default`, `schedule`) planted first, then 24,000 cache writes at `SETEX ... 86400` to force sustained eviction.
+
+| Policy | Evicted keys | `queue:default` | `schedule` |
+| --- | --- | --- | --- |
+| `allkeys-lru` (today's production) | 21,853 | **gone** | **gone** |
+| `volatile-lru` (this change) | 42,798 | intact | intact |
+
+So #4335 is not theoretical: under sustained pressure the current policy does drop Sidekiq's keyspace, and it drops it silently. A first, gentler run (4,000 writes, 855 evictions) left both keys alive — LRU samples rather than sorts, so the failure needs pressure to surface, which is exactly why `evicted_keys:0` in production is not reassurance.
+
+RDB compatibility, both directions:
+
+- 7.2.15 writes `REDIS0011`; 8.2.9 starts on that dump, keeps `db0`/`db1` and their TTLs, and applies `volatile-lru`.
+- 8.2.9 writes `REDIS0012`; 7.2.15 refuses it with `# Can't handle RDB format version 12` / `# Fatal error loading the DB` and exits. D4's rollback step is required, not precautionary.
+- `MODULE LIST` on 8.2.9 with a custom `cmd`: `timeseries`, `search`, `bf`, `vectorset`, `ReJSON` — loaded, as the issue found.
+
+## Intent Verification
+
+- [ ] **CI runs against 8.2.9** — all four workflows show the new image and pass, including the full Ruby suite
+- [ ] **Production reports 8.2.9** — `INFO server` after the accessory reboot
+- [ ] **Sidekiq's keyspace is unevictable** — `CONFIG GET maxmemory-policy` returns `volatile-lru`, and Sidekiq's keys carry no TTL
+- [ ] **Nothing was lost in the cutover** — `INFO keyspace` shows the same databases before and after, and the worker processes jobs again
+- [ ] **The cache still sheds** — `evicted_keys` may now rise from 0 under pressure; that is the valve working, not a regression


### PR DESCRIPTION
Resolves #4334, resolves #4335

## What

- CI (×4 workflows) and `docker-compose.yml`: `redis:7.2.15-alpine` → `redis:8.2.9-alpine`
- `config/deploy.yml`: accessory `redis:7.2.15` → `redis:8.2.9`, and `--maxmemory-policy allkeys-lru` → `volatile-lru`
- Exec plan: `docs/exec-plans/4334-redis-8-upgrade.md`

The two issues are resolved together because they edit the same `cmd:` line — one accessory restart instead of two, and the upgrade already needs a drained-queue window, which is the safest moment to change an eviction policy.

## 8.2.9, not the 8.2.8 the issue researched

Same support line (until 2030-09-01), published 2026-08-20, a month newer, identical 27.8 MB compressed.

## `volatile-lru`, and why it is enough

`maxmemory-policy` applies to the whole instance rather than per database, so the policy the cache needs is also the policy Sidekiq's queues get. `volatile-lru` evicts **only keys carrying a TTL**, which splits the instance exactly where it matters:

| Keyspace | DB | TTL | Under `volatile-lru` |
| --- | --- | --- | --- |
| Sidekiq `queue:*`, `retry`, `schedule` | 0 | none | never evicted |
| Rails cache | 1 | `expires_in: 1.day` store default | evictable |
| API usage counters | 1 | 8 days, per write | evictable |
| Rack::Attack throttles | 1 | period-based | evictable |
| Sessions | 2 | `expire_after: 2.hours` | evictable |

No call site writes to the cache with `expires_in: nil` or `0`, so the safety valve keeps a real keyspace to work on.

A second accessory with `noeviction` is what Sidekiq's docs recommend and it was considered — it costs a new accessory, a second URL through `config/redis.yml` and the Kamal secrets, and a cutover for the queue data already in DB 0. The exec plan records that trade-off along with the other rejected options.

## Measured, not assumed

Isolated `redis:8.2.9-alpine`, `maxmemory 3mb`, two TTL-less Sidekiq keys planted first, then 24,000 cache writes at `SETEX … 86400`:

| Policy | Evicted keys | `queue:default` | `schedule` |
| --- | --- | --- | --- |
| `allkeys-lru` (today's production) | 21,853 | **gone** | **gone** |
| `volatile-lru` (this PR) | 42,798 | intact | intact |

So #4335 is not theoretical — under sustained pressure the current policy does drop Sidekiq's keyspace, silently. Worth noting: a first, gentler run (4,000 writes, 855 evictions) left both keys alive under *both* policies. LRU samples rather than sorts, so the failure needs pressure to surface — which is precisely why `evicted_keys:0` in production is not evidence of safety.

RDB, both directions:

- 7.2.15 writes `REDIS0011`; 8.2.9 starts on that dump, keeps `db0`/`db1` and their TTLs, applies `volatile-lru`
- 8.2.9 writes `REDIS0012`; 7.2.15 refuses it — `# Can't handle RDB format version 12` — and exits during startup
- `MODULE LIST` on 8.2.9 with a custom `cmd`: `timeseries`, `search`, `bf`, `vectorset`, `ReJSON` all load, at ~21 MB RSS idle

## Do Rails and Sidekiq actually support 8.2?

Checked rather than assumed. No gem gates on the server version except Sidekiq, and only from below — `sidekiq/cli.rb:78` raises under 7.0.0 and has no upper bound; `redis` 5.4.1 and `redis-client` 0.30.1 never inspect it.

Since "nobody blocks it" is not the same as "it works", every Redis consumer was exercised against a real `redis:8.2.9-alpine` started with the production `cmd`. **13/13 passing:**

| Consumer | Checked |
| --- | --- |
| Sidekiq | enqueue / read back / delete on `queue:*`, `perform_in` → scheduled set, retry-set round-trip, `Sidekiq::Stats`, process set |
| Sidekiq `queue:*` | no TTL — asserted directly, since that is what `volatile-lru` rests on |
| Rails cache | `write`/`read`/`fetch`/`increment`/`delete_matched`, and that a written key really gets a TTL |
| Sessions | `Redis::Store` round-trip with `expire_after`, TTL confirmed |
| Action Cable | redis pubsub across two connections with a `channel_prefix` |
| Rack::Attack | throttle counter through its Redis-backed store |
| `ApiUsageTracker` | `scan_each` over the namespaced keyspace |
| Protocol | explicit `HELLO 3` RESP3 handshake and round-trip |

Plus a real `sidekiq` server booted against it, took a job and shut down cleanly:

```
WARNING: Your Redis instance will evict Sidekiq data under heavy load.
The 'noeviction' maxmemory policy is recommended (current policy: 'volatile-lru').
...
jid=10627b353ada2ca69feb8fff class=ProbeJob: start
jid=10627b353ada2ca69feb8fff class=ProbeJob elapsed=0.0: done
```

## Which Sidekiq keys `volatile-lru` can actually reach

Sidekiq is not entirely TTL-free, so this needs to be precise rather than reassuring:

| Sidekiq key | TTL | Consequence if evicted |
| --- | --- | --- |
| `queue:*`, `retry`, `schedule`, `dead` | none | unreachable — this is the job data #4335 is about |
| Heartbeat / process keys | 60s, rewritten every 10s | worker drops out of the Web UI until the next beat; cosmetic |
| `stat:processed:<date>` | 5 years | one day's counter in the stats |
| Metrics histograms | 8 hours | a metric |
| `Sidekiq::Job::Iterable` state | 30 days | **would be real damage** — an interrupted iterable job restarts from the beginning |

Only the last row would hurt, and it does not apply here: the app uses `Sidekiq::Job::Iterable` nowhere. The `JobIteration::ActiveRecordCursor` seen elsewhere is Shopify's gem behind `maintenance_tasks`, whose cursor is a Postgres column (`maintenance_tasks_runs.cursor`), not a Redis key.

Also worth stating: Sidekiq OSS never recovers jobs from the process set — that is a Pro feature — so an evicted heartbeat cannot lose or replay a job.

## Known and accepted

Sidekiq keeps warning at boot. `sidekiq/cli.rb:80-91` compares the policy against `noeviction` verbatim and does not know that Sidekiq's own keys carry no TTL and are therefore unreachable by `volatile-lru`. A false positive here; the `cmd:` line carries a comment saying so.

## Not in this PR: the cutover

Production is untouched until CI is green against 8.2.9. The deploy needs a human at the terminal — record `INFO memory` / `INFO keyspace` first, drain the queues, `bin/accessory-live reboot redis`, verify `redis_version:8.2.9` and `CONFIG GET maxmemory-policy`, then resume the worker. Draining first is what makes the rollback (delete `dump.rdb`, which discards DB 0) acceptable rather than destructive. Full procedure in the exec plan.

🤖
