### PR TITLE
fix(admin): stop the navigation flashing on the login page

### DIFF
--- a/app/frontend/admin/App.vue
+++ b/app/frontend/admin/App.vue
@@ -53,8 +53,12 @@ const route = useRoute();
 
 // Every section needs authentication, so on the login page the sidebar is a
 // logo above an empty list and the mobile bar is a burger that opens it. Both
-// are dropped rather than rendered empty.
-const navigationVisible = computed(() => route.name !== "admin-login");
+// are dropped rather than rendered empty. Named routes only: an unresolved
+// route has no name, and reading that as "not the login page" rendered the
+// navigation for a frame and then faded it back out over half a second.
+const navigationVisible = computed(
+  () => route.name !== undefined && route.name !== "admin-login",
+);
 
 const comlink = useComlink();
 

--- a/app/frontend/entrypoints/admin.ts
+++ b/app/frontend/entrypoints/admin.ts
@@ -42,4 +42,11 @@ setupAppsignal(app);
 app.use(veeValidate);
 app.use(Tooltip);
 
-app.mount("#app");
+const mountApp = () => app.mount("#app");
+
+// Not `mountApp()` on its own: the router resolves its first navigation
+// asynchronously, so the first render would be the start location, where
+// `route.name` is undefined and `route.meta` empty. Mounted on a rejected
+// navigation as well, so a dead route chunk shows the app instead of leaving
+// the intro splash up for good — `router.onError` reloads in production.
+router.isReady().then(mountApp, mountApp);


### PR DESCRIPTION
#4830 dropped the navigation from the login page, but it still appears there for
about half a second on load.

The router resolves its first navigation asynchronously — nothing awaits
`router.isReady()` before `app.mount()` — so the first render is the start
location, where `route.name` is `undefined`. The guard reads
`route.name !== "admin-login"`, `undefined` passes it, and the sidebar mounts.
When the route resolves the `v-if` flips, and because the sidebar sits in a
`<transition name="fade">` it stays on screen for the full `opacity 0.5s` leave.
The initial mount itself does not animate (no `appear`), so it comes in at
`opacity: 1` and then fades away.

Measured against the dev server by sampling the `.app-body` class per animation
frame from the first frame on:

```
   35ms  intro=true                       (Rails splash)
 2184ms  body="page-undefined app-body"   ← mount, route unresolved
 2242ms  body="page-admin-login app-body" ← route resolved, v-if flips
```

The `page-undefined` class shows the same gap reaches beyond the navigation:
`route.name` and `route.meta` feed two more class bindings in the template.

So mounting now waits for the first navigation, and the guard only accepts
named routes. The rejection handler on `isReady()` is not just there to satisfy
`no-floating-promises`: a route chunk that fails to load must not leave the
intro splash up for good, and `router.onError` already reloads in production.

`app.use(pinia)` stays where it is — it runs synchronously before the await,
while the `beforeResolve` guard reads the session store a microtask later.

## Not doing the same for the frontend app

`frontend.ts` mounts the same way, but there is nothing to fix there:

- No app-level chrome is gated on `route.name`. `<FrontendNavigation />` has no
  `v-if`, so nothing renders and un-renders. The `route.name` comparisons in
  `FleetNav`, `Hangar/FilterForm` and `Vehicles/Panel` are all inside page
  components, which mount only after the route resolves.
- `page-undefined` is inert there. `admin/pages/login.scss` is the only
  stylesheet that selects a `.page-*` class.
- The one class that does flip, `main-inner--with-primary-action`, only swaps a
  flex layout while the content area is still empty.

Against that, deferring the mount would push first paint on the public app out
by the route chunk's load time.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admin navigation now appears only for recognized routes and is hidden on the admin login page.
  - Unresolved routes no longer display desktop or mobile admin navigation.
  - The admin interface now waits for the initial route to resolve before rendering.
  - If the initial route fails to load, the admin interface still appears instead of remaining on the loading screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->