### PR TITLE
feat(mailer): send admin mails in the admin's accent

### DIFF
--- a/app/lib/mailer_theme.rb
+++ b/app/lib/mailer_theme.rb
@@ -51,6 +51,39 @@ module MailerTheme
   WARNING_CAP_HOVER = "#fdcaa6"
   FLOOD_TEXT = "#ffffff"
 
+  # The accent, per theme.
+  #
+  # stylesheets/shared/themes.scss gives the app a theme layer: a theme is a set
+  # of tokens components read through var(), selected by data-theme on <html>,
+  # and the admin layout sets data-theme="admin". A mail has no <html> we
+  # control per recipient and no var() any client would resolve, so the
+  # selection happens in Ruby instead - ApplicationMailer.mail_theme is the
+  # attribute, and the layout interpolates the literal.
+  #
+  # The default theme is absent here for the same reason it is absent from
+  # themes.scss: PRIMARY above is what a mail that names no theme gets, so it
+  # cannot drift out from under one.
+  #
+  # Only the accent is themed. themes.scss also derives three tones from it -
+  # shade, shade-soft, tint - for a rail glow, a hovered toggle border and pill
+  # label text, none of which a mail has. Add one here when a mail grows the
+  # element that needs it, not before.
+  ACCENTS = {
+    admin: "#a855f7" # --color-primary under [data-theme="admin"]
+  }.freeze
+
+  # Raises rather than falling back, because a mistyped theme that quietly
+  # renders the frontend blue is exactly the bug this indirection exists to
+  # make impossible.
+  def self.accent(theme)
+    return PRIMARY if theme.nil?
+
+    ACCENTS.fetch(theme.to_sym) do
+      raise ArgumentError,
+        "unknown mail theme #{theme.inspect}; MailerTheme::ACCENTS has #{ACCENTS.keys.join(", ")}"
+    end
+  end
+
   # Which surface each translucent token composites against. Read by the test.
   BASES = {
     "surface" => :background,

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -3,6 +3,12 @@
 class AdminMailer < ApplicationMailer
   helper AdminReportHelper
 
+  # Every mail in here goes to an AdminUser, so it comes from the same place the
+  # admin app does and wears the same accent. See themes.scss for why that is a
+  # violet: it was chosen for distance from every colour the app already assigns
+  # a meaning to, and its contrast profile matches the blue it stands in for.
+  self.mail_theme = :admin
+
   OPEN_NOTIFICATIONS_LIMIT = 10
 
   # Sent per admin rather than to the whole super-admin list at once: the digest

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,8 +5,25 @@ class ApplicationMailer < ActionMailer::Base
 
   layout "mailer"
 
+  # The mail equivalent of data-theme on <html>, which is how the app selects a
+  # theme and how the admin layout picks up its violet accent. A mail cannot use
+  # that mechanism - it has no var() any client resolves - so the mailer names
+  # its theme and MailerTheme resolves the literal the layout interpolates.
+  #
+  # nil is the same absence data-theme has on the frontend: not a theme called
+  # "default", just a document that selects none.
+  class_attribute :mail_theme, default: nil
+
+  helper_method :mail_accent
+
   rescue_from Postmark::InactiveRecipientError do |_exception|
     handle_inactive_error
+  end
+
+  # The one themed value a mail has. Everything else in MailerTheme is neutral
+  # chrome, which a theme deliberately does not touch.
+  private def mail_accent
+    MailerTheme.accent(mail_theme)
   end
 
   private def handle_inactive_error

--- a/app/views/layouts/mailer.html.mjml
+++ b/app/views/layouts/mailer.html.mjml
@@ -124,7 +124,7 @@
         the :primary tone already wears at rest - so a primary button lifts its
         surface and its label and keeps the cap it had.
       */
-      .mail-btn--neutral:hover .mail-btn__cap { background-color: <%= MailerTheme::PRIMARY %> !important; }
+      .mail-btn--neutral:hover .mail-btn__cap { background-color: <%= mail_accent %> !important; }
 
       .mail-btn--danger:hover {
         background-color: <%= MailerTheme::DANGER %> !important;
@@ -281,9 +281,9 @@
           <%= I18n.t("copyright") %> &copy; <%= Time.current.year %>
           <%= Rails.configuration.app.copyright_owner %>
           <br />
-          <a href="<%= frontend_privacy_policy_url %>" style="color: <%= MailerTheme::PRIMARY %>;"><%= I18n.t("mailer.privacy") %></a>
+          <a href="<%= frontend_privacy_policy_url %>" style="color: <%= mail_accent %>;"><%= I18n.t("mailer.privacy") %></a>
           &nbsp;&middot;&nbsp;
-          <a href="<%= frontend_settings_notifications_url %>" style="color: <%= MailerTheme::PRIMARY %>;"><%= I18n.t("mailer.notification_settings") %></a>
+          <a href="<%= frontend_settings_notifications_url %>" style="color: <%= mail_accent %>;"><%= I18n.t("mailer.notification_settings") %></a>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/app/views/model_mailer/notify_new.html.mjml
+++ b/app/views/model_mailer/notify_new.html.mjml
@@ -13,7 +13,7 @@
   <%= I18n.t("mailer.model.new.headline_part_2", manufacturer: @model.manufacturer.name) %>
   <a href="<%= frontend_model_url(slug: @model.slug) %>"
      target="_blank"
-     style="color: <%= MailerTheme::PRIMARY %>; text-decoration: none;"><%= @model.name %></a>!
+     style="color: <%= mail_accent %>; text-decoration: none;"><%= @model.name %></a>!
 </mj-text>
 
 <% if @model.store_image.attached? %>

--- a/app/views/shared/mailer/_btn.html.mjml
+++ b/app/views/shared/mailer/_btn.html.mjml
@@ -18,6 +18,10 @@
   active, borrowed here at rest to mark the one action a mail is asking for.
   Nothing in the app changes.
 
+  Which colour that is depends on the mailer's theme, not on this file: an
+  AdminMailer resolves the admin violet, everything else the frontend blue. Same
+  for the hovered neutral cap. See ApplicationMailer.mail_theme.
+
   Hover is real, in the clients that have a pointer and keep an embedded
   stylesheet - Apple Mail, Gmail's web client, Outlook.com, Yahoo. The rules
   live in the layout's mj-style under .mail-btn, because a pseudo-class cannot
@@ -50,7 +54,7 @@
   width = defined?(width) && width.present? ? width : 260
   cap_color = {
     neutral: MailerTheme::ENDCAP,
-    primary: MailerTheme::PRIMARY,
+    primary: mail_accent,
     danger: MailerTheme::DANGER,
     warning: MailerTheme::WARNING
   }.fetch(tone)

--- a/app/views/vehicle_mailer/on_sale.html.mjml
+++ b/app/views/vehicle_mailer/on_sale.html.mjml
@@ -21,7 +21,7 @@
 <mj-text mj-class="h2" padding="0 0 12px">
   <a href="<%= frontend_model_url(slug: @vehicle.model.slug) %>"
      target="_blank"
-     style="color: <%= MailerTheme::PRIMARY %>; text-decoration: none;"><%= @vehicle.model.name %></a>
+     style="color: <%= mail_accent %>; text-decoration: none;"><%= @vehicle.model.name %></a>
   <%= I18n.t("mailer.vehicle.on_sale.headline.part_two") %>
 </mj-text>
 

--- a/test/lib/mailer_theme_test.rb
+++ b/test/lib/mailer_theme_test.rb
@@ -8,6 +8,7 @@ require "test_helper"
 # disagree - in either direction.
 class MailerThemeTest < ActiveSupport::TestCase
   THEME_FILE = Rails.root.join("app/frontend/entrypoints/tailwind.css")
+  THEME_LAYER = Rails.root.join("app/frontend/stylesheets/shared/themes.scss")
 
   # --color-<name>: <value>, ignoring the var() aliases (the mission categories).
   DECLARATION = /^\s*--color-([a-z0-9-]+):\s*(#[0-9a-f]{3,6}|rgb\([^)]*\))\s*;/i
@@ -77,6 +78,38 @@ class MailerThemeTest < ActiveSupport::TestCase
       "--cap-h-btn is max(2px, --cap-h - 2px)"
     assert_equal [MailerTheme::CAP_HEIGHT_BTN.to_i / 2, 1].max, MailerTheme::CAP_RADIUS_BTN.to_i,
       "--cap-r-btn is held to half the button cap's own height"
+  end
+
+  # A theme is a set of custom properties on the frontend, and no mail client
+  # resolves one - so ACCENTS restates the accent each theme declares, with the
+  # same risk of drift the colours above have and the same answer to it.
+  test "each themed accent equals that theme's --color-primary" do
+    css = THEME_LAYER.read
+
+    MailerTheme::ACCENTS.each do |theme, accent|
+      block = css[/\[data-theme=["']#{Regexp.escape(theme.to_s)}["']\]\s*\{(.*?)\}/m, 1]
+      assert block,
+        "themes.scss declares no [data-theme=\"#{theme}\"] block, but MailerTheme::ACCENTS " \
+        "has an accent for it. Either the theme was renamed or it no longer exists."
+
+      declared = block[/^\s*--color-primary:\s*(#[0-9a-f]{3,6})\s*;/i, 1]
+      assert declared, "[data-theme=\"#{theme}\"] declares no --color-primary"
+
+      assert_equal normalize_hex(declared), accent.downcase,
+        "MailerTheme::ACCENTS[#{theme.inspect}] is #{accent} but themes.scss declares " \
+        "#{declared} for that theme. Update the constant."
+    end
+  end
+
+  test "a mail that names no theme gets the default accent" do
+    assert_equal MailerTheme::PRIMARY, MailerTheme.accent(nil)
+  end
+
+  # Silently rendering the frontend blue is the failure this indirection exists
+  # to prevent, so a name nobody declared has to be loud.
+  test "an unknown theme raises rather than falling back" do
+    error = assert_raises(ArgumentError) { MailerTheme.accent(:nope) }
+    assert_match(/unknown mail theme :nope/, error.message)
   end
 
   # The flooded tones are the one pair with no --color-* to mirror: Btn writes

--- a/test/mailers/mjml_rendering_test.rb
+++ b/test/mailers/mjml_rendering_test.rb
@@ -21,6 +21,8 @@ require "test_helper"
 #   border-radius off the element MJML puts the panel's frame on.
 # - The button's hover state is the one part of it that cannot be inlined, so it
 #   is the one part premailer could throw away.
+# - The accent is per theme, and a mail resolves it in Ruby because no client
+#   resolves a custom property - so a mail can silently wear the wrong one.
 class MjmlRenderingTest < ActionMailer::TestCase
   MJML_LAYOUT = "mailer"
 
@@ -140,7 +142,7 @@ class MjmlRenderingTest < ActionMailer::TestCase
         "the lifted label" =>
           /\.mail-btn:hover \.mail-btn__label\s*\{\s*color:\s*#{MailerTheme::LIFTED}\s*!important/io,
         "the lit end-cap" =>
-          /\.mail-btn--neutral:hover \.mail-btn__cap\s*\{\s*background-color:\s*#{MailerTheme::PRIMARY}\s*!important/io
+          /\.mail-btn--neutral:hover \.mail-btn__cap\s*\{\s*background-color:\s*#{accent_for(preview)}\s*!important/i
       }.each do |what, pattern|
         assert_match pattern, html,
           "#{preview.name}##{email} lost #{what}. premailer is supposed to leave a " \
@@ -156,6 +158,41 @@ class MjmlRenderingTest < ActionMailer::TestCase
         "#{preview.name}##{email} moved the button's padding off the anchor, so the " \
         "hover area is now wider than the link.")
     end
+
+    # The admin app is a violet place and its mails are sent from it, so they
+    # carry the violet too. Nothing else about them changes - a theme touches
+    # the accent and only the accent - which is exactly what makes the wrong one
+    # hard to notice: the mail still looks right, just like the other app.
+    test "#{preview.name}##{email} wears its mailer's accent and no other" do
+      html = html_part_for(preview, email).downcase
+      accent = accent_for(preview)
+
+      assert_includes html, accent,
+        "#{preview.name}##{email} contains no #{accent} anywhere. " \
+        "#{self.class.mailer_for(preview)}.mail_theme is " \
+        "#{self.class.mailer_for(preview).mail_theme.inspect}, so that is the accent " \
+        "every link and end-cap in it should resolve to."
+
+      [*MailerTheme::ACCENTS.values, MailerTheme::PRIMARY].each do |other|
+        next if other.downcase == accent
+
+        refute_includes html, other.downcase,
+          "#{preview.name}##{email} still contains #{other}, which belongs to a " \
+          "different theme. A call site is reading MailerTheme::PRIMARY directly " \
+          "instead of going through mail_accent."
+      end
+    end
+  end
+
+  # A theme that no mailer selects is dead weight, and an accent asserted only
+  # against mails that never use it proves nothing.
+  test "every declared accent is selected by some mailer" do
+    selected = self.class.mjml_emails.map { |preview, _| self.class.mailer_for(preview).mail_theme }.uniq
+
+    unused = MailerTheme::ACCENTS.keys - selected
+    assert_empty unused,
+      "MailerTheme::ACCENTS declares #{unused.join(", ")}, which no mailer with a preview " \
+      "selects - so nothing above checks that theme renders."
   end
 
   # The hover assertions above are guarded on a button being present, so this
@@ -170,6 +207,10 @@ class MjmlRenderingTest < ActionMailer::TestCase
   end
 
   private
+
+  def accent_for(preview)
+    MailerTheme.accent(self.class.mailer_for(preview).mail_theme).downcase
+  end
 
   # premailer generates the text part in its delivery hook, so the multipart
   # message only exists after the hook has run. Calling the hook directly keeps


### PR DESCRIPTION
> Stacked on #4835 — base is `feat/mail-btn-hover`, so the diff to review is the second commit. Merge that one first.

## What

The admin app has been a violet place since the theme layer landed. Its mails were still blue. Every mail `AdminMailer` sends goes to an `AdminUser`, so it comes from the same place the admin app does and should look like it.

```
admin weekly     violet ×5   blue ×0
admin notify     violet ×3   blue ×0
devise reset     violet ×0   blue ×5
```

## How

The frontend selects a theme with `data-theme` on `<html>` and reads tokens through `var()`. A mail can use neither — there is no per-recipient `<html>` we control, and no client resolves a custom property. So the selection moves into Ruby:

```ruby
# ApplicationMailer
class_attribute :mail_theme, default: nil   # the same absence data-theme has

# AdminMailer
self.mail_theme = :admin
```

`MailerTheme::ACCENTS` holds the literal, `MailerTheme.accent` resolves it, and the views interpolate it through a `mail_accent` helper.

Two deliberate choices:

- **The default theme is absent from `ACCENTS`**, for the same reason it is absent from `themes.scss`: `PRIMARY` stays what a mailer naming no theme gets, so it cannot drift out from under one.
- **An unknown name raises** rather than falling back. Quietly rendering the frontend blue is the failure this indirection exists to prevent.

## Scope

Only the accent is themed, which is the entire surface a mail has for one: the weekly report's button cap, the hovered neutral cap, and the two footer links. Neutral surfaces, panel end-caps, the backdrop and the header lockup are untouched — the lockup needed no admin variant, it is the planet mark and `TEXT` with no accent in it.

`themes.scss` derives three more tones from the accent (shade, shade-soft, tint) for a rail glow, a hovered toggle border and pill label text. No mail has any of those, so none are mirrored.

## Contrast

Nothing needed re-tuning, and I checked rather than taking it from the theme's own notes:

| | violet | blue | needs |
|---|---|---|---|
| footer link on black | 5.31:1 | 5.78:1 | 4.5:1 |
| 2px cap on the control | 3.80:1 | 4.14:1 | 3:1 |

## Tests

`MailerThemeTest` recomputes each accent from `themes.scss` itself, so a drift in either file fails — the same discipline the colour constants already have. `MjmlRenderingTest` asserts every preview contains its own mailer's accent and **none of the others**, which is what catches a call site reading `MailerTheme::PRIMARY` directly, plus a guard that every declared accent is actually selected by some mailer so the assertion cannot go vacuous.

`bin/rails test test/mailers test/lib/mailer_theme_test.rb` — 248 tests, 882 assertions, green. `bin/ruby-lint` clean.

## Noticed, not touched

The layout links an admin mail's footer to `frontend_privacy_policy_url` and `frontend_settings_notifications_url` — frontend user settings, which an `AdminUser` does not have. Predates this change and is a routing question, not a colour one.

🤖
