### PR TITLE
chore(deps): migrate to pnpm 12

### DIFF
--- a/.github/workflows/js-setup-action/action.yml
+++ b/.github/workflows/js-setup-action/action.yml
@@ -5,8 +5,10 @@ runs:
   steps:
     # No version input: pnpm/action-setup reads it from packageManager in
     # package.json, so the version is declared in exactly one place.
+    # Pinned to an exact tag: pnpm 12 needs the native bootstrap added in
+    # v6.1.0, and the floating v6 tag still points at v6.0.10.
     - name: Install pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@v6.1.0
 
     - name: Setup Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/ruby-tests.job.yml
+++ b/.github/workflows/ruby-tests.job.yml
@@ -58,8 +58,10 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      # Pinned to an exact tag: pnpm 12 needs the native bootstrap added in
+      # v6.1.0, and the floating v6 tag still points at v6.0.10.
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v6.1.0
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 4.0.5
 nodejs lts
-pnpm 10.34.5
+pnpm 12.3.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ ARG NODE_MAJOR=24
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_MAJOR}.x | bash - && \
     apt-get install --no-install-recommends -y nodejs && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
-RUN corepack enable && corepack prepare pnpm@10.34.5 --activate
+RUN corepack enable && corepack prepare pnpm@12.3.4 --activate
 
 # Install Ruby gems
 COPY Gemfile Gemfile.lock .tool-versions ./

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fleetyards",
   "private": true,
   "version": "7.15.0",
-  "packageManager": "pnpm@10.34.5",
+  "packageManager": "pnpm@12.3.4",
   "scripts": {
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -150,12 +150,5 @@
     "vue-tsc": "3.3.11",
     "workbox-build": "^7.4.1",
     "workbox-window": "^7.4.1"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "vite-plugin-pwa>vite": "8"
-      }
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,19 @@
 packages:
   - '.'
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  '@hyperjump/json-pointer': false
+  '@hyperjump/json-schema': false
+  '@hyperjump/json-schema-core': false
+  '@hyperjump/pact': false
+  '@parcel/watcher': false
+  '@scarf/scarf': false
+  core-js: false
+  esbuild: true
+  msw: false
+  vue-demi: false
+peerDependencyRules:
+  allowedVersions:
+    vite-plugin-pwa>vite: '8'
 overrides:
   json5: '>=2.2.2'
   semver: '>=7.5.2'


### PR DESCRIPTION
Closes #4837.

> Stacked auf #4838 — Base ist `chore/bump-bundler-pnpm`, nicht `main`. Der Diff hier zeigt nur die Migration.

pnpm 10.34.5 → 12.3.4. Zwei Majors, und beide fassen genau die Settings an, die dieses Projekt benutzt — der Versionspin war der kleinste Teil.

## Die beiden Settings, die umziehen mussten

**`onlyBuiltDependencies` → `allowBuilds`.** In pnpm 11 ersatzlos entfernt, in 12 bricht ein unbekannter Key in `pnpm-workspace.yaml` bei gepinntem `packageManager` hart mit `ERR_PNPM_UNRECOGNIZED_WORKSPACE_SETTINGS` ab.

Der Punkt, der beim Umschreiben auffällt: `allowBuilds` ist keine Allowlist, sondern eine vollständige Entscheidung. Unter `onlyBuiltDependencies: [esbuild]` wurden zehn weitere Pakete mit Build-Skript stillschweigend ignoriert; pnpm 12 verweigert die Installation mit `ERR_PNPM_IGNORED_BUILDS`, bis jedes einzeln entschieden ist. Sie stehen jetzt explizit auf `false` — also genau das Verhalten, das sie vorher schon hatten. `msw` ist der einzige, bei dem man kurz zweifelt; der Service Worker liegt nicht unter `public/`, das Build-Skript lief also auch bisher nie.

**`peerDependencyRules` raus aus `package.json`.** Das `pnpm`-Feld wird von pnpm 12 gar nicht mehr gelesen — mit `[WARN] The "pnpm" field in package.json is no longer read by pnpm`, aber ohne Fehler. Die Regel für `vite-plugin-pwa>vite` wäre also klanglos verschwunden.

## pnpm 12 verteilt sich anders, und das trifft die CI

Das `pnpm`-npm-Paket ist ab 12 ein Wrapper, der sein Binary aus plattformspezifischen `@pnpm/exe.<platform>`-Paketen zieht. Zwei Konsequenzen:

- **`pnpm/action-setup@v6` reicht nicht.** Der native Bootstrap dafür kam erst in **v6.1.0** (05.09.2026), und der schwebende `v6`-Tag zeigt weiterhin auf `v6.0.10` — nachgerechnet, beide Tags dereferenzieren auf verschiedene Commits. Deshalb hier ausnahmsweise ein exakter Tag statt des Major-Tags, mit Begründung im Kommentar.
- **Ein bestehender pnpm-10-Checkout kann sich nicht selbst hochziehen.** `pnpm --version` scheitert mit `Failed to switch pnpm to v12.3.4 … pnpm CLI is missing at …/@pnpm+exe/12.3.4/bin`, weil der Self-Switch von pnpm 10 das alte, monolithische `@pnpm/exe` erwartet. Wer nach dem Merge zieht, muss pnpm 12 einmal out of band installieren (`mise install`, corepack oder Standalone). Das ist ein reines Onboarding-Ärgernis, kein Repo-Problem — aber es wird jeden treffen.

Corepack ist unbetroffen: `corepack prepare pnpm@12.3.4 --activate` läuft durch, das Binary wird beim ersten `pnpm`-Aufruf nachgeladen. Der Dockerfile-Pfad bleibt damit unverändert gültig.

## Lockfile

`pnpm-lock.yaml` bekommt ein **zweites YAML-Dokument** vorangestellt, das pnpm selbst und seine acht Plattform-Executables pinnt (`packageManagerDependencies`). `lockfileVersion` bleibt `9.0`, der Dependency-Graph ist unangetastet — die 101 neuen Zeilen sind vollständig dieses neue Dokument.

Die in den Release Notes angekündigte Vereinfachung des `patchedDependencies`-Formats ist **nicht** passiert: der `@tresjs/core`-Eintrag steht weiter als `{hash, path}` im Lockfile. Die Migration ist offenbar lazy und greift erst, wenn der Abschnitt ohnehin neu geschrieben wird. Funktioniert in beiden Formaten, der Patch wird sauber angewendet.

## `minimumReleaseAge`

Ab pnpm 11 ist der Default 1440 Minuten — frisch veröffentlichte Pakete werden 24h lang nicht aufgelöst. Bewusst **nicht** überschrieben: das ist Supply-Chain-Schutz, und `minimumReleaseAgeStrict` bleibt `false`, was bereits gelockte Pakete von der Prüfung ausnimmt. `--frozen-lockfile` löst ohnehin nicht auf und meldet nur `✓ Lockfile passes supply-chain policies`. Praktische Folge: Dependabot-Bumps auf ein taufrisches Release kommen einen Tag später statt sofort.

## Verifiziert

Alles lokal in einem Worktree mit pnpm 12.3.4:

- `pnpm install --force` — vollständige Neuauflösung, 1387 Pakete, `postinstall` läuft, orval- und Cable-Clients byte-identisch
- `CI=true pnpm install --frozen-lockfile` — der CI-Pfad, grün
- `pnpm test` — 77 Dateien, 555 Tests grün
- `pnpm lint:js`, `pnpm format`, `pnpm lint:ts` (nach `bin/vite build --mode=test`) — alle Exit 0
- Der Docker-Pfad in einem Wegwerf-Image nachgebaut, das Node 24, `corepack prepare pnpm@12.3.4` und `pnpm install --frozen-lockfile --ignore-scripts` auf `ruby:4.0.2-slim` ausführt: baut durch, `pnpm --version` meldet 12.3.4 im Container

Zwei Nebenbeobachtungen ohne Änderungsbedarf: `optimisticRepeatInstall` ist ab 11 default an, ein zweites `pnpm install` sagt jetzt „Already up to date" in 16ms und überspringt `postinstall` — für eine echte Verifikation braucht es `--force`. Und pnpm 10 bricht ein `install` über ein pnpm-12-`node_modules` mit `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` ab, wenn kein TTY da ist; beim Zurückwechseln auf einen älteren Branch hilft `CI=true`.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the project’s package manager to pnpm 12.3.4 across local development, builds, and automated workflows.
  - Pinned the package setup action to a specific compatible version for more consistent builds.
  - Refined workspace build-script permissions with explicit package-level controls.
  - Updated workspace configuration to support using Vite 8 with the progressive web app plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->