### PR TITLE
fix(sc_data): two ways a reader saw the wrong build

### DIFF
--- a/app/frontend/shared/stores/scDataSource.spec.ts
+++ b/app/frontend/shared/stores/scDataSource.spec.ts
@@ -70,4 +70,30 @@ describe("scDataSource store", () => {
     expect(store.requestParam).toBeUndefined();
     expect(store.hasChoice).toBe(false);
   });
+
+  // The boot requests go out before the list can arrive, so a rehydrated choice
+  // has to answer on its own -- otherwise the first paint is the default's data
+  // under the other build's label.
+  it("sends a rehydrated choice before the list has arrived", () => {
+    const store = useScDataSourceStore();
+    store.select("ptu");
+
+    expect(store.available).toEqual([]);
+    expect(store.requestParam).toBe("ptu");
+  });
+
+  it("still sends nothing before the list arrives when nothing was chosen", () => {
+    const store = useScDataSourceStore();
+
+    expect(store.requestParam).toBeUndefined();
+  });
+
+  it("stops sending a rehydrated choice the server does not offer", () => {
+    const store = useScDataSourceStore();
+    store.select("ptu");
+
+    store.setAvailable([live]);
+
+    expect(store.requestParam).toBeUndefined();
+  });
 });

--- a/app/frontend/shared/stores/scDataSource.ts
+++ b/app/frontend/shared/stores/scDataSource.ts
@@ -43,7 +43,16 @@ export const useScDataSourceStore = defineStore("scDataSource", {
 
     // What the axios client puts on a request. Nothing for the default, so a
     // reader who has not chosen sends exactly what it always sent.
-    requestParam(): string | undefined {
+    requestParam(state): string | undefined {
+      // The list has not arrived yet and the boot requests are already going
+      // out -- they are issued in the same tick as the switch's own query, so
+      // no answer can beat them. A stored choice is the only answer there is,
+      // and it is never the default: `select` stores undefined for that one.
+      // A source the server no longer offers is ignored rather than refused,
+      // so the worst case is the default it would have served anyway, and
+      // `setAvailable` drops the selection as soon as the list lands.
+      if (!state.available.length) return state.environment;
+
       const selected = this.selected as ScDataSourceOption | undefined;
 
       if (!selected || selected.default) return undefined;

--- a/app/lib/sc_data/source.rb
+++ b/app/lib/sc_data/source.rb
@@ -171,5 +171,25 @@ module ScData
     def to_s
       "#{version} (#{environment})"
     end
+
+    # What a cached fragment names so two environments cannot share an entry.
+    # `json.cache!` keys on the record, and a record backed by a build says
+    # something different per source -- so every public fragment that renders a
+    # fact has to carry this, or the first source to warm an entry answers for
+    # both.
+    #
+    # The version is in it as well as the environment, because the record's own
+    # `cache_version` is about to stop moving: while the dual-held columns are
+    # still there a load rewrites the row too and `updated_at` covers a new
+    # build by accident. Once those columns are dropped a load writes only the
+    # build row, and an environment-only stamp would go on serving the previous
+    # build's numbers.
+    #
+    # Named `cache_key` so `ActiveSupport::Cache` picks it up from the key array
+    # on its own -- a fragment names the source itself rather than a stringified
+    # detail of it.
+    def cache_key
+      "sc-data/#{environment}/#{version}"
+    end
   end
 end

--- a/app/views/api/v1/commodities/_commodity.jbuilder
+++ b/app/views/api/v1/commodities/_commodity.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", commodity, commodity.item_prices_cache_key] do
+json.cache! ["v1", commodity, ::ScData::Source.current, commodity.item_prices_cache_key] do
   json.partial!("api/v1/commodities/base", commodity:)
 end

--- a/app/views/api/v1/components/_component.jbuilder
+++ b/app/views/api/v1/components/_component.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", component, component.item_prices_cache_key, Manufacturer.artwork_version] do
+json.cache! ["v1", component, ::ScData::Source.current, component.item_prices_cache_key, Manufacturer.artwork_version] do
   json.partial!("api/v1/components/base", component:)
 end

--- a/app/views/api/v1/equipment/_equipment.jbuilder
+++ b/app/views/api/v1/equipment/_equipment.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", equipment, equipment.item_prices_cache_key, Manufacturer.artwork_version] do
+json.cache! ["v1", equipment, ::ScData::Source.current, equipment.item_prices_cache_key, Manufacturer.artwork_version] do
   json.partial!("api/v1/equipment/base", equipment:)
 end

--- a/app/views/api/v1/fleet_vehicles/_vehicle.jbuilder
+++ b/app/views/api/v1/fleet_vehicles/_vehicle.jbuilder
@@ -3,7 +3,7 @@
 # Owner contact links live here rather than in the shared public partial: this
 # list is scoped to fleet members by FleetVehiclePolicy, while the same partial
 # also renders public hangars, where an owner shares a name and nothing more.
-json.cache! ["v1-fleet", vehicle.model, Manufacturer.artwork_version, vehicle.user, vehicle] do
+json.cache! ["v1-fleet", vehicle.model, ::ScData::Source.current, Manufacturer.artwork_version, vehicle.user, vehicle] do
   json.partial!("api/v1/public/vehicles/base", vehicle:)
 
   unless vehicle.user.hide_owner?

--- a/app/views/api/v1/hardpoints/_hardpoint.jbuilder
+++ b/app/views/api/v1/hardpoints/_hardpoint.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", hardpoint, hardpoint.component, Manufacturer.artwork_version] do
+json.cache! ["v1", hardpoint, ::ScData::Source.current, hardpoint.component, Manufacturer.artwork_version] do
   json.partial!("api/v1/hardpoints/base", hardpoint:)
 end

--- a/app/views/api/v1/model_module_packages/_model_module_package.jbuilder
+++ b/app/views/api/v1/model_module_packages/_model_module_package.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", module_package, Manufacturer.artwork_version] do
+json.cache! ["v1", module_package, ::ScData::Source.current, Manufacturer.artwork_version] do
   json.partial!("api/v1/model_module_packages/base", module_package:)
 end

--- a/app/views/api/v1/model_modules/_model_module.jbuilder
+++ b/app/views/api/v1/model_modules/_model_module.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model_module, Manufacturer.artwork_version] do
+json.cache! ["v1", model_module, ::ScData::Source.current, Manufacturer.artwork_version] do
   json.partial!("api/v1/model_modules/base", model_module:)
 end

--- a/app/views/api/v1/models/_model.jbuilder
+++ b/app/views/api/v1/models/_model.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", model, Manufacturer.artwork_version, local_assigns.fetch(:extended, false)] do
+json.cache! ["v1", model, ::ScData::Source.current, Manufacturer.artwork_version, local_assigns.fetch(:extended, false)] do
   json.partial!("api/v1/models/base", model:, extended: local_assigns.fetch(:extended, false))
 end

--- a/app/views/api/v1/models/hardpoints.jbuilder
+++ b/app/views/api/v1/models/hardpoints.jbuilder
@@ -3,10 +3,11 @@
 json.array! @hardpoints,
   partial: "api/v1/hardpoints/base",
   as: :hardpoint,
-  # The build row is in the key because the facts now come from it: a build
-  # landing under an untouched slot leaves the row's own `updated_at` alone, so
-  # keying on the slot alone would serve the previous build's loadout. For a
-  # matrix slot `facts` is the slot itself and this collapses back to one entry.
+  # The source is in the key because the facts come from the build in force, and
+  # the build row as well: a build landing under an untouched slot leaves the
+  # row's own `updated_at` alone, so keying on the slot alone would serve the
+  # previous build's loadout. For a matrix slot `facts` is the slot itself and
+  # that half collapses back to one entry per source.
   cached: ->(hardpoint) {
-    ["v2", hardpoint, hardpoint.facts, hardpoint.facts.component, Manufacturer.artwork_version]
+    ["v2", hardpoint, ::ScData::Source.current, hardpoint.facts, hardpoint.facts.component, Manufacturer.artwork_version]
   }

--- a/app/views/api/v1/models/modules.jbuilder
+++ b/app/views/api/v1/models/modules.jbuilder
@@ -2,7 +2,7 @@
 
 json.items do
   json.array! @model_modules do |model_module|
-    json.cache! ["v1", model_module, Manufacturer.artwork_version] do
+    json.cache! ["v1", model_module, ::ScData::Source.current, Manufacturer.artwork_version] do
       json.partial!("api/v1/model_modules/base", model_module:)
     end
     json.slot @module_slots[model_module.id]

--- a/app/views/api/v1/public/vehicles/_vehicle.jbuilder
+++ b/app/views/api/v1/public/vehicles/_vehicle.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", vehicle.model, Manufacturer.artwork_version, vehicle.user, vehicle] do
+json.cache! ["v1", vehicle.model, ::ScData::Source.current, Manufacturer.artwork_version, vehicle.user, vehicle] do
   json.partial!("api/v1/public/vehicles/base", vehicle:)
 end

--- a/app/views/api/v1/vehicles/_vehicle.jbuilder
+++ b/app/views/api/v1/vehicles/_vehicle.jbuilder
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", vehicle.model, Manufacturer.artwork_version, vehicle] do
+json.cache! ["v1", vehicle.model, ::ScData::Source.current, Manufacturer.artwork_version, vehicle] do
   json.partial!("api/v1/vehicles/base", vehicle:)
 end

--- a/test/integration/api/v1/sc_data_source_param_test.rb
+++ b/test/integration/api/v1/sc_data_source_param_test.rb
@@ -53,11 +53,80 @@ class Api::V1::ScDataSourceParamTest < ActionDispatch::IntegrationTest
       "the next request went back to the default"
   end
 
+  # A cached fragment must not be shared between the two sources. `json.cache!`
+  # keys on the record, and a record backed by a build says something different
+  # per source -- so without the source in the key the first request to warm an
+  # entry answers for both. Both orders, because the bug is whichever source
+  # got there first.
+  test "a cached fragment is not shared between sources" do
+    with_fragment_caching do
+      get "/api/v1/commodities"
+      assert_equal ["Live Name"], response.parsed_body["items"].map { |item| item["name"] }
+
+      get "/api/v1/commodities", params: {source: "ptu"}
+      assert_equal ["PTU Name"], response.parsed_body["items"].map { |item| item["name"] },
+        "the ptu request was served the live build's cached fragment"
+    end
+  end
+
+  test "a cached fragment warmed by ptu does not answer for the default" do
+    with_fragment_caching do
+      get "/api/v1/commodities", params: {source: "ptu"}
+      assert_equal ["PTU Name"], response.parsed_body["items"].map { |item| item["name"] }
+
+      get "/api/v1/commodities"
+      assert_equal ["Live Name"], response.parsed_body["items"].map { |item| item["name"] },
+        "the default was served the ptu build's cached fragment"
+    end
+  end
+
+  # The model fragment is the one every ships list renders, and its facts come
+  # from the build.
+  test "a cached model fragment is not shared between sources" do
+    model_with_builds
+
+    with_fragment_caching do
+      get "/api/v1/models"
+      assert_equal [100.0], response.parsed_body["items"].map { |item| item.dig("speeds", "scmSpeed") }
+
+      get "/api/v1/models", params: {source: "ptu"}
+      assert_equal [200.0], response.parsed_body["items"].map { |item| item.dig("speeds", "scmSpeed") },
+        "the ptu request was served the live build's cached model"
+    end
+  end
+
+  # The vehicle fragments key on `vehicle.model` rather than on a record of
+  # their own, which is the shape a grep for the catalogues would miss.
+  test "a cached vehicle fragment is not shared between sources" do
+    user = create(:user)
+    vehicle = create(:vehicle, model: model_with_builds, user:)
+
+    sign_in user
+
+    with_fragment_caching do
+      get "/api/v1/vehicles/#{vehicle.id}"
+      assert_equal 100.0, response.parsed_body.dig("model", "speeds", "scmSpeed")
+
+      get "/api/v1/vehicles/#{vehicle.id}", params: {source: "ptu"}
+      assert_equal 200.0, response.parsed_body.dig("model", "speeds", "scmSpeed"),
+        "the ptu request was served the live build's cached vehicle"
+    end
+  end
+
   test "the source reaches a filter, not just a reader" do
     get "/api/v1/commodities", params: {source: "ptu", q: {nameCont: "PTU"}}
     assert_equal ["PTU Name"], response.parsed_body["items"].map { |item| item["name"] }
 
     get "/api/v1/commodities", params: {source: "ptu", q: {nameCont: "Live"}}
     assert_empty response.parsed_body["items"]
+  end
+
+  # The column is deliberately a value neither build carries, so a payload that
+  # fell through to it cannot be mistaken for either side.
+  private def model_with_builds
+    model = create(:model, scm_speed: 1)
+    model.builds.create!(environment: "live", version: "1.0.0", scm_speed: 100)
+    model.builds.create!(environment: "ptu", version: "1.1.0", scm_speed: 200)
+    model
   end
 end

--- a/test/lib/sc_data/source_test.rb
+++ b/test/lib/sc_data/source_test.rb
@@ -170,4 +170,27 @@ class ScData::SourceTest < ActiveSupport::TestCase
   test "the environment may be named as a symbol" do
     assert_equal 2, ScData::Source.builds_retained(:ptu)
   end
+  # A cached fragment names the source so two environments cannot share an
+  # entry, and `ActiveSupport::Cache` reads that off the object itself.
+  test "two environments never stamp a cache key the same way" do
+    live = ScData::Source.new(environment: "live", version: "1.0.0")
+    ptu = ScData::Source.new(environment: "ptu", version: "1.0.0")
+
+    assert_not_equal live.cache_key, ptu.cache_key
+  end
+
+  # The version is in the stamp because a load will stop touching the record's
+  # own row once the dual-held columns are gone, and `cache_version` with it.
+  test "a new build of the same environment stamps differently" do
+    before = ScData::Source.new(environment: "live", version: "1.0.0")
+    after = ScData::Source.new(environment: "live", version: "1.1.0")
+
+    assert_not_equal before.cache_key, after.cache_key
+  end
+
+  test "the stamp is what a cache key array expands to" do
+    source = ScData::Source.new(environment: "ptu", version: "1.1.0")
+
+    assert_includes ActiveSupport::Cache.expand_cache_key([source]), source.cache_key
+  end
 end


### PR DESCRIPTION
Two ways a reader could be looking at one build while being told it is the other. Both found by checking the first production PTU load against live, both invisible so far, and both able to serve genuinely wrong numbers the moment the two builds disagree on a fact anyone reads.

## Why now

`/sc-data/compare` reported 19 changed models between live `4.10.0` and ptu `4.10.1`, and yet **every public payload was byte-identical between `?source=ptu` and the default**. That turned out to have two unrelated causes stacked on top of each other, and only one of them is a data question:

| | |
| --- | --- |
| A stored `ptu` choice never reached the boot requests | fixed here |
| No `json.cache!` key named the source | fixed here |
| The 19 changes are stale live rows, not a patch difference | not a code change — see below |

## A stored source choice was inert on every page load

Pick `ptu`, reload, and the page renders **live** data with the switch parked on `ptu`.

`useScDataSourceStore` persists only `environment` — "the available list comes from the server on every boot; only the choice is worth keeping". But `requestParam` resolves through `selected`, which is `available.find(...)`, and that list is empty until `/sc-data/sources` answers. So every boot request went out with no `source` at all, and nothing refetched once the list landed. Only a *click* ever worked, because `select()` follows it with `queryClient.invalidateQueries()`.

Measured against production, and it is not a latency problem — the page's queries and the switch's own `useScDataSources()` are issued in the same tick, so no answer can beat them:

```
    92ms  REQ version
    93ms  REQ sc-data/sources
   136ms  REQ models?page=1          <- no source=ptu
   136ms  REQ filters/models/...     <- no source=ptu
          ... 0 of 10 requests carried the parameter
   switch active segment: ptu
```

A stored choice now answers on its own while the list is missing. It is never the default — `select` stores `undefined` for that one — and a source the server no longer offers is ignored rather than refused, so the worst case is the default it would have served anyway, with `setAvailable` dropping the selection as soon as the list arrives. No extra request, no second invalidate.

## One cached fragment served both environments

`json.cache!` keys on the record, and a record backed by a build says something different per source. Nothing in any key named the source, so whichever request warmed an entry answered for the other one too.

`ScData::Source#cache_key` is the stamp, read off the object by `ActiveSupport::Cache` straight from the key array. **The version is in it as well as the environment**: while the dual-held columns are still there a load rewrites the row too, so `updated_at` covers a new build by accident — once those columns are dropped a load writes only the build row, and an environment-only stamp would go on serving the previous build's numbers.

Twelve fragments, found by walking the partial graph rather than grepping. Grep undercounts this badly, and the four `_vehicle.jbuilder`s are why: they key on `vehicle.model`, so no search for a catalogue name finds them.

Two things the walk settled that are worth not re-deriving:

- **Admin views need no stamp.** `Admin::Api::BaseController` inherits from `ActionController::API`, not from `Api::BaseController`, so it never sees `?source=` and has nothing to be wrong about. Its hardpoint fragment already keys on `hardpoint.facts` for the within-environment case.
- **A shared key array across two templates was never a collision.** jbuilder appends the template digest, so the admin and public `_model_module.jbuilder` — identical key arrays — have always been separate entries. Only the *same* template under two sources collided.

## The 19 changed models: no re-parse, a re-load

Not fixed here, because there is nothing in the code to fix. The parsed trees are on disk, so this is checked rather than inferred: **all 19 model files are byte-identical between `parsed/live` and `parsed/ptu`**, both stamped `parsed_at 2026-09-07`. The game files did not change for these ships.

The live side is what is stale. The current tree says `speeds.reverse/acceleration/decceleration: null`; the ptu build row says NULL and is correct, while the live build row still holds the `0.0` an older parser wrote, from the tree as it was *before* the 2026-09-07 re-parse. The six `scm_speed` rows are a different mechanism again — no ground vehicle has a FlightController in its loadout, so no sc_data load ever writes the fact, and the live value is the RSI matrix number that the `model_builds` backfill copied off the column.

So the fix is a re-load of live `4.10.0`, which clears 47 of the 53 affected fields. Deliberately not run as part of this PR.

## Verified

- **The four integration tests fail without the view change**, each with the other source's payload: `Expected: [200.0] Actual: [100.0]` on the model fragment, `Expected: ["Live Name"] Actual: ["PTU Name"]` on the ptu-first ordering. Both directions are covered, because the bug is whichever source got there first.
- The vehicle fragment has its own test, since `vehicle.model` is the shape a grep would have missed.
- `sc_data_source_param_test` 10/10, `test/lib/sc_data/` 89/89, and the four endpoints that already had fragment-caching tests 46/46.
- Store specs 9/9. `bin/ruby-lint`, `pnpm lint:ts`, eslint and prettier all clean.

🤖
