### PR TITLE
fix(admin): slide the navigation in and out

### DIFF
--- a/app/frontend/admin/App.vue
+++ b/app/frontend/admin/App.vue
@@ -212,7 +212,7 @@ const setNoScroll = () => {
     <BackgroundImage />
 
     <div class="app-content">
-      <transition name="fade" mode="out-in">
+      <transition name="nav-panel">
         <AdminNavigation v-if="navigationVisible" />
       </transition>
       <div class="main-wrapper">

--- a/app/frontend/stylesheets/shared/transitions.scss
+++ b/app/frontend/stylesheets/shared/transitions.scss
@@ -97,6 +97,54 @@
   transition-delay: 0.5s;
 }
 
+// nav-panel
+//
+// The sidebar's own box is `position: fixed`, so the `nav` around it is nothing
+// but a spacer for the main column to flex against. Fading alone held that
+// spacer at full width for the whole transition and then dropped it in a single
+// frame, which slid the page sideways — at login the form is still on screen for
+// that jump. So the spacer collapses along with the panel, and the panel leaves
+// to its own side rather than being slid under. Below the desktop breakpoint the
+// panel is off-canvas and the `nav` reserves no room, so only the fade applies.
+.nav-panel-enter-active,
+.nav-panel-leave-active {
+  transition: opacity $transition-base-speed ease;
+}
+
+.nav-panel-enter-from,
+.nav-panel-leave-to {
+  opacity: 0;
+}
+
+@media (min-width: $desktop-breakpoint) {
+  // The width these override is `.app-navigation` from a scoped component
+  // stylesheet, so it reaches the browser as `.app-navigation[data-v-x]` and
+  // already carries two selectors' worth of specificity. A two-class selector
+  // here only ties it and then loses on source order, which is not ours to
+  // pick — hence the `.app-content` ancestor.
+  .app-content .app-navigation.nav-panel-enter-active,
+  .app-content .app-navigation.nav-panel-leave-active {
+    transition:
+      width $transition-base-speed ease,
+      min-width $transition-base-speed ease,
+      opacity $transition-base-speed ease;
+
+    .app-navigation__wrapper {
+      transition: transform $transition-base-speed ease;
+    }
+  }
+
+  .app-content .app-navigation.nav-panel-enter-from,
+  .app-content .app-navigation.nav-panel-leave-to {
+    width: 0;
+    min-width: 0;
+
+    .app-navigation__wrapper {
+      transform: translateX(-100%);
+    }
+  }
+}
+
 // fade-nav
 .fade-nav-enter-active {
   transition: opacity 0.3s;


### PR DESCRIPTION
Follow-up to #4833. The navigation no longer flashes on the login page, but
arriving and leaving still moves the page sideways in one frame.

The sidebar's own box is `position: fixed`, so the `nav` around it is nothing but
a 300px spacer for the main column to flex against. `fade` animates opacity
alone, so that spacer stands at full width for the whole half second and then
goes in a single frame. It shows most at login: the form is still fully on
screen when the navigation claims its room, and jumps 150px sideways. At logout
the form is inserted only after the content's own `out-in` fade ends — roughly
when the spacer goes, and still at `opacity: 0`.

`nav-panel` collapses the spacer along with the panel and slides the panel out to
its own side rather than leaving it in place for the content to travel under.

Measured on the compiled stylesheets — the login form's position per animation
frame, and the panel's own:

```
fade       leave @1600px   Δ150px   frames-that-moved=1    largest-jump=150px   panelX  8 →   8
nav-panel  leave @1600px   Δ150px   frames-that-moved=27   largest-jump=11px    panelX  8 → -292
fade       enter @1600px   Δ150px   frames-that-moved=1    largest-jump=150px
nav-panel  enter @1600px   Δ150px   frames-that-moved=27   largest-jump=11px
… @700px:  both names, both directions: Δ0px, frames-that-moved=0
```

Two things worth knowing about the diff:

- **The `.app-content` ancestor in those selectors is load-bearing.** The width
  they override comes from a scoped component stylesheet, so it reaches the
  browser as `.app-navigation[data-v-x]` — two selectors' worth of specificity. A
  two-class selector only ties it and then loses on source order, which is not
  ours to pick. The first version of this change was inert for exactly that
  reason, in production and not just in the harness.
- **Below `$desktop-breakpoint` only the fade applies.** There the panel is
  off-canvas and the `nav` reserves no room, so there is nothing to collapse —
  the @700px rows above are the check that the change is inert on mobile.

`mode="out-in"` goes with the fade: there is only ever one child, and without it
a login straight after a logout interrupts the collapse rather than queueing
behind it.

Not in scope: the mobile tab bar still fades. Its room is reserved by
`body { padding-bottom }` in `layout.scss`, which the `:has()` rule in
`login.scss` flips with no transition — a separate, vertical case.

🤖
