### PR TITLE
fix(admin): drop the empty navigation from the login page

### DIFF
--- a/app/frontend/admin/App.vue
+++ b/app/frontend/admin/App.vue
@@ -51,6 +51,11 @@ useImportUpdates(isAuthenticated);
 
 const route = useRoute();
 
+// Every section needs authentication, so on the login page the sidebar is a
+// logo above an empty list and the mobile bar is a burger that opens it. Both
+// are dropped rather than rendered empty.
+const navigationVisible = computed(() => route.name !== "admin-login");
+
 const comlink = useComlink();
 
 const i18nStore = useI18nStore();
@@ -204,7 +209,7 @@ const setNoScroll = () => {
 
     <div class="app-content">
       <transition name="fade" mode="out-in">
-        <AdminNavigation />
+        <AdminNavigation v-if="navigationVisible" />
       </transition>
       <div class="main-wrapper">
         <div ref="mainInner" class="main-inner">
@@ -249,7 +254,7 @@ const setNoScroll = () => {
     </div>
 
     <transition name="fade" mode="out-in">
-      <AdminNavigationMobile v-if="mobile" />
+      <AdminNavigationMobile v-if="mobile && navigationVisible" />
     </transition>
 
     <AppConfirm />

--- a/app/frontend/admin/pages/login.scss
+++ b/app/frontend/admin/pages/login.scss
@@ -53,3 +53,12 @@
     }
   }
 }
+
+// The mobile tab bar is dropped on this page, so the room the layout reserves
+// for it is dead space at the foot of the form. Matched on the page class the
+// app body carries, since the padding sits on `body` itself.
+@media (max-width: $desktop-breakpoint) {
+  body:has(.page-admin-login) {
+    padding-bottom: 0;
+  }
+}


### PR DESCRIPTION
## What

Removes the sidebar and the mobile tab bar from the admin login page.

Every admin section declares `needsAuthentication: true`, so `AppNavigationItems` filtered all of them out while logged out. What was left on `/login/`:

- **Sidebar** — the logo and title, an empty `main` slot, and a single footer entry: "Login", linking to the page you were already on.
- **Mobile** — a fixed bottom bar containing only the burger button, which opened that same near-empty drawer, plus the `padding-bottom` the layout reserves on `body` for a bar with nothing in it.

The logo and title are already part of the login form's own `<Heading>`, so the sidebar duplicated those too.

## How

- `App.vue` gates both `AdminNavigation` and `AdminNavigationMobile` on the route name. The layout is flex, so `main-wrapper` simply takes the full width — the centred 300px form is untouched.
- `login.scss` drops the reserved mobile-bar padding under `$desktop-breakpoint`. It matches on `.page-admin-login`, the class `.app-body` already derives from the route name, because the padding sits on `body` itself.

The gate is on the route name rather than on `isAuthenticated`, so the 404 page keeps its nav — and with it the footer "Login" entry, which is the one place that link actually leads somewhere.

## Notes

`AppNavigationHeader` still renders. It is empty on this page but costs ~40px of dead space through its padding; left alone as a separate call.

## Verification

`prettier`, `eslint` and `vue-tsc --noEmit` pass. Not checked visually in a running app.

🤖
