### PR TITLE
feat(mailer): give the mail button the app's hover state

### DIFF
--- a/app/lib/mailer_theme.rb
+++ b/app/lib/mailer_theme.rb
@@ -20,6 +20,7 @@ module MailerTheme
   # --color-control is byte-identical to --color-surface; see the panel-redesign
   # plan's F10 for why that is worth knowing rather than deduplicating.
   CONTROL = "#23272b"         # --color-control, over BACKGROUND
+  CONTROL_HOVER = "#31373d"   # --color-control-hover, over BACKGROUND
 
   # Drawn on the surface.
   EDGE = "#4f555a"            # --color-edge, over SURFACE
@@ -30,6 +31,7 @@ module MailerTheme
 
   # Opaque already.
   TEXT = "#c8c8c8"            # --color-text
+  LIFTED = "#eeeeee"          # --color-lifted
   MUTED = "#7a8288"           # --color-muted
   ENDCAP = "#7a8288"          # --color-endcap
   PRIMARY = "#428bca"         # --color-primary
@@ -38,10 +40,22 @@ module MailerTheme
   SUCCESS = "#5cb85c"         # --color-success
   GOLD = "#d4af37"            # --color-gold
 
+  # The cap a flooded tone wears while hovered. Btn writes it as
+  # rgb(255 255 255 / .65) rather than as a token, because on a red or orange
+  # surface the primary cap the neutral states borrow is unreadable and the cap
+  # has to follow the label to white instead. Resolved here against the flood it
+  # is drawn on, which is the tone's own colour - so these two are the only
+  # values in this file with no --color-* to mirror, and MailerThemeTest checks
+  # them by recomputing the composite instead.
+  DANGER_CAP_HOVER = "#f3b8be"
+  WARNING_CAP_HOVER = "#fdcaa6"
+  FLOOD_TEXT = "#ffffff"
+
   # Which surface each translucent token composites against. Read by the test.
   BASES = {
     "surface" => :background,
     "control" => :background,
+    "control-hover" => :background,
     "edge" => :surface,
     "edge-soft" => :surface,
     "edge-faint" => :surface

--- a/app/lib/mailer_theme.rb
+++ b/app/lib/mailer_theme.rb
@@ -51,6 +51,39 @@ module MailerTheme
   WARNING_CAP_HOVER = "#fdcaa6"
   FLOOD_TEXT = "#ffffff"
 
+  # The accent, per theme.
+  #
+  # stylesheets/shared/themes.scss gives the app a theme layer: a theme is a set
+  # of tokens components read through var(), selected by data-theme on <html>,
+  # and the admin layout sets data-theme="admin". A mail has no <html> we
+  # control per recipient and no var() any client would resolve, so the
+  # selection happens in Ruby instead - ApplicationMailer.mail_theme is the
+  # attribute, and the layout interpolates the literal.
+  #
+  # The default theme is absent here for the same reason it is absent from
+  # themes.scss: PRIMARY above is what a mail that names no theme gets, so it
+  # cannot drift out from under one.
+  #
+  # Only the accent is themed. themes.scss also derives three tones from it -
+  # shade, shade-soft, tint - for a rail glow, a hovered toggle border and pill
+  # label text, none of which a mail has. Add one here when a mail grows the
+  # element that needs it, not before.
+  ACCENTS = {
+    admin: "#a855f7" # --color-primary under [data-theme="admin"]
+  }.freeze
+
+  # Raises rather than falling back, because a mistyped theme that quietly
+  # renders the frontend blue is exactly the bug this indirection exists to
+  # make impossible.
+  def self.accent(theme)
+    return PRIMARY if theme.nil?
+
+    ACCENTS.fetch(theme.to_sym) do
+      raise ArgumentError,
+        "unknown mail theme #{theme.inspect}; MailerTheme::ACCENTS has #{ACCENTS.keys.join(", ")}"
+    end
+  end
+
   # Which surface each translucent token composites against. Read by the test.
   BASES = {
     "surface" => :background,

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -3,6 +3,12 @@
 class AdminMailer < ApplicationMailer
   helper AdminReportHelper
 
+  # Every mail in here goes to an AdminUser, so it comes from the same place the
+  # admin app does and wears the same accent. See themes.scss for why that is a
+  # violet: it was chosen for distance from every colour the app already assigns
+  # a meaning to, and its contrast profile matches the blue it stands in for.
+  self.mail_theme = :admin
+
   OPEN_NOTIFICATIONS_LIMIT = 10
 
   # Sent per admin rather than to the whole super-admin list at once: the digest

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,8 +5,25 @@ class ApplicationMailer < ActionMailer::Base
 
   layout "mailer"
 
+  # The mail equivalent of data-theme on <html>, which is how the app selects a
+  # theme and how the admin layout picks up its violet accent. A mail cannot use
+  # that mechanism - it has no var() any client resolves - so the mailer names
+  # its theme and MailerTheme resolves the literal the layout interpolates.
+  #
+  # nil is the same absence data-theme has on the frontend: not a theme called
+  # "default", just a document that selects none.
+  class_attribute :mail_theme, default: nil
+
+  helper_method :mail_accent
+
   rescue_from Postmark::InactiveRecipientError do |_exception|
     handle_inactive_error
+  end
+
+  # The one themed value a mail has. Everything else in MailerTheme is neutral
+  # chrome, which a theme deliberately does not touch.
+  private def mail_accent
+    MailerTheme.accent(mail_theme)
   end
 
   private def handle_inactive_error

--- a/app/views/layouts/mailer.html.mjml
+++ b/app/views/layouts/mailer.html.mjml
@@ -102,6 +102,44 @@
       .cap-top p { border-radius: 0 0 <%= MailerTheme::CAP_RADIUS %> <%= MailerTheme::CAP_RADIUS %> !important; }
       .cap-bottom p { border-radius: <%= MailerTheme::CAP_RADIUS %> <%= MailerTheme::CAP_RADIUS %> 0 0 !important; }
 
+      /*
+        Hover, on the button. Btn lights the end-cap and lifts the surface and
+        the label, and leaves the frame alone for every tone but the two that
+        flood - a recoloured border reads as the control changing shape. These
+        rules restate that, and only that.
+
+        They have to live here rather than inline because no style attribute can
+        carry a pseudo-class, and they need !important because the resting value
+        they replace IS an inline style. premailer keeps a selector containing
+        :hover out of its inlining pass and re-emits it into a style block, so
+        the rules survive the delivery hook - but Gmail drops this block in a
+        forwarded message and Outlook's Word engine has no hover at all, which
+        is the same floor the cap radius above accepts.
+      */
+      .mail-btn:hover { background-color: <%= MailerTheme::CONTROL_HOVER %> !important; }
+      .mail-btn:hover .mail-btn__label { color: <%= MailerTheme::LIFTED %> !important; }
+
+      /*
+        Neutral borrows the primary cap while hovered, which is the treatment
+        the :primary tone already wears at rest - so a primary button lifts its
+        surface and its label and keeps the cap it had.
+      */
+      .mail-btn--neutral:hover .mail-btn__cap { background-color: <%= MailerTheme::PRIMARY %> !important; }
+
+      .mail-btn--danger:hover {
+        background-color: <%= MailerTheme::DANGER %> !important;
+        border-color: <%= MailerTheme::DANGER %> !important;
+      }
+      .mail-btn--danger:hover .mail-btn__label { color: <%= MailerTheme::FLOOD_TEXT %> !important; }
+      .mail-btn--danger:hover .mail-btn__cap { background-color: <%= MailerTheme::DANGER_CAP_HOVER %> !important; }
+
+      .mail-btn--warning:hover {
+        background-color: <%= MailerTheme::WARNING %> !important;
+        border-color: <%= MailerTheme::WARNING %> !important;
+      }
+      .mail-btn--warning:hover .mail-btn__label { color: <%= MailerTheme::FLOOD_TEXT %> !important; }
+      .mail-btn--warning:hover .mail-btn__cap { background-color: <%= MailerTheme::WARNING_CAP_HOVER %> !important; }
+
       .mail-panel > table {
         border: 2px solid <%= MailerTheme::EDGE %> !important;
         border-radius: <%= MailerTheme::RADIUS_SURFACE %> !important;

--- a/app/views/layouts/mailer.html.mjml
+++ b/app/views/layouts/mailer.html.mjml
@@ -124,7 +124,7 @@
         the :primary tone already wears at rest - so a primary button lifts its
         surface and its label and keeps the cap it had.
       */
-      .mail-btn--neutral:hover .mail-btn__cap { background-color: <%= MailerTheme::PRIMARY %> !important; }
+      .mail-btn--neutral:hover .mail-btn__cap { background-color: <%= mail_accent %> !important; }
 
       .mail-btn--danger:hover {
         background-color: <%= MailerTheme::DANGER %> !important;
@@ -281,9 +281,9 @@
           <%= I18n.t("copyright") %> &copy; <%= Time.current.year %>
           <%= Rails.configuration.app.copyright_owner %>
           <br />
-          <a href="<%= frontend_privacy_policy_url %>" style="color: <%= MailerTheme::PRIMARY %>;"><%= I18n.t("mailer.privacy") %></a>
+          <a href="<%= frontend_privacy_policy_url %>" style="color: <%= mail_accent %>;"><%= I18n.t("mailer.privacy") %></a>
           &nbsp;&middot;&nbsp;
-          <a href="<%= frontend_settings_notifications_url %>" style="color: <%= MailerTheme::PRIMARY %>;"><%= I18n.t("mailer.notification_settings") %></a>
+          <a href="<%= frontend_settings_notifications_url %>" style="color: <%= mail_accent %>;"><%= I18n.t("mailer.notification_settings") %></a>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/app/views/model_mailer/notify_new.html.mjml
+++ b/app/views/model_mailer/notify_new.html.mjml
@@ -13,7 +13,7 @@
   <%= I18n.t("mailer.model.new.headline_part_2", manufacturer: @model.manufacturer.name) %>
   <a href="<%= frontend_model_url(slug: @model.slug) %>"
      target="_blank"
-     style="color: <%= MailerTheme::PRIMARY %>; text-decoration: none;"><%= @model.name %></a>!
+     style="color: <%= mail_accent %>; text-decoration: none;"><%= @model.name %></a>!
 </mj-text>
 
 <% if @model.store_image.attached? %>

--- a/app/views/shared/mailer/_btn.html.mjml
+++ b/app/views/shared/mailer/_btn.html.mjml
@@ -18,6 +18,10 @@
   active, borrowed here at rest to mark the one action a mail is asking for.
   Nothing in the app changes.
 
+  Which colour that is depends on the mailer's theme, not on this file: an
+  AdminMailer resolves the admin violet, everything else the frontend blue. Same
+  for the hovered neutral cap. See ApplicationMailer.mail_theme.
+
   Hover is real, in the clients that have a pointer and keep an embedded
   stylesheet - Apple Mail, Gmail's web client, Outlook.com, Yahoo. The rules
   live in the layout's mj-style under .mail-btn, because a pseudo-class cannot
@@ -50,7 +54,7 @@
   width = defined?(width) && width.present? ? width : 260
   cap_color = {
     neutral: MailerTheme::ENDCAP,
-    primary: MailerTheme::PRIMARY,
+    primary: mail_accent,
     danger: MailerTheme::DANGER,
     warning: MailerTheme::WARNING
   }.fetch(tone)

--- a/app/views/shared/mailer/_btn.html.mjml
+++ b/app/views/shared/mailer/_btn.html.mjml
@@ -15,12 +15,25 @@
 
   :primary has no counterpart in BtnTonesEnum, which is neutral | danger |
   warning. It is the cap the app shows when a neutral button is hovered or
-  active. Email cannot hover, so that treatment is unused there and is borrowed
-  here to mark the one action a mail is asking for. Nothing in the app changes.
+  active, borrowed here at rest to mark the one action a mail is asking for.
+  Nothing in the app changes.
+
+  Hover is real, in the clients that have a pointer and keep an embedded
+  stylesheet - Apple Mail, Gmail's web client, Outlook.com, Yahoo. The rules
+  live in the layout's mj-style under .mail-btn, because a pseudo-class cannot
+  be expressed inline; premailer leaves them there rather than inlining them,
+  and they carry !important so they outrank the inline resting style. Every
+  resting style is still inline, so the button a client without hover renders is
+  the button that was here before.
+
+  Padding sits on the <a>, not on its cell, so the pointer area and the click
+  area are the same rectangle. With it on the cell, an 18px strip down each side
+  lit up without being clickable.
 
   Every style is inline. Gmail strips <style> in a forwarded message and the
   frame is not something that may vanish - only the cap's corner radius, which
-  lives in the layout's mj-style, is allowed to degrade.
+  lives in the layout's mj-style, and the hover treatment, which is by
+  definition something a reader can do without.
 
   The width is fixed because a 12% inset needs a width to be 12% of, and
   Outlook's Word engine gives a shrink-to-fit table none. A long locale wraps
@@ -42,11 +55,14 @@
     warning: MailerTheme::WARNING
   }.fetch(tone)
   cap_cell = "font-size:0;line-height:0;height:#{MailerTheme::CAP_HEIGHT_BTN};"
+  # 150ms ease-in-out, the same curve Btn transitions on. A client that has no
+  # hover drops the declaration and loses nothing.
+  ease = "transition:background-color 150ms ease-in-out,border-color 150ms ease-in-out,color 150ms ease-in-out;"
   bar = ->(radius) do
     <<~HTML
       <tr>
         <td width="#{MailerTheme::CAP_INSET}" style="#{cap_cell}">&nbsp;</td>
-        <td width="#{MailerTheme::CAP_WIDTH}" style="#{cap_cell}background-color:#{cap_color};border-radius:#{radius};">&nbsp;</td>
+        <td class="mail-btn__cap" width="#{MailerTheme::CAP_WIDTH}" style="#{cap_cell}#{ease}background-color:#{cap_color};border-radius:#{radius};">&nbsp;</td>
         <td width="#{MailerTheme::CAP_INSET}" style="#{cap_cell}">&nbsp;</td>
       </tr>
     HTML
@@ -58,12 +74,12 @@
     <td style="padding:0;">
       <table role="presentation" border="0" cellpadding="0" cellspacing="0" style="border-collapse:separate;width:<%= width %>px;">
         <tr>
-          <td style="background-color:<%= MailerTheme::CONTROL %>;border:1px solid <%= MailerTheme::EDGE %>;border-radius:<%= MailerTheme::RADIUS_CONTROL %>;padding:0;">
+          <td class="mail-btn mail-btn--<%= tone %>" style="<%= ease %>background-color:<%= MailerTheme::CONTROL %>;border:1px solid <%= MailerTheme::EDGE %>;border-radius:<%= MailerTheme::RADIUS_CONTROL %>;padding:0;">
             <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collapse:collapse;">
               <%= bar.call("0 0 #{btn_r} #{btn_r}").html_safe %>
               <tr>
-                <td colspan="3" align="center" style="padding:12px 18px;">
-                  <a href="<%= href %>" style="color:<%= MailerTheme::TEXT %>;font-family:<%= MailerTheme::BODY_FONT %>;font-size:16px;line-height:20px;text-decoration:none;display:block;"><%= label %></a>
+                <td colspan="3" align="center" style="padding:0;">
+                  <a class="mail-btn__label" href="<%= href %>" style="<%= ease %>color:<%= MailerTheme::TEXT %>;font-family:<%= MailerTheme::BODY_FONT %>;font-size:16px;line-height:20px;text-decoration:none;display:block;padding:12px 18px;"><%= label %></a>
                 </td>
               </tr>
               <%= bar.call("#{btn_r} #{btn_r} 0 0").html_safe %>

--- a/app/views/vehicle_mailer/on_sale.html.mjml
+++ b/app/views/vehicle_mailer/on_sale.html.mjml
@@ -21,7 +21,7 @@
 <mj-text mj-class="h2" padding="0 0 12px">
   <a href="<%= frontend_model_url(slug: @vehicle.model.slug) %>"
      target="_blank"
-     style="color: <%= MailerTheme::PRIMARY %>; text-decoration: none;"><%= @vehicle.model.name %></a>
+     style="color: <%= mail_accent %>; text-decoration: none;"><%= @vehicle.model.name %></a>
   <%= I18n.t("mailer.vehicle.on_sale.headline.part_two") %>
 </mj-text>
 

--- a/test/lib/mailer_theme_test.rb
+++ b/test/lib/mailer_theme_test.rb
@@ -8,6 +8,7 @@ require "test_helper"
 # disagree - in either direction.
 class MailerThemeTest < ActiveSupport::TestCase
   THEME_FILE = Rails.root.join("app/frontend/entrypoints/tailwind.css")
+  THEME_LAYER = Rails.root.join("app/frontend/stylesheets/shared/themes.scss")
 
   # --color-<name>: <value>, ignoring the var() aliases (the mission categories).
   DECLARATION = /^\s*--color-([a-z0-9-]+):\s*(#[0-9a-f]{3,6}|rgb\([^)]*\))\s*;/i
@@ -77,6 +78,38 @@ class MailerThemeTest < ActiveSupport::TestCase
       "--cap-h-btn is max(2px, --cap-h - 2px)"
     assert_equal [MailerTheme::CAP_HEIGHT_BTN.to_i / 2, 1].max, MailerTheme::CAP_RADIUS_BTN.to_i,
       "--cap-r-btn is held to half the button cap's own height"
+  end
+
+  # A theme is a set of custom properties on the frontend, and no mail client
+  # resolves one - so ACCENTS restates the accent each theme declares, with the
+  # same risk of drift the colours above have and the same answer to it.
+  test "each themed accent equals that theme's --color-primary" do
+    css = THEME_LAYER.read
+
+    MailerTheme::ACCENTS.each do |theme, accent|
+      block = css[/\[data-theme=["']#{Regexp.escape(theme.to_s)}["']\]\s*\{(.*?)\}/m, 1]
+      assert block,
+        "themes.scss declares no [data-theme=\"#{theme}\"] block, but MailerTheme::ACCENTS " \
+        "has an accent for it. Either the theme was renamed or it no longer exists."
+
+      declared = block[/^\s*--color-primary:\s*(#[0-9a-f]{3,6})\s*;/i, 1]
+      assert declared, "[data-theme=\"#{theme}\"] declares no --color-primary"
+
+      assert_equal normalize_hex(declared), accent.downcase,
+        "MailerTheme::ACCENTS[#{theme.inspect}] is #{accent} but themes.scss declares " \
+        "#{declared} for that theme. Update the constant."
+    end
+  end
+
+  test "a mail that names no theme gets the default accent" do
+    assert_equal MailerTheme::PRIMARY, MailerTheme.accent(nil)
+  end
+
+  # Silently rendering the frontend blue is the failure this indirection exists
+  # to prevent, so a name nobody declared has to be loud.
+  test "an unknown theme raises rather than falling back" do
+    error = assert_raises(ArgumentError) { MailerTheme.accent(:nope) }
+    assert_match(/unknown mail theme :nope/, error.message)
   end
 
   # The flooded tones are the one pair with no --color-* to mirror: Btn writes

--- a/test/lib/mailer_theme_test.rb
+++ b/test/lib/mailer_theme_test.rb
@@ -17,10 +17,12 @@ class MailerThemeTest < ActiveSupport::TestCase
     "background" => :BACKGROUND,
     "surface" => :SURFACE,
     "control" => :CONTROL,
+    "control-hover" => :CONTROL_HOVER,
     "edge" => :EDGE,
     "edge-soft" => :EDGE_SOFT,
     "edge-faint" => :EDGE_FAINT,
     "text" => :TEXT,
+    "lifted" => :LIFTED,
     "muted" => :MUTED,
     "endcap" => :ENDCAP,
     "primary" => :PRIMARY,
@@ -75,6 +77,24 @@ class MailerThemeTest < ActiveSupport::TestCase
       "--cap-h-btn is max(2px, --cap-h - 2px)"
     assert_equal [MailerTheme::CAP_HEIGHT_BTN.to_i / 2, 1].max, MailerTheme::CAP_RADIUS_BTN.to_i,
       "--cap-r-btn is held to half the button cap's own height"
+  end
+
+  # The flooded tones are the one pair with no --color-* to mirror: Btn writes
+  # their hovered cap as a literal rgb(255 255 255 / .65) over the flood. Same
+  # contract as the mirrored colours - the constant is the composite - so it is
+  # checked the same way, against the tone the app floods with.
+  test "the flooded hover caps are white at .65 over their own tone" do
+    {
+      "danger" => :DANGER_CAP_HOVER,
+      "warning" => :WARNING_CAP_HOVER
+    }.each do |token, constant|
+      base = rgb(flatten(token))
+      expected = hex(base.map { |c| 255 * 0.65 + (c * 0.35) })
+
+      assert_equal expected, MailerTheme.const_get(constant).downcase,
+        "MailerTheme::#{constant} must be rgb(255 255 255 / .65) composited over " \
+        "--color-#{token} (#{@theme[token]}), which is #{expected}."
+    end
   end
 
   test "the two cap insets leave exactly the cap width between them" do

--- a/test/mailers/mjml_rendering_test.rb
+++ b/test/mailers/mjml_rendering_test.rb
@@ -19,6 +19,8 @@ require "test_helper"
 #   reconfiguring premailer-rails silently makes every mail HTML-only.
 # - premailer drops the backdrop image, in two different ways, and strips the
 #   border-radius off the element MJML puts the panel's frame on.
+# - The button's hover state is the one part of it that cannot be inlined, so it
+#   is the one part premailer could throw away.
 class MjmlRenderingTest < ActionMailer::TestCase
   MJML_LAYOUT = "mailer"
 
@@ -122,6 +124,49 @@ class MjmlRenderingTest < ActionMailer::TestCase
         "#{preview.name}##{email} has no #{MailerTheme::ENDCAP} anywhere - the panel's " \
         "end-cap is the app's signature and it did not survive compilation."
     end
+
+    # Hover is the only part of the button that cannot be an inline style, so it
+    # is the only part that depends on premailer leaving a rule alone. It does
+    # keep selectors containing a pseudo-class and re-emits them into a style
+    # block, but nothing in the pipeline states that, and a button whose hover
+    # quietly stopped resolving looks exactly like one that never had it.
+    test "#{preview.name}##{email} keeps the button's hover rules unmerged" do
+      html = html_part_for(preview, email)
+      next unless html.include?('class="mail-btn')
+
+      {
+        "the hovered surface" =>
+          /\.mail-btn:hover\s*\{\s*background-color:\s*#{MailerTheme::CONTROL_HOVER}\s*!important/io,
+        "the lifted label" =>
+          /\.mail-btn:hover \.mail-btn__label\s*\{\s*color:\s*#{MailerTheme::LIFTED}\s*!important/io,
+        "the lit end-cap" =>
+          /\.mail-btn--neutral:hover \.mail-btn__cap\s*\{\s*background-color:\s*#{MailerTheme::PRIMARY}\s*!important/io
+      }.each do |what, pattern|
+        assert_match pattern, html,
+          "#{preview.name}##{email} lost #{what}. premailer is supposed to leave a " \
+          "selector containing :hover out of its inlining pass and re-emit it into a " \
+          "style block - check it still does, and that the rule still carries " \
+          "!important, without which the inline resting value wins."
+      end
+
+      # The pointer area and the click area are the same rectangle only while
+      # the padding is on the anchor. Back on the cell, an 18px strip down each
+      # side lights up and does nothing.
+      assert_match(/<a class="mail-btn__label"[^>]*style="[^"]*padding:\s*12px 18px/, html,
+        "#{preview.name}##{email} moved the button's padding off the anchor, so the " \
+        "hover area is now wider than the link.")
+    end
+  end
+
+  # The hover assertions above are guarded on a button being present, so this
+  # keeps them from passing vacuously if the partial is ever renamed.
+  test "at least one preview renders a button" do
+    with_button = self.class.mjml_emails.count do |preview, email|
+      html_part_for(preview, email).include?('class="mail-btn')
+    end
+
+    refute_equal 0, with_button,
+      "No preview renders shared/mailer/_btn, so every hover assertion above is vacuous."
   end
 
   private

--- a/test/mailers/mjml_rendering_test.rb
+++ b/test/mailers/mjml_rendering_test.rb
@@ -21,6 +21,8 @@ require "test_helper"
 #   border-radius off the element MJML puts the panel's frame on.
 # - The button's hover state is the one part of it that cannot be inlined, so it
 #   is the one part premailer could throw away.
+# - The accent is per theme, and a mail resolves it in Ruby because no client
+#   resolves a custom property - so a mail can silently wear the wrong one.
 class MjmlRenderingTest < ActionMailer::TestCase
   MJML_LAYOUT = "mailer"
 
@@ -140,7 +142,7 @@ class MjmlRenderingTest < ActionMailer::TestCase
         "the lifted label" =>
           /\.mail-btn:hover \.mail-btn__label\s*\{\s*color:\s*#{MailerTheme::LIFTED}\s*!important/io,
         "the lit end-cap" =>
-          /\.mail-btn--neutral:hover \.mail-btn__cap\s*\{\s*background-color:\s*#{MailerTheme::PRIMARY}\s*!important/io
+          /\.mail-btn--neutral:hover \.mail-btn__cap\s*\{\s*background-color:\s*#{accent_for(preview)}\s*!important/i
       }.each do |what, pattern|
         assert_match pattern, html,
           "#{preview.name}##{email} lost #{what}. premailer is supposed to leave a " \
@@ -156,6 +158,41 @@ class MjmlRenderingTest < ActionMailer::TestCase
         "#{preview.name}##{email} moved the button's padding off the anchor, so the " \
         "hover area is now wider than the link.")
     end
+
+    # The admin app is a violet place and its mails are sent from it, so they
+    # carry the violet too. Nothing else about them changes - a theme touches
+    # the accent and only the accent - which is exactly what makes the wrong one
+    # hard to notice: the mail still looks right, just like the other app.
+    test "#{preview.name}##{email} wears its mailer's accent and no other" do
+      html = html_part_for(preview, email).downcase
+      accent = accent_for(preview)
+
+      assert_includes html, accent,
+        "#{preview.name}##{email} contains no #{accent} anywhere. " \
+        "#{self.class.mailer_for(preview)}.mail_theme is " \
+        "#{self.class.mailer_for(preview).mail_theme.inspect}, so that is the accent " \
+        "every link and end-cap in it should resolve to."
+
+      [*MailerTheme::ACCENTS.values, MailerTheme::PRIMARY].each do |other|
+        next if other.downcase == accent
+
+        refute_includes html, other.downcase,
+          "#{preview.name}##{email} still contains #{other}, which belongs to a " \
+          "different theme. A call site is reading MailerTheme::PRIMARY directly " \
+          "instead of going through mail_accent."
+      end
+    end
+  end
+
+  # A theme that no mailer selects is dead weight, and an accent asserted only
+  # against mails that never use it proves nothing.
+  test "every declared accent is selected by some mailer" do
+    selected = self.class.mjml_emails.map { |preview, _| self.class.mailer_for(preview).mail_theme }.uniq
+
+    unused = MailerTheme::ACCENTS.keys - selected
+    assert_empty unused,
+      "MailerTheme::ACCENTS declares #{unused.join(", ")}, which no mailer with a preview " \
+      "selects - so nothing above checks that theme renders."
   end
 
   # The hover assertions above are guarded on a button being present, so this
@@ -170,6 +207,10 @@ class MjmlRenderingTest < ActionMailer::TestCase
   end
 
   private
+
+  def accent_for(preview)
+    MailerTheme.accent(self.class.mailer_for(preview).mail_theme).downcase
+  end
 
   # premailer generates the text part in its delivery hook, so the multipart
   # message only exists after the hook has run. Calling the hook directly keeps


### PR DESCRIPTION
## What

`Btn` lights its end-cap and lifts its surface and its label on hover. The mail button — the same control, caps and all — was flat. It now does the same thing.

| | surface | label | cap |
|---|---|---|---|
| rest | `#23272b` | `#c8c8c8` | tone |
| hover | `#31373d` | `#eeeeee` | `--color-primary` |

Per tone, mirroring `Btn`: `neutral` moves its cap grey → blue, `primary` already wears the hovered cap so it just gains the lift, and `danger`/`warning` flood and take the border with them, their caps following the label to white.

## Why it works at all

The partial said email cannot hover. Not quite: every client with a pointer that keeps an embedded stylesheet honours `:hover` — Apple Mail, Gmail's web client, Outlook.com, Yahoo.

Hover is the one part of a button that cannot be an inline style, so the rules live in the layout's `mj-style`. Two things had to hold, and both were verified against the delivered HTML rather than the compiled MJML:

- **premailer leaves them alone.** It keeps a selector containing a pseudo-class out of its inlining pass and re-emits it into a style block. All ten rules arrive intact.
- **They outrank the resting value**, which is itself an inline style — hence `!important`, the same call `.cap-top` already makes.

Measured in Chromium on a real delivered mail:

```
rest    surface rgb(35,39,43)   label rgb(200,200,200)  cap rgb(66,139,202)
hover   surface rgb(49,55,61)   label rgb(238,238,238)  cap rgb(66,139,202)
```

## Where it doesn't

Outlook's Word engine has no hover, and Gmail drops the embedded block in a forwarded message. Every resting style is still inline, so both render exactly the button that was there before. That is the same floor the cap's corner radius already accepts.

## Padding moved onto the anchor

With it on the cell, an 18px strip down each side lit up without being clickable. The link box is now 258×44 inside a 260×50 face — everything but the caps and the border.

## Colours

`CONTROL_HOVER` and `LIFTED` are composited from the theme the way every other colour in `MailerTheme` is. The two flooded tones are the exception: `Btn` writes their hovered cap as a literal `rgb(255 255 255 / .65)` rather than as a token, so the test recomputes them against the tone they are drawn on instead of against a `--color-*` that does not exist.

## Tests

`MjmlRenderingTest` asserts the rules survive the delivery hook and that the padding stays on the anchor, guarded by a test that at least one preview renders a button so it cannot pass vacuously. `MailerThemeTest` recomputes the four new colours from `tailwind.css`.

`bin/rails test test/mailers test/lib/mailer_theme_test.rb` — 221 tests, 758 assertions, green. `bin/ruby-lint` clean.

## Not verified

Playwright's webkit browser is not installed locally, so Apple Mail's engine is unchecked. The CSS involved is plain enough that I would not expect a difference, but only Chromium was measured.

🤖
