### PR TITLE
fix(hangar): keep a loaner in step with the ship it belongs to

### DIFF
--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -273,10 +273,18 @@ class Vehicle < ApplicationRecord
   end
 
   def create_loaner(model_loaner)
-    existing_loaner = Vehicle.where(loaner: true, vehicle_id: id, model_id: model_loaner.id, wanted:, user_id:).first
+    # `vehicle_id` already ties the row to this parent, so scoping the lookup by
+    # `wanted` too only makes it miss the rows written under the previous value:
+    # the parent flips, a second set is created, and the first is stranded with
+    # a stale flag that then reaches fleets.
+    existing_loaner = Vehicle.where(loaner: true, vehicle_id: id, model_id: model_loaner.id, user_id:).first
 
     if existing_loaner.present?
-      existing_loaner.update(hidden: Vehicle.exists?(loaner: true, model_id: model_loaner.id, wanted:, user_id:, hidden: false))
+      existing_loaner.update(
+        wanted:,
+        hidden: Vehicle.where(loaner: true, model_id: model_loaner.id, wanted:, user_id:, hidden: false)
+          .where.not(id: existing_loaner.id).exists?
+      )
 
       return
     end

--- a/app/tasks/maintenance/repair_loaner_flags_task.rb
+++ b/app/tasks/maintenance/repair_loaner_flags_task.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Repairs the loaner rows two defects in `Vehicle#create_loaner` left behind.
+  #
+  # `wanted` used to be part of the existing-loaner lookup, so a ship moving
+  # between hangar and wishlist missed its own loaners, created a second set and
+  # stranded the first with a stale flag. A stranded row claiming `wanted: false`
+  # under a wishlisted parent then passed `update_fleet_vehicle_for_all` and
+  # reached the fleet.
+  #
+  # `hidden` was recomputed with a query that matched the row being recomputed,
+  # so a visible loaner answered "a visible loaner already exists" about itself
+  # and hid itself on the parent's next save. A user's only loaner disappeared
+  # after any second save of its parent.
+  #
+  # Runs per user rather than per row: `hidden` is a property of a whole
+  # (model, wanted) group -- exactly one visible -- and repairing rows one at a
+  # time in arbitrary order would hide all of them or leave several visible
+  # depending on the order they arrived in.
+  #
+  # A task rather than a data migration, for the reason `BackfillHardpointBuilds`
+  # records: `bin/deploy-release` runs `data:migrate` inside the Kamal pre-deploy
+  # hook, and this walks every loaner in the database.
+  #
+  # Re-runnable, and no `dry_run` attribute -- one defaulting to true makes a
+  # console run roll back silently while still reporting "succeeded".
+  class RepairLoanerFlagsTask < MaintenanceTasks::Task
+    def collection
+      User.where(id: Vehicle.where(loaner: true).select(:user_id))
+    end
+
+    def count
+      collection.count
+    end
+
+    def process(user)
+      loaners = Vehicle.where(loaner: true, user_id: user.id).includes(:parent_vehicle).to_a
+      return if loaners.empty?
+
+      touched = realign_wanted(loaners) | revisit_hidden(loaners)
+
+      touched.each { |loaner| schedule_fleet_update(loaner) }
+    end
+
+    # A loaner without a parent is not this task's business: nothing says what
+    # its `wanted` should be, and destroying it is a decision for whoever finds
+    # out how it got orphaned.
+    private def realign_wanted(loaners)
+      loaners.select do |loaner|
+        parent = loaner.parent_vehicle
+        next false if parent.nil? || loaner.wanted == parent.wanted
+
+        loaner.update_columns(wanted: parent.wanted, updated_at: Time.zone.now)
+        true
+      end
+    end
+
+    # One visible row per (model, wanted) group. The survivor is the one already
+    # visible where there is one, so a repair does not move which loaner a user
+    # sees when the group was correct apart from its neighbours.
+    private def revisit_hidden(loaners)
+      loaners.group_by { |loaner| [loaner.model_id, loaner.wanted] }.flat_map do |_group_key, group|
+        visible = group.find { |loaner| !loaner.hidden? } || group.first
+
+        group.select do |loaner|
+          should_hide = !loaner.equal?(visible)
+          next false if loaner.hidden? == should_hide
+
+          loaner.update_columns(hidden: should_hide, updated_at: Time.zone.now)
+          true
+        end
+      end
+    end
+
+    # `schedule_fleet_vehicle_update` is an `after_commit` that returns early for
+    # a hidden vehicle, and `update_columns` skips callbacks anyway. Both are why
+    # the fleet side is driven from here: a row we hide would otherwise keep the
+    # `FleetVehicle` this task exists to remove.
+    private def schedule_fleet_update(loaner)
+      Updater::FleetVehicleUpdateJob.perform_async(loaner.id)
+    end
+  end
+end

--- a/app/tasks/maintenance/repair_loaner_flags_task.rb
+++ b/app/tasks/maintenance/repair_loaner_flags_task.rb
@@ -25,6 +25,12 @@ module Maintenance
   #
   # Re-runnable, and no `dry_run` attribute -- one defaulting to true makes a
   # console run roll back silently while still reporting "succeeded".
+  #
+  # Nothing locks a parent against a concurrent save. `create_loaner` runs
+  # inside the parent's own transaction, so a flip landing mid-batch can leave
+  # one loaner holding the `wanted` read at the start of that user's rows --
+  # the value it already holds today, corrected by the parent's next save or by
+  # a re-run. Locking every parent would block real saves behind a batch job.
   class RepairLoanerFlagsTask < MaintenanceTasks::Task
     def collection
       User.where(id: Vehicle.where(loaner: true).select(:user_id))

--- a/docs/exec-plans/2469-loaner-wanted-drifts-from-parent.md
+++ b/docs/exec-plans/2469-loaner-wanted-drifts-from-parent.md
@@ -1,0 +1,126 @@
+# Wrongfully attributed loaners in fleet view
+
+## Goal
+
+`Vehicle#create_loaner` stops stranding rows when a ship moves between hangar and wishlist, and stops hiding the loaner it just found, so a user's loaners reflect the ships they actually hold — with the rows already damaged repaired.
+
+## Context
+
+Reported three years ago against a real fleet. Two symptoms, which turn out to be two distinct bugs sitting in the same five-line method:
+
+> all the loaners on the list were considered to be commanded by myself […] they were loaners from unpurchased ships
+
+> when I removed my ships from the fleet we had no loaners that showed up at all
+
+Both were dismissed at the time as "the underlying loaner system makes this very complicated". They are not complicated; the method one screen further down the same file already does both things correctly.
+
+I first triaged this as fixed by reading the code — `create_loaner` does copy `wanted` from its parent — and had to retract that publicly. It copies `wanted` **at creation only**. Only the data shows the drift.
+
+Resolves #2469
+
+### The evidence
+
+`create_bundled_snub_craft` is the same relationship — a child vehicle derived from a parent — implemented without the defect. Measured on a production snapshot, 2026-09-10:
+
+| | rows | child disagrees with parent | share |
+|---|---:|---:|---:|
+| `bundled` (no `wanted:` in the lookup) | 6,218 | 1 | 0.02% |
+| `loaner` (`wanted:` in the lookup) | 584,809 | 54,429 | **9.31%** |
+
+Of those 54,429, the 36,418 with a wishlisted parent and `wanted: false` on themselves are the ones that reach fleets, because `FleetMembership#update_fleet_vehicle_for_all` consults the loaner row's own flag.
+
+Separately, grouping every user's loaners by model and wishlist state:
+
+| | groups |
+|---|---:|
+| one loaner, visible | 148,253 |
+| **one loaner, hidden** | **115,983** |
+| several loaners, all hidden | 24,981 |
+
+A lone loaner has nothing to be deduplicated against, so 140,964 groups where the user should see a loaner and sees none.
+
+## Decisions
+
+### D1 — Drop `wanted:` from the lookup and sync it, mirroring the sibling
+
+```ruby
+existing_loaner = Vehicle.where(loaner: true, vehicle_id: id, model_id: model_loaner.id, wanted:, user_id:).first
+```
+
+`vehicle_id` already ties the row to this one parent, so `wanted:` narrows nothing legitimate — it only makes the lookup miss rows written under the previous value. The method then creates a second set and leaves the first behind; `remove_loaners` runs `after_destroy`, so nothing reconciles them.
+
+`create_bundled_snub_craft` omits `wanted:` from its lookup and assigns it when it differs. Adopting that shape is a change *towards* the file's own convention, and the 0.02%-versus-9.31% split is the measurement that the shape is the thing that matters.
+
+### D2 — The `hidden` recomputation has to exclude the row it is about
+
+```ruby
+existing_loaner.update(hidden: Vehicle.exists?(loaner: true, model_id:, wanted:, user_id:, hidden: false))
+```
+
+On the create path this is right: the row does not exist yet, so the question "is a visible loaner of this model already here?" is well posed. On the update path the row *is* in that set, so a visible loaner answers `true` about itself and hides itself. Any second save of the parent — a rename is enough — makes a user's only loaner disappear.
+
+`remove_loaners` already writes the correct form, `.where.not(id: loaner_vehicle.id)`. So this too is a change towards an existing convention rather than a new idea.
+
+### D3 — Repair as a maintenance task, not a data migration
+
+`bin/deploy-release` runs `data:migrate` inside the Kamal pre-deploy hook, so a migration touching ~585k rows would sit in the deploy's critical path. `BackfillHardpointBuildsTask` records this reasoning and `app/tasks/maintenance/` is where its siblings live.
+
+No `dry_run` attribute: one defaulting to true rolls a console run back silently while still reporting "succeeded".
+
+### D4 — The repair drives the fleet side explicitly
+
+`schedule_fleet_vehicle_update` is `after_commit` and returns early when `hidden?`. Repairing a row that stays hidden would therefore fix the vehicle and leave its stale `FleetVehicle` behind. The task enqueues the update itself rather than relying on the callback.
+
+### D5 — Scope stays at these two bugs
+
+The reporter also raised loaners against hangar groups. That part works now: `update_fleet_vehicle_for_hangar_group` unions the parent's `hangar_group_ids` into the loaner's. Nothing to do.
+
+## What changed
+
+### Phase 1 — `create_loaner`
+1. Remove `wanted:` from the existing-loaner lookup.
+2. Assign `wanted:` on the found row, alongside `hidden`.
+3. Exclude the row itself from the `hidden` recomputation.
+
+### Phase 2 — Tests
+4. A `VehicleLoanersTest` mirroring `VehicleBundledSnubCraftsTest`, which already covers auto-creation, idempotence on re-save, the `wanted` cascade and destruction — the loaner side has none of these.
+5. Two regression tests naming the bugs: a parent flipping `wanted` leaves exactly one loaner carrying the new value, and re-saving a parent does not hide a sole loaner.
+
+### Phase 3 — Repair task
+6. `Maintenance::RepairLoanerFlagsTask` — realign `wanted` with the parent, recompute `hidden` per (user, model, wanted) group, and enqueue the fleet-vehicle update for every row it touches.
+
+## Intent Verification
+
+- [ ] **Flipping does not strand** — moving a ship to the wishlist and back leaves one loaner per parent+model, carrying the parent's current value
+- [ ] **A lone loaner stays visible** — saving a parent twice does not hide its only loaner
+- [ ] **Deduplication still works** — a second parent loaning the same model still yields exactly one visible loaner
+- [ ] **Fleets follow** — a loaner whose parent is wishlisted leaves the fleet
+- [ ] **The repair converges** — after the task, zero loaner rows disagree with their parent, and no group of one is hidden
+- [ ] **The repair is re-runnable** — a second run changes nothing
+
+## Key files
+
+| File | Role |
+|------|------|
+| `app/models/vehicle.rb` | `create_loaner`, and `create_bundled_snub_craft` as the correct sibling |
+| `app/models/fleet_membership.rb` | `update_fleet_vehicle_for_all` reads the loaner's own `wanted` |
+| `test/models/vehicle_test.rb` | `VehicleBundledSnubCraftsTest`, the shape the loaner tests mirror |
+| `app/tasks/maintenance/` | Repair task, beside its backfill siblings |
+
+## Not in scope (deferred)
+
+- **Loaners against hangar groups** — already correct, see D5.
+- **The 18,011 rows with a hangar parent and a wishlisted loaner** — the mirror image of the leak, harmless in fleets because the filter drops them anyway, but repaired by the same task.
+- **Making `hidden` a derived value** rather than a stored column, which is what would prevent this class of bug outright. A much larger change than the report warrants.
+
+## Discovery Log
+
+- **2026-09-10** Phases 1-3 implemented. Verified the regression tests earn their place by reverting the fix: `cascades wanted state`, `flipping wanted back and forth` and `re-saving does not hide its only loaner` fail on the old method (2 loaners where 1 is expected, twice; `hidden` true where false is expected), and the five tests covering behaviour that already worked stay green. `bin/ruby-lint` clean.
+- **2026-09-10** Research. Confirmed the drift and its mechanism against the production snapshot, and found the second bug — the `hidden` self-hit — while reading the same method. Confirmed `create_bundled_snub_craft` is the same relationship done correctly, and that its data is clean, which is what makes the fix a convention alignment rather than a guess.
+
+## Progress
+
+- [x] Phase 1 — `create_loaner`
+- [x] Phase 2 — Tests
+- [x] Phase 3 — Repair task
+- [ ] Run the repair in production after the fix ships

--- a/docs/exec-plans/2469-loaner-wanted-drifts-from-parent.md
+++ b/docs/exec-plans/2469-loaner-wanted-drifts-from-parent.md
@@ -9,7 +9,7 @@
 Reported three years ago against a real fleet. Two symptoms, which turn out to be two distinct bugs sitting in the same five-line method:
 
 > all the loaners on the list were considered to be commanded by myself […] they were loaners from unpurchased ships
-
+>
 > when I removed my ships from the fleet we had no loaners that showed up at all
 
 Both were dismissed at the time as "the underlying loaner system makes this very complicated". They are not complicated; the method one screen further down the same file already does both things correctly.

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -106,6 +106,94 @@ class VehicleBundledSnubCraftsTest < ActiveSupport::TestCase
   end
 end
 
+class VehicleLoanersTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    @loaner_model = create(:model)
+    @parent_model = create(:model).tap { |m| m.loaners << @loaner_model }
+  end
+
+  test "auto-creates a loaner for each model.loaners entry" do
+    assert_difference -> { Vehicle.where(loaner: true, user_id: @user.id).count }, 1 do
+      create(:vehicle, user: @user, model: @parent_model, wanted: false)
+    end
+
+    loaner = Vehicle.find_by(loaner: true, user_id: @user.id)
+    assert_equal @loaner_model.id, loaner.model_id
+    assert_equal false, loaner.wanted
+  end
+
+  test "is idempotent: re-saving the parent does not duplicate the loaner" do
+    parent = create(:vehicle, user: @user, model: @parent_model, wanted: false)
+
+    assert_no_difference -> { Vehicle.where(loaner: true, vehicle_id: parent.id).count } do
+      parent.update!(name: "Renamed")
+    end
+  end
+
+  test "cascades wanted state to the loaner" do
+    parent = create(:vehicle, user: @user, model: @parent_model, wanted: false)
+
+    parent.update!(wanted: true)
+
+    loaners = Vehicle.where(loaner: true, vehicle_id: parent.id)
+    assert_equal 1, loaners.count
+    assert_equal true, loaners.first.wanted
+  end
+
+  # The lookup used to be scoped by `wanted`, so a flip missed the existing row,
+  # created a second one and stranded the first with the old value -- which is
+  # what put loaners of wishlisted ships into fleets.
+  test "flipping wanted back and forth strands no loaner" do
+    parent = create(:vehicle, user: @user, model: @parent_model, wanted: false)
+
+    parent.update!(wanted: true)
+    parent.update!(wanted: false)
+
+    loaners = Vehicle.where(loaner: true, vehicle_id: parent.id)
+    assert_equal 1, loaners.count
+    assert_equal false, loaners.first.wanted
+  end
+
+  # The `hidden` recomputation matched the row it was about, so a visible loaner
+  # answered "yes, a visible loaner exists" about itself and hid itself on the
+  # parent's next save.
+  test "re-saving the parent does not hide its only loaner" do
+    parent = create(:vehicle, user: @user, model: @parent_model, wanted: false)
+    assert_equal false, Vehicle.find_by(loaner: true, vehicle_id: parent.id).hidden
+
+    parent.update!(name: "Renamed")
+
+    assert_equal false, Vehicle.find_by(loaner: true, vehicle_id: parent.id).hidden
+  end
+
+  test "keeps exactly one visible loaner when two parents loan the same model" do
+    other_parent_model = create(:model).tap { |m| m.loaners << @loaner_model }
+
+    create(:vehicle, user: @user, model: @parent_model, wanted: false)
+    create(:vehicle, user: @user, model: other_parent_model, wanted: false)
+
+    loaners = Vehicle.where(loaner: true, user_id: @user.id, model_id: @loaner_model.id)
+    assert_equal 2, loaners.count
+    assert_equal 1, loaners.where(hidden: false).count
+  end
+
+  test "destroys loaners when the parent is destroyed" do
+    parent = create(:vehicle, user: @user, model: @parent_model, wanted: false)
+    assert_equal 1, Vehicle.where(loaner: true, vehicle_id: parent.id).count
+
+    parent.destroy
+
+    assert_equal 0, Vehicle.where(loaner: true, vehicle_id: parent.id).count
+  end
+
+  test "does not create loaners for a loaner vehicle" do
+    loaner_parent = create(:vehicle, :loaner, user: @user, model: @parent_model)
+
+    assert_empty Vehicle.where(loaner: true, vehicle_id: loaner_parent.id)
+  end
+end
+
 class VehicleScheduleFleetVehicleUpdateTest < ActiveSupport::TestCase
   setup do
     @vehicle = create(:vehicle)

--- a/test/tasks/maintenance/repair_loaner_flags_task_test.rb
+++ b/test/tasks/maintenance/repair_loaner_flags_task_test.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Maintenance
+  class RepairLoanerFlagsTaskTest < ActiveSupport::TestCase
+    setup do
+      @task = ::Maintenance::RepairLoanerFlagsTask.new
+      @user = create(:user)
+      @loaner_model = create(:model)
+      @parent_model = create(:model).tap { |m| m.loaners << @loaner_model }
+    end
+
+    test "#collection is the users owning a loaner and nobody else" do
+      create(:vehicle, user: @user, model: @parent_model, wanted: false)
+      without_loaners = create(:user)
+
+      ids = @task.collection.pluck(:id)
+
+      assert_includes ids, @user.id
+      assert_not_includes ids, without_loaners.id
+    end
+
+    # The stranded row the old lookup left behind: it claims the hangar while the
+    # ship it hangs off is wishlisted, which is what let it reach a fleet.
+    test "#process realigns a loaner whose wanted disagrees with its parent" do
+      parent = create(:vehicle, user: @user, model: @parent_model, wanted: true)
+      loaner = Vehicle.find_by(loaner: true, vehicle_id: parent.id)
+      loaner.update_columns(wanted: false)
+
+      @task.process(@user)
+
+      assert_equal true, loaner.reload.wanted
+    end
+
+    test "#process leaves an orphaned loaner alone" do
+      orphan = create(:vehicle, :loaner, user: @user, model: @loaner_model, wanted: false)
+      orphan.update_columns(vehicle_id: nil)
+
+      @task.process(@user)
+
+      assert_nil orphan.reload.vehicle_id
+      assert_equal false, orphan.wanted
+    end
+
+    # The self-hit: a sole loaner answered "a visible loaner already exists"
+    # about itself and hid itself.
+    test "#process unhides a sole loaner" do
+      parent = create(:vehicle, user: @user, model: @parent_model, wanted: false)
+      loaner = Vehicle.find_by(loaner: true, vehicle_id: parent.id)
+      loaner.update_columns(hidden: true)
+
+      @task.process(@user)
+
+      assert_equal false, loaner.reload.hidden
+    end
+
+    test "#process leaves exactly one loaner of a model visible" do
+      other_parent_model = create(:model).tap { |m| m.loaners << @loaner_model }
+      create(:vehicle, user: @user, model: @parent_model, wanted: false)
+      create(:vehicle, user: @user, model: other_parent_model, wanted: false)
+      Vehicle.where(loaner: true, user_id: @user.id).update_all(hidden: false)
+
+      @task.process(@user)
+
+      loaners = Vehicle.where(loaner: true, user_id: @user.id, model_id: @loaner_model.id)
+      assert_equal 2, loaners.count
+      assert_equal 1, loaners.where(hidden: false).count
+    end
+
+    # Hangar and wishlist are separate lists, so one of each stays visible.
+    test "#process keeps a visible loaner per wanted state" do
+      other_parent_model = create(:model).tap { |m| m.loaners << @loaner_model }
+      create(:vehicle, user: @user, model: @parent_model, wanted: false)
+      create(:vehicle, user: @user, model: other_parent_model, wanted: true)
+
+      @task.process(@user)
+
+      loaners = Vehicle.where(loaner: true, user_id: @user.id, model_id: @loaner_model.id)
+      assert_equal 1, loaners.where(hidden: false, wanted: false).count
+      assert_equal 1, loaners.where(hidden: false, wanted: true).count
+    end
+
+    test "#process does not move which loaner is visible when the group is already correct" do
+      other_parent_model = create(:model).tap { |m| m.loaners << @loaner_model }
+      create(:vehicle, user: @user, model: @parent_model, wanted: false)
+      create(:vehicle, user: @user, model: other_parent_model, wanted: false)
+      visible_before = Vehicle.find_by(loaner: true, user_id: @user.id, hidden: false)
+
+      @task.process(@user)
+
+      assert_equal visible_before.id, Vehicle.find_by(loaner: true, user_id: @user.id, hidden: false).id
+    end
+
+    test "#process is idempotent" do
+      parent = create(:vehicle, user: @user, model: @parent_model, wanted: true)
+      Vehicle.find_by(loaner: true, vehicle_id: parent.id).update_columns(wanted: false, hidden: true)
+
+      @task.process(@user)
+      first_pass = Vehicle.where(loaner: true, user_id: @user.id).pluck(:id, :wanted, :hidden).sort
+
+      @task.process(@user)
+
+      assert_equal first_pass, Vehicle.where(loaner: true, user_id: @user.id).pluck(:id, :wanted, :hidden).sort
+    end
+
+    test "#process schedules a fleet update for every row it touches" do
+      parent = create(:vehicle, user: @user, model: @parent_model, wanted: true)
+      loaner = Vehicle.find_by(loaner: true, vehicle_id: parent.id)
+      loaner.update_columns(wanted: false)
+
+      Updater::FleetVehicleUpdateJob.jobs.clear
+      @task.process(@user)
+
+      assert_includes Updater::FleetVehicleUpdateJob.jobs.map { |job| job["args"].first }, loaner.id
+    end
+
+    test "#process schedules nothing when there is nothing to repair" do
+      create(:vehicle, user: @user, model: @parent_model, wanted: false)
+
+      Updater::FleetVehicleUpdateJob.jobs.clear
+      @task.process(@user)
+
+      assert_empty Updater::FleetVehicleUpdateJob.jobs
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2469

Reported three years ago and set aside as "the underlying loaner system gets very complicated". It is not complicated: two bugs share a five-line method, and the method one screen further down the same file already does both things correctly.

Worth saying plainly — I first triaged this as already fixed by reading the code, because `create_loaner` *does* copy `wanted` from its parent. It copies it **at creation only**. Only the data showed the drift, and the wrong call had to be retracted on the issue.

## The two bugs

**`wanted` drifts.** The existing-loaner lookup was scoped by the parent's *current* `wanted`:

```ruby
Vehicle.where(loaner: true, vehicle_id: id, model_id: model_loaner.id, wanted:, user_id:).first
```

`vehicle_id` already ties the row to one parent, so `wanted` narrowed nothing legitimate — it only made the lookup miss rows written under the previous value. A ship moving between hangar and wishlist therefore got a second set of loaners while the first was stranded with a stale flag. `remove_loaners` runs `after_destroy`, so nothing reconciled them. A stranded row claiming the hangar under a wishlisted parent passes `update_fleet_vehicle_for_all` and reaches the fleet — the reporter's *"loaners from unpurchased ships"*.

**A sole loaner hides itself.** `hidden` was recomputed with a query that matched the row being recomputed. On the create path that is well posed, since the row does not exist yet. On the update path a visible loaner answers "a visible loaner already exists" about itself and hides itself. Any second save of the parent — a rename is enough — makes a user's only loaner vanish. That is the reporter's other symptom: *"we had no loaners that showed up at all"*.

## Why this shape of fix

`create_bundled_snub_craft` is the same relationship — a child vehicle derived from a parent — written without either defect. Measured on a production snapshot:

| | rows | child disagrees with parent | share |
|---|---:|---:|---:|
| `bundled` (no `wanted` in the lookup) | 6,218 | 1 | 0.02% |
| `loaner` (`wanted` in the lookup) | 584,809 | 54,429 | **9.31%** |

And `remove_loaners` already writes the correct exclusion, `.where.not(id: ...)`. So both changes adopt a form this file already contains rather than inventing one.

## Blast radius

Of the 54,429 drifted rows, **36,418** have a wishlisted parent while claiming the hangar — those are the ones in fleets today. Grouping every user's loaners by model and wishlist state also turns up **115,983** groups holding a single loaner that is hidden, plus 24,981 groups hidden entirely: 140,964 places where a user should see a loaner and sees none.

`Maintenance::RepairLoanerFlagsTask` fixes both, per user rather than per row — `hidden` is a property of a whole group, so repairing rows individually in arbitrary order would hide all of them or leave several visible depending on the order they arrived in. It drives the fleet update itself, because `schedule_fleet_vehicle_update` returns early for a hidden vehicle and would otherwise leave the `FleetVehicle` the repair exists to remove.

**This wants running after the fix ships.** The code change stops new damage; it does not undo the existing rows.

## Tests

`VehicleLoanersTest` mirrors `VehicleBundledSnubCraftsTest`, which covered auto-creation, idempotence, the `wanted` cascade and destruction for bundled children while the loaner side had none of it.

I checked the three regression tests earn their place by reverting the fix and re-running: `cascades wanted state`, `flipping wanted back and forth` and `re-saving does not hide its only loaner` fail on the old method — two loaners where one is expected, twice, and `hidden` true where false is expected — while the five tests covering behaviour that already worked stay green.

675 tests across `test/models/` and `test/tasks/` pass. `bin/ruby-lint` clean.

## Not in scope

- Loaners against hangar groups, the third thing the report raised — that part works now, `update_fleet_vehicle_for_hangar_group` unions the parent's groups into the loaner's.
- Making `hidden` derived rather than stored, which is what would prevent this class of bug outright. Much larger than the report warrants.

Plan: `docs/exec-plans/2469-loaner-wanted-drifts-from-parent.md`

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loaner vehicle handling when vehicles move between hangar and wishlist states.
  * Prevented duplicate or incorrectly hidden loaners.
  * Added a maintenance task to repair existing loaner visibility and wishlist-state inconsistencies.
  * Fleet updates are now scheduled for repaired loaners.

* **Tests**
  * Added coverage for loaner creation, state changes, deduplication, visibility, cleanup, and repair-task behavior.

* **Documentation**
  * Documented the loaner-state issue, resolution, verification plan, and maintenance strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->