### PR TITLE
feat(fleets): show an error page for a bad invite link

### DIFF
--- a/app/frontend/frontend/pages/fleets/invite.vue
+++ b/app/frontend/frontend/pages/fleets/invite.vue
@@ -5,6 +5,7 @@ export default {
 </script>
 
 <script lang="ts" setup>
+import InviteInvalid from "@/shared/components/InviteInvalid/index.vue";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useFleetStore } from "@/frontend/stores/fleet";
@@ -29,6 +30,11 @@ const router = useRouter();
 
 const inviteToken = computed(() => route.params.token as string);
 
+// The lookup failing is a property of the link itself, so it stays on the page
+// rather than becoming a toast the reader is redirected away from. Redeeming a
+// valid invite can fail transiently, which is why only this half is a state.
+const inviteInvalid = ref(false);
+
 const useInvite = async () => {
   await findFleetByInvite(inviteToken.value)
     .then((fleet) => {
@@ -48,18 +54,10 @@ const useInvite = async () => {
         },
       });
     })
-    .catch(async (error) => {
+    .catch((error) => {
       console.error(error);
 
-      displayAlert({
-        text: t("messages.fleetInvite.notFound"),
-      });
-
-      await router
-        .push({
-          name: "home",
-        })
-        .catch(() => {});
+      inviteInvalid.value = true;
     });
 };
 
@@ -102,5 +100,7 @@ const handleFleetInvite = async () => {
 </script>
 
 <template>
-  <section class="container fleet-detail" />
+  <section class="container fleet-detail">
+    <InviteInvalid v-if="inviteInvalid" :token="inviteToken" />
+  </section>
 </template>

--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -16,6 +16,7 @@ import ModelPanel from "@/frontend/components/Models/Panel/index.vue";
 import ModelsTable from "@/frontend/components/Models/Table/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
 import Forbidden from "@/shared/components/Forbidden/index.vue";
+import InviteInvalid from "@/shared/components/InviteInvalid/index.vue";
 import NotAuthorized from "@/shared/components/NotAuthorized/index.vue";
 import NotFound from "@/shared/components/NotFound/index.vue";
 import Paginator from "@/shared/components/Paginator/index.vue";
@@ -374,15 +375,18 @@ const updatePerPage = (value: number | string) => {
 
   <Heading :level="HeadingLevelEnum.H2">Error Pages</Heading>
   <p>
-    The four full-page error blocks. They are normally rendered as a whole
+    The five full-page error blocks. They are normally rendered as a whole
     route, so they bring their own heading. <code>Forbidden</code> is the one
     for a resource that exists and is not yours, as against
     <code>NotAuthorized</code> for not being signed in at all.
+    <code>InviteInvalid</code> names the token it was given, which is opaque and
+    long enough to run out of the box if it does not break.
   </p>
   <NotFound />
   <NotAuthorized />
   <Forbidden />
   <ServerError />
+  <InviteInvalid token="8f14e45fceea167a5a36dedd4bea2543" />
 
   <Heading :level="HeadingLevelEnum.H2">FetchProgressBar</Heading>
   <p>

--- a/app/frontend/shared/components/InviteInvalid/index.vue
+++ b/app/frontend/shared/components/InviteInvalid/index.vue
@@ -1,0 +1,61 @@
+<script lang="ts">
+export default {
+  name: "InviteInvalid",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import Box from "@/shared/components/Box/index.vue";
+import Text from "@/shared/components/base/Text/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import { PanelTonesEnum } from "@/shared/components/base/Panel/types";
+import { HeadingSizeEnum } from "@/shared/components/base/Heading/types";
+
+type Props = {
+  token?: string;
+};
+
+defineProps<Props>();
+
+const { t } = useI18n();
+</script>
+
+<template>
+  <Box
+    :tone="PanelTonesEnum.ERROR"
+    :heading-size="HeadingSizeEnum.HERO"
+    animated
+    large
+  >
+    <template #heading>
+      {{ t("headlines.inviteInvalid") }}
+    </template>
+    <template #default>
+      <Text>{{ t("texts.inviteInvalid") }}</Text>
+      <Text v-if="token" muted no-spacing>
+        {{ t("labels.inviteToken") }}:
+        <span class="invite-invalid__token">{{ token }}</span>
+      </Text>
+    </template>
+    <template #footer>
+      <Btn :to="{ name: 'home' }">
+        <i class="fa fa-chevron-left" />
+        {{ t("actions.backToHome").toUpperCase() }}
+      </Btn>
+    </template>
+  </Box>
+</template>
+
+<style lang="scss" scoped>
+.invite-invalid__token {
+  padding: 0.1rem 0.35rem;
+  font-family: monospace;
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 3px;
+  // A token is opaque and arbitrarily long, so it breaks anywhere rather than
+  // running out of the box.
+  overflow-wrap: anywhere;
+}
+</style>

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -188,6 +188,7 @@
       "notFound": "Navigationsfehler",
       "forbidden": "Zugriff verweigert",
       "featureNotReady": "Demnächst",
+      "inviteInvalid": "Ungültiger Einladungslink",
       "accessDenied": "Zugriff verweigert",
       "serverError": "Serverfehler",
       "comments": "Kommentare",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -124,6 +124,7 @@
         "publicShort": "Öffentlich"
       },
       "fleetInviteToken": "Flotteneinladung",
+      "inviteToken": "Einladungscode",
       "scDataVersion": "Patch-Version",
       "createdAt": "Erstellt am",
       "updatedAt": "Aktualisiert am",

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -307,7 +307,6 @@
       "fleetInvite": {
         "used": "<b>Beitrittsanfrage für %{fleet} gesendet!</b><br>Sobald deine Mitgliedschaft akzeptiert wird, wirst du per E-Mail benachrichtigt",
         "failure": "Einladung konnte nicht verwendet werden.",
-        "notFound": "Einladung nicht gefunden.",
         "confirm": "Bist du sicher, dass du der Flotte beitreten möchtest: \"%{fleet}\"?"
       },
       "holoViewer": {

--- a/app/frontend/translations/de/texts.json
+++ b/app/frontend/translations/de/texts.json
@@ -21,6 +21,7 @@
       "notFound": "You are currently venturing unknown space. In the event you are lost, the UEE highly recommends plotting a new destination back towards home-space.",
       "forbidden": "Deine Freigabe deckt diesen Bereich nicht ab. Wird eine Funktion gerade erst ausgerollt, kannst du sie unter Einstellungen > Funktionen selbst aktivieren, sobald sie für dich verfügbar ist.",
       "featureNotReady": "Diese Funktion ist noch nicht fertig und wird bald verfügbar sein. Bleiben Sie dran!",
+      "inviteInvalid": "Dieser Einladungslink ist nicht gültig. Möglicherweise wurde er falsch übertragen, er ist abgelaufen oder er hat sein Nutzungslimit erreicht. Bitte lass dir von der Person, die dich eingeladen hat, einen neuen Link geben.",
       "accessDenied": "Sie sind nicht berechtigt, diese Seite anzuzeigen.",
       "serverError": "Der Server hat derzeit technische Probleme. Bitte versuchen Sie es später erneut.",
       "compare": {

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -180,6 +180,7 @@
       "notFound": "Navigation Error",
       "forbidden": "Access Denied",
       "featureNotReady": "Coming Soon",
+      "inviteInvalid": "Invalid Invite Link",
       "accessDenied": "Access Denied",
       "serverError": "Server Error",
       "comments": "Comments",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -124,6 +124,7 @@
         "publicShort": "Public"
       },
       "fleetInviteToken": "Fleet Invite",
+      "inviteToken": "Invite code",
       "scDataVersion": "Patch Version",
       "createdAt": "Created at",
       "updatedAt": "Updated at",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -306,7 +306,6 @@
       "fleetInvite": {
         "used": "<b>Join request for %{fleet} send!</b><br>Once your Membership is accepted you will be notified via email",
         "failure": "Invite could not be used.",
-        "notFound": "Invite not found.",
         "confirm": "Are you sure you want to join the Fleet: \"%{fleet}\"?"
       },
       "holoViewer": {

--- a/app/frontend/translations/en/texts.json
+++ b/app/frontend/translations/en/texts.json
@@ -21,6 +21,7 @@
       "notFound": "You are currently venturing unknown space. In the event you are lost, the UEE highly recommends plotting a new destination back towards home-space.",
       "forbidden": "Your clearance does not cover this area. If a feature is still being rolled out, you can switch it on yourself under Settings > Features once it is available to you.",
       "featureNotReady": "This feature is not yet ready and will be available soon. Stay tuned!",
+      "inviteInvalid": "This invite link is not valid. It may have been mistyped, it may have expired, or it may have already reached its limit of uses. Ask whoever invited you for a new link.",
       "accessDenied": "You are not authorized to view this page.",
       "serverError": "The server is currently experiencing technical difficulties. Please try again later.",
       "compare": {

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -188,6 +188,7 @@
       "notFound": "Error de navegación",
       "forbidden": "Acceso denegado",
       "featureNotReady": "Próximamente",
+      "inviteInvalid": "Enlace de invitación no válido",
       "accessDenied": "Acceso denegado",
       "serverError": "Error del servidor",
       "comments": "Comentarios",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -124,6 +124,7 @@
         "publicShort": "Público"
       },
       "fleetInviteToken": "Invitación de flota",
+      "inviteToken": "Código de invitación",
       "scDataVersion": "Versión del parche",
       "createdAt": "Creado el",
       "updatedAt": "Actualizado el",

--- a/app/frontend/translations/es/messages.json
+++ b/app/frontend/translations/es/messages.json
@@ -307,7 +307,6 @@
       "fleetInvite": {
         "used": "<b>¡Solicitud de unión para %{fleet} enviada!</b><br>Una vez que tu membresía sea aceptada serás notificado por email",
         "failure": "La invitación no pudo ser utilizada.",
-        "notFound": "Invitación no encontrada.",
         "confirm": "¿Estás seguro de que quieres unirte a la Flota: \"%{fleet}\"?"
       },
       "holoViewer": {

--- a/app/frontend/translations/es/texts.json
+++ b/app/frontend/translations/es/texts.json
@@ -21,6 +21,7 @@
       "notFound": "You are currently venturing unknown space. In the event you are lost, the UEE highly recommends plotting a new destination back towards home-space.",
       "forbidden": "Tu autorización no cubre esta zona. Si una función se está desplegando todavía, podrás activarla tú mismo en Ajustes > Funciones en cuanto esté disponible.",
       "featureNotReady": "Esta función aún no está lista y estará disponible pronto. ¡Esté atento!",
+      "inviteInvalid": "Este enlace de invitación no es válido. Puede que se haya copiado mal, que haya caducado o que ya haya alcanzado su límite de usos. Pide un enlace nuevo a quien te invitó.",
       "accessDenied": "No está autorizado para ver esta página.",
       "serverError": "El servidor está experimentando dificultades técnicas. Inténtelo más tarde.",
       "compare": {

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -188,6 +188,7 @@
       "notFound": "Erreur de navigation",
       "forbidden": "Accès refusé",
       "featureNotReady": "Bientôt disponible",
+      "inviteInvalid": "Lien d'invitation invalide",
       "accessDenied": "Accès refusé",
       "serverError": "Erreur du serveur",
       "comments": "Commentaires",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -124,6 +124,7 @@
         "publicShort": "Public"
       },
       "fleetInviteToken": "invitation de la flotte",
+      "inviteToken": "Code d'invitation",
       "scDataVersion": "Version corrigée",
       "createdAt": "Créé le",
       "updatedAt": "Mis à jour le",

--- a/app/frontend/translations/fr/messages.json
+++ b/app/frontend/translations/fr/messages.json
@@ -307,7 +307,6 @@
       "fleetInvite": {
         "used": "<b>Demande d'adhésion pour %{fleet} envoyée !</b><br>Une fois votre adhésion acceptée, vous serez notifié par email",
         "failure": "L'invitation n'a pas pu être utilisée.",
-        "notFound": "Invitation non trouvée.",
         "confirm": "Êtes-vous sûr de vouloir rejoindre la flotte : \"%{fleet}\" ?"
       },
       "holoViewer": {

--- a/app/frontend/translations/fr/texts.json
+++ b/app/frontend/translations/fr/texts.json
@@ -21,6 +21,7 @@
       "notFound": "You are currently venturing unknown space. In the event you are lost, the UEE highly recommends plotting a new destination back towards home-space.",
       "forbidden": "Votre autorisation ne couvre pas cette zone. Si une fonctionnalité est en cours de déploiement, vous pourrez l'activer vous-même dans Paramètres > Fonctionnalités dès qu'elle sera disponible.",
       "featureNotReady": "Cette fonctionnalité n'est pas encore prête et sera bientôt disponible. Restez à l'écoute !",
+      "inviteInvalid": "Ce lien d'invitation n'est pas valide. Il a peut-être été mal recopié, il a peut-être expiré, ou il a peut-être déjà atteint sa limite d'utilisations. Demandez un nouveau lien à la personne qui vous a invité.",
       "accessDenied": "Vous n'êtes pas autorisé à consulter cette page.",
       "serverError": "Le serveur rencontre actuellement des difficultés techniques. Veuillez réessayer plus tard.",
       "compare": {

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -188,6 +188,7 @@
       "notFound": "Errore di Navigazione",
       "forbidden": "Accesso negato",
       "featureNotReady": "In arrivo",
+      "inviteInvalid": "Link di invito non valido",
       "accessDenied": "Accesso negato",
       "serverError": "Errore del server",
       "comments": "Commenti",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -124,6 +124,7 @@
         "publicShort": "Pubblico"
       },
       "fleetInviteToken": "Inviti Alla Flotta",
+      "inviteToken": "Codice di invito",
       "scDataVersion": "Versione Della Patch",
       "createdAt": "Creato il",
       "updatedAt": "Aggiornato il",

--- a/app/frontend/translations/it/messages.json
+++ b/app/frontend/translations/it/messages.json
@@ -306,7 +306,6 @@
       "fleetInvite": {
         "used": "<b>Richiesta di partecipazione a %{fleet} inviata!</b><br>Una volta che la tua iscrizione sarà accettata, sarai avvisato via email",
         "failure": "L'invito non può essere usato.",
-        "notFound": "Invito non trovato.",
         "confirm": "Sei sicuro di voler partecipare alla Flotta: \"%{fleet}\"?"
       },
       "holoViewer": {

--- a/app/frontend/translations/it/texts.json
+++ b/app/frontend/translations/it/texts.json
@@ -21,6 +21,7 @@
       "notFound": "Attualmente stai avventurando uno spazio sconosciuto. In caso di smarrimento, l'UEE raccomanda vivamente di tracciare una nuova destinazione di nuovo verso lo spazio di casa.",
       "forbidden": "La tua autorizzazione non copre quest'area. Se una funzione è ancora in distribuzione, potrai attivarla tu stesso in Impostazioni > Funzioni non appena sarà disponibile.",
       "featureNotReady": "Questa funzione non è ancora pronta e sarà disponibile a breve. Resta sintonizzato!",
+      "inviteInvalid": "Questo link di invito non è valido. Potrebbe essere stato copiato male, potrebbe essere scaduto oppure potrebbe aver già raggiunto il limite di utilizzi. Chiedi un nuovo link a chi ti ha invitato.",
       "accessDenied": "Non sei autorizzato a visualizzare questa pagina.",
       "serverError": "Il server sta riscontrando difficoltà tecniche. Riprova più tardi.",
       "compare": {

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -188,6 +188,7 @@
       "notFound": "导航错误",
       "forbidden": "拒绝访问",
       "featureNotReady": "即将推出",
+      "inviteInvalid": "邀请链接无效",
       "accessDenied": "拒绝访问",
       "serverError": "服务器错误",
       "comments": "评论",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -124,6 +124,7 @@
         "publicShort": "公开"
       },
       "fleetInviteToken": "舰队邀请",
+      "inviteToken": "邀请码",
       "scDataVersion": "补丁版本",
       "createdAt": "创建于",
       "updatedAt": "更新于",

--- a/app/frontend/translations/zh-CN/messages.json
+++ b/app/frontend/translations/zh-CN/messages.json
@@ -306,7 +306,6 @@
       "fleetInvite": {
         "used": "<b>%{fleet} 的加入请求已发送！</b><br>一旦您的会员资格被接受，您将通过电子邮件收到通知",
         "failure": "邀请无法使用。",
-        "notFound": "邀请未找到。",
         "confirm": "您确定要加入舰队：\"%{fleet}\"吗？"
       },
       "holoViewer": {

--- a/app/frontend/translations/zh-CN/texts.json
+++ b/app/frontend/translations/zh-CN/texts.json
@@ -21,6 +21,7 @@
       "notFound": "You are currently venturing unknown space. In the event you are lost, the UEE highly recommends plotting a new destination back towards home-space.",
       "forbidden": "你的权限不包含此区域。如果某项功能仍在灰度发布中，等它对你开放后，可以在“设置 > 功能”中自行开启。",
       "featureNotReady": "此功能尚未完成，即将推出。敬请期待！",
+      "inviteInvalid": "此邀请链接无效。可能是输入有误、已过期，或已达到使用次数上限。请向邀请你的人索取新的链接。",
       "accessDenied": "您无权查看此页面。",
       "serverError": "服务器当前遇到技术问题。请稍后再试。",
       "compare": {

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -188,6 +188,7 @@
       "notFound": "導航錯誤",
       "forbidden": "拒絕存取",
       "featureNotReady": "即將推出",
+      "inviteInvalid": "邀請連結無效",
       "accessDenied": "拒絕存取",
       "serverError": "伺服器錯誤",
       "comments": "評論",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -124,6 +124,7 @@
         "publicShort": "公開"
       },
       "fleetInviteToken": "艦隊邀請",
+      "inviteToken": "邀請碼",
       "scDataVersion": "補丁版本",
       "createdAt": "建立於",
       "updatedAt": "更新於",

--- a/app/frontend/translations/zh-TW/messages.json
+++ b/app/frontend/translations/zh-TW/messages.json
@@ -306,7 +306,6 @@
       "fleetInvite": {
         "used": "<b>已發送加入%{fleet}的申請！</b><br>一旦您的會員資格被接受，您將收到電子郵件通知",
         "failure": "邀請無法使用。",
-        "notFound": "找不到邀請。",
         "confirm": "您確定要加入艦隊：\"%{fleet}\"嗎？"
       },
       "holoViewer": {

--- a/app/frontend/translations/zh-TW/texts.json
+++ b/app/frontend/translations/zh-TW/texts.json
@@ -21,6 +21,7 @@
       "notFound": "You are currently venturing unknown space. In the event you are lost, the UEE highly recommends plotting a new destination back towards home-space.",
       "forbidden": "你的權限不包含此區域。如果某項功能仍在灰度發布中，等它對你開放後，可以在「設定 > 功能」中自行開啟。",
       "featureNotReady": "此功能尚未完成，即將推出。敬請期待！",
+      "inviteInvalid": "此邀請連結無效。可能是輸入有誤、已過期，或已達到使用次數上限。請向邀請你的人索取新的連結。",
       "accessDenied": "您無權檢視此頁面。",
       "serverError": "伺服器目前遇到技術問題。請稍後再試。",
       "compare": {

--- a/docs/exec-plans/3481-error-page-for-bad-invite-links.md
+++ b/docs/exec-plans/3481-error-page-for-bad-invite-links.md
@@ -1,0 +1,94 @@
+# Add an error page for bad invite links
+
+## Goal
+
+An invite link that is wrong, expired or used up renders a readable error state on the invite page itself, instead of a blank page and a toast the user is immediately redirected away from.
+
+## Context
+
+A reporter was given a wrong invite link by their org and saw a blank page. As an experienced user they assumed their browser or the site was broken and spent time debugging before an org member told them the link was bad.
+
+`app/frontend/frontend/pages/fleets/invite.vue` renders `<section class="container fleet-detail" />` — an element with no content — and does all of its communication through a transient `displayAlert` toast, after which it pushes the user to `home`. A missed toast leaves exactly the empty page from the issue screenshot, and the redirect means there is nothing left on screen to go back and read.
+
+Resolves #3481
+
+## Decisions
+
+### D1 — Render the failure on the page, do not redirect away from it
+
+The page already knows the lookup failed; it just has nothing to show for it. The *not found* case becomes a persistent state on the page instead of a toast plus `router.push({ name: "home" })`. A toast is the wrong instrument for a terminal state the user has to read and act on — it is gone in seconds, and the redirect removes the context that would explain it.
+
+### D2 — A fifth shared error component, not an inline composition
+
+Revised during implementation. The first draft composed the primitives inline in `invite.vue`, on the grounds that a component earns its place at the second caller. That was wrong about this codebase: `shared/components/` already holds four full-page error blocks — `NotFound`, `NotAuthorized`, `Forbidden`, `ServerError` — each with a single real caller, all four built from the same `Box` / `Text` / `Btn` shape, and all four rendered side by side under "Error Pages" in `pages/visual-tests/states.vue`.
+
+So the house pattern is one component per error state, and `InviteInvalid` becomes the fifth. It takes a `token` prop, which is the one thing that makes it differ from its siblings, and joins them on the visual-tests page — which is also the only way to eyeball it without a live invite link.
+
+### D3 — One message for all three causes
+
+`Api::V1::FleetsController#find_by_invite` resolves the token through `FleetInviteUrl.active.find_by!`, and `active` means *not expired* **and** *uses left*. A typo'd token, an expired link and an exhausted link are therefore indistinguishable to the client — all three arrive as a 404. The copy says the link is invalid or no longer valid rather than claiming which one it is.
+
+The reporter asked for the bad link to appear in the error box; showing the token satisfies that without the page having to reconstruct a URL.
+
+### D4 — Only the lookup becomes a page state
+
+Redeeming a valid invite (`handleFleetInvite`) keeps its toast and redirect. By that point the user has confirmed a real fleet, and a failure there is transient — a server error, a race — rather than a property of the link they were given. Turning it into the same terminal error state would misreport a retryable failure.
+
+### D5 — New keys go under `headlines`/`texts`, not `messages`
+
+`headlines.notFound` / `texts.notFound` and their `forbidden` and `featureNotReady` siblings are where full-page error copy already lives. The new keys join them. `messages.fleetInvite.notFound` has exactly one reference — the toast this change removes — so it goes with it.
+
+## What changed
+
+### Phase 1 — Error state on the invite page
+
+1. New `app/frontend/shared/components/InviteInvalid/index.vue`, following its four siblings, with a `token` prop and a scoped rule that breaks the token rather than letting it run out of the box.
+2. `invite.vue`: an `inviteInvalid` ref that the `findFleetByInvite` catch sets, in place of `displayAlert` + `router.push`; the component renders inside the existing `<section>`.
+3. Register it under "Error Pages" in `pages/visual-tests/states.vue`.
+4. Leave the confirm dialog and `handleFleetInvite` paths untouched.
+
+### Phase 2 — Copy in all seven locales
+
+5. Add `headlines.inviteInvalid`, `texts.inviteInvalid` and `labels.inviteToken` to all seven locales, hand-translated. Crowdin is not in use and `enableFallback` hides gaps, so an en-only key silently ships English to six locales.
+6. Remove `messages.fleetInvite.notFound` from all seven locales, its only caller being gone.
+
+All 28 translation files round-trip byte-identically through `json.dumps(indent=2, ensure_ascii=False)`, so the edits were scripted and the diff is exactly one line per file.
+
+## Intent Verification
+
+- [ ] **Bad token shows something** — opening `/fleets/invites/<garbage>/` renders a visible error box, not a blank page
+- [ ] **It stays on screen** — the page does not redirect to home behind the error
+- [ ] **Expired and exhausted links land there too** — an invite past `expires_after`, and one with `limit` used up, reach the same state
+- [ ] **The happy path is unchanged** — a valid invite still opens the join confirm dialog and joining still works
+- [ ] **The link is named** — the error box shows the token the user opened
+- [ ] **Seven locales** — both new keys exist in every locale directory, and the removed key is gone from all seven
+
+## Key files
+
+| File | Role |
+|------|------|
+| `app/frontend/frontend/pages/fleets/invite.vue` | The page; today an empty `<section>` plus toasts |
+| `app/frontend/shared/components/InviteInvalid/index.vue` | New; the fifth full-page error block |
+| `app/frontend/shared/components/NotFound/index.vue` | The pattern its four siblings establish |
+| `app/frontend/frontend/pages/visual-tests/states.vue` | Where the error blocks are rendered for eyeballing |
+| `app/frontend/frontend/pages/fleets/routes.ts` | Route `fleet-invite`, `needsAuthentication: true`, no `title` meta |
+| `app/controllers/api/v1/fleets_controller.rb` | `find_by_invite`, raises `RecordNotFound` → 404 |
+| `app/models/fleet_invite_url.rb` | `active` scope — the reason three causes collapse into one 404 |
+| `app/frontend/translations/*/headlines.json`, `texts.json`, `messages.json` | Copy, seven locales |
+
+## Not in scope (deferred)
+
+- **The `needsAuthentication: true` guard** — a logged-out visitor with a bad link is sent to login first and only meets this error after signing in. Whether an invite page should be readable while logged out is a separate product question.
+- **The backend's 404 body** — `find_by_invite` falls into a `rescue_from` that renders `messages.record_not_found.fleet` interpolated with `params[:slug]`, which is never a slug on this route. The client never reads the body, so this is cosmetic.
+- **Distinguishing expired from wrong** — would need the API to stop conflating them in `active`, and to answer differently for a token that exists but is spent. Worth doing only if the single message turns out to confuse people.
+
+## Discovery Log
+
+- **2026-09-10** Phases 1 and 2 implemented. `lint:js`, `format` and `lint:ts` green. D2 revised on contact with the code: the four existing error components make a fifth the conventional choice, not an inline composition. No spec added — all four siblings are presentational and untested, and the project's check for them is the visual-tests page.
+- **2026-09-10** Initial research and plan creation. Confirmed the blank page is the empty `<section>` in the template, not a failed render. Confirmed via `FleetInviteUrl.active` that wrong, expired and exhausted tokens are one indistinguishable 404. Confirmed `messages.fleetInvite.notFound` has a single caller.
+
+## Progress
+
+- [x] Phase 1 — Error state on the invite page
+- [x] Phase 2 — Copy in all seven locales
+- [ ] Manual check against a running dev server


### PR DESCRIPTION
Resolves #3481

A user was given a wrong invite link by their org and saw a blank page. As an experienced user they assumed their browser or the site was broken and went looking for a fault on their own machine, until an org member told them the link was bad.

The blank page was not a failed render — it is what `fleets/invite.vue` has always drawn. The template was `<section class="container fleet-detail" />`, an element with no content, and everything the page had to say went through a `displayAlert` toast followed by a redirect home. Miss the toast and there is nothing left on screen to explain anything.

## What changed

The lookup failing is a property of the link itself, so it now renders on the page instead of being a toast the reader is pushed away from. Redeeming a *valid* invite keeps its toast and redirect: by then the user has confirmed a real fleet, and a failure there is transient rather than something about the link.

`InviteInvalid` joins `NotFound`, `NotAuthorized`, `Forbidden` and `ServerError` in `shared/components/`, built from the same `Box` / `Text` / `Btn` shape, and takes its place in their line-up on the visual-tests states page — which is also the only way to look at it without a live invite link.

## One message for three causes

`find_by_invite` resolves the token through `FleetInviteUrl.active.find_by!`, and `active` means *not expired* **and** *uses left*. A mistyped token, an expired link and an exhausted one are indistinguishable to the client — all three arrive as one 404 — so the copy says the link is invalid or no longer valid rather than claiming which. The token is shown, which is what the reporter asked for when they suggested putting the bad link in the box.

## Notes

- Copy is hand-translated across all seven locales. `messages.fleetInvite.notFound` is removed; the toast was its only caller. All 28 translation files round-trip byte-identically through `json.dumps(indent=2, ensure_ascii=False)`, so the edits were scripted and the diff is exactly one line per file rather than a reformat.
- No spec: all four sibling error blocks are presentational and untested, and the project's check for them is the visual-tests page, where this one now sits.
- Deferred — a logged-out visitor with a bad link still meets the login screen first, because the route keeps `needsAuthentication: true`. Whether invite pages should be readable while logged out is a separate product question.

Plan: `docs/exec-plans/3481-error-page-for-bad-invite-links.md`

🤖
