### PR TITLE
feat(oauth): open application registration, gated by admin approval

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/oauth_application_reject_bulk_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/oauth_application_reject_bulk_input.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class OauthApplicationRejectBulkInput
+          include OpenapiRuby::Components::Base
+
+          schema({
+            type: :object,
+            properties: {
+              rejectionReason: {type: :string},
+              ids: {type: :array, items: {type: :string, format: :uuid}},
+              all: {
+                type: :boolean,
+                default: false,
+                description: "Apply to every application matching `q` instead of `ids`."
+              },
+              q: ::Admin::V1::Schemas::Queries::OauthApplicationQuery
+            },
+            additionalProperties: false,
+            required: %w[rejectionReason],
+            description: "Naming neither `ids` nor `all` selects nothing."
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/inputs/oauth_application_reject_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/oauth_application_reject_input.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      module Inputs
+        class OauthApplicationRejectInput
+          include OpenapiRuby::Components::Base
+
+          # The reason is what the owner is shown, so it is required here rather
+          # than optional with a validation waiting behind it.
+          schema({
+            type: :object,
+            properties: {
+              rejectionReason: {type: :string}
+            },
+            additionalProperties: false,
+            required: %w[rejectionReason]
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/oauth_application.rb
+++ b/app/api_components/admin/v1/schemas/oauth_application.rb
@@ -18,11 +18,17 @@ module Admin
             scopes: {type: :string},
             ownerName: {type: :string},
             ownerId: {type: :string, format: :uuid},
+            state: {type: :string, enum: %w[pending approved rejected]},
+            rejectionReason: {type: [:string, :null]},
+            approvedAt: {type: [:string, :null], format: "date-time"},
+            rejectedAt: {type: [:string, :null], format: "date-time"},
+            reviewedByName: {type: [:string, :null]},
+            logo: ::Shared::V1::Schemas::MediaFile,
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id name uid secret confidential redirectUri scopes createdAt updatedAt]
+          required: %w[id name uid secret confidential redirectUri scopes state createdAt updatedAt]
         })
       end
     end

--- a/app/api_components/admin/v1/schemas/oauth_application_bulk_result.rb
+++ b/app/api_components/admin/v1/schemas/oauth_application_bulk_result.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Admin
+  module V1
+    module Schemas
+      class OauthApplicationBulkResult
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            count: {type: :integer}
+          },
+          additionalProperties: false,
+          required: %w[count]
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/admin/v1/schemas/queries/oauth_application_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/oauth_application_query.rb
@@ -11,7 +11,8 @@ module Admin
             type: :object,
             properties: {
               nameCont: {type: :string},
-              ownerIdEq: {type: :string, format: :uuid}
+              ownerIdEq: {type: :string, format: :uuid},
+              aasmStateEq: {type: :string, enum: %w[pending approved rejected]}
             },
             additionalProperties: false,
             example: {}

--- a/app/api_components/oauth/v1/schemas/oauth_pre_authorization.rb
+++ b/app/api_components/oauth/v1/schemas/oauth_pre_authorization.rb
@@ -12,6 +12,16 @@ module Oauth
             clientId: {type: :string},
             clientName: {type: :string},
             redirectUri: {type: :string},
+            clientLogo: {
+              type: :object,
+              properties: {
+                url: {type: :string, format: :uri},
+                smallUrl: {type: :string, format: :uri},
+                mediumUrl: {type: :string, format: :uri}
+              },
+              additionalProperties: false,
+              required: %w[url]
+            },
             state: {type: :string},
             responseType: {type: :string},
             responseMode: {type: :string},

--- a/app/api_components/v1/schemas/inputs/oauth_application_input.rb
+++ b/app/api_components/v1/schemas/inputs/oauth_application_input.rb
@@ -12,6 +12,7 @@ module V1
             name: {type: :string},
             redirectUri: {type: :string},
             confidential: {type: :boolean},
+            logo: {type: [:string, :null]},
             scopes: {type: :array, items: {type: :string}}
           },
           additionalProperties: false,

--- a/app/api_components/v1/schemas/inputs/oauth_application_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/oauth_application_update_input.rb
@@ -12,6 +12,7 @@ module V1
             name: {type: [:string, :null]},
             redirectUri: {type: [:string, :null]},
             confidential: {type: :boolean},
+            logo: {type: [:string, :null]},
             scopes: {type: [:array, :null], items: {type: :string}}
           },
           additionalProperties: false

--- a/app/api_components/v1/schemas/oauth_application.rb
+++ b/app/api_components/v1/schemas/oauth_application.rb
@@ -14,11 +14,14 @@ module V1
           confidential: {type: :boolean},
           redirectUri: {type: :string},
           scopes: {type: :string},
+          state: {type: :string, enum: %w[pending approved rejected]},
+          rejectionReason: {type: [:string, :null]},
+          logo: ::Shared::V1::Schemas::MediaFile,
           createdAt: {type: :string, format: "date-time"},
           updatedAt: {type: :string, format: "date-time"}
         },
         additionalProperties: false,
-        required: %w[id name uid confidential redirectUri scopes createdAt updatedAt]
+        required: %w[id name uid confidential redirectUri scopes state createdAt updatedAt]
       })
     end
   end

--- a/app/api_components/v1/schemas/oauth_application_with_secret.rb
+++ b/app/api_components/v1/schemas/oauth_application_with_secret.rb
@@ -15,11 +15,14 @@ module V1
           confidential: {type: :boolean},
           redirectUri: {type: :string},
           scopes: {type: :string},
+          state: {type: :string, enum: %w[pending approved rejected]},
+          rejectionReason: {type: [:string, :null]},
+          logo: ::Shared::V1::Schemas::MediaFile,
           createdAt: {type: :string, format: "date-time"},
           updatedAt: {type: :string, format: "date-time"}
         },
         additionalProperties: false,
-        required: %w[id name uid secret confidential redirectUri scopes createdAt updatedAt]
+        required: %w[id name uid secret confidential redirectUri scopes state createdAt updatedAt]
       })
     end
   end

--- a/app/controllers/admin/api/v1/oauth_applications_controller.rb
+++ b/app/controllers/admin/api/v1/oauth_applications_controller.rb
@@ -4,7 +4,7 @@ module Admin
   module Api
     module V1
       class OauthApplicationsController < ::Admin::Api::BaseController
-        before_action :set_application, only: %i[show update destroy]
+        before_action :set_application, only: %i[show update destroy approve reject]
 
         def index
           authorize! with: ::Admin::OauthApplicationPolicy
@@ -27,6 +27,8 @@ module Admin
 
           authorize! @oauth_application, with: ::Admin::OauthApplicationPolicy
 
+          @oauth_application.approve
+
           if @oauth_application.save
             render :show, status: :created
           else
@@ -38,6 +40,30 @@ module Admin
           return if @oauth_application.update(oauth_application_params)
 
           render json: ValidationError.new("oauth_application.update", errors: @oauth_application.errors), status: :bad_request
+        end
+
+        def approve
+          @oauth_application.reviewed_by = current_admin_user
+          @oauth_application.approve
+
+          return render :show if @oauth_application.save
+
+          render json: ValidationError.new("oauth_application.approve", errors: @oauth_application.errors), status: :bad_request
+        end
+
+        # The reason is what the owner is shown, so a refusal without one is
+        # rejected here rather than saved as an unexplained state.
+        def reject
+          @oauth_application.assign_attributes(
+            reviewed_by: current_admin_user,
+            rejection_reason: params[:rejectionReason].presence || params[:rejection_reason].presence
+          )
+
+          @oauth_application.reject
+
+          return render :show if @oauth_application.save
+
+          render json: ValidationError.new("oauth_application.reject", errors: @oauth_application.errors), status: :bad_request
         end
 
         def destroy
@@ -60,7 +86,8 @@ module Admin
         private def oauth_application_query_params
           params.fetch(:q, {}).permit(
             :name_cont,
-            :owner_id_eq
+            :owner_id_eq,
+            :aasm_state_eq
           )
         end
       end

--- a/app/controllers/admin/api/v1/oauth_applications_controller.rb
+++ b/app/controllers/admin/api/v1/oauth_applications_controller.rb
@@ -66,10 +66,51 @@ module Admin
           render json: ValidationError.new("oauth_application.reject", errors: @oauth_application.errors), status: :bad_request
         end
 
+        # Clearing a spree has to be one action rather than fifty. `update_all`
+        # skips validations and callbacks, so every column the reject event
+        # would have written is named here -- a state without its reason is the
+        # unexplained refusal this whole feature exists to avoid.
+        def reject_bulk
+          authorize! with: ::Admin::OauthApplicationPolicy
+
+          reason = params[:rejectionReason].presence || params[:rejection_reason].presence
+
+          if reason.blank?
+            render json: ValidationError.new("oauth_application.reject", message: I18n.t("validation_error.oauth_application.reject")), status: :bad_request
+            return
+          end
+
+          @count = bulk_selection.update_all(
+            aasm_state: "rejected",
+            rejected_at: Time.current,
+            approved_at: nil,
+            rejection_reason: reason,
+            reviewed_by_id: current_admin_user.id,
+            updated_at: Time.current
+          )
+
+          render :reject_bulk
+        end
+
         def destroy
           return if @oauth_application.destroy
 
           render json: ValidationError.new("oauth_application.destroy", errors: @oauth_application.errors), status: :bad_request
+        end
+
+        # The reader either ticked rows or asked for everything the current filter
+        # matches, and `all` has to say so out loud. A body naming neither
+        # selects nothing rather than everything.
+        private def bulk_selection
+          return filtered_scope if ActiveModel::Type::Boolean.new.cast(params[:all])
+
+          Oauth::Application.where(id: Array(params[:ids]))
+        end
+
+        # The list the index would return, without paging and without ordering --
+        # PostgreSQL refuses an ORDER BY in an UPDATE.
+        private def filtered_scope
+          Oauth::Application.ransack(oauth_application_query_params.except("sorts")).result.reorder(nil)
         end
 
         private def set_application

--- a/app/controllers/api/v1/oauth_applications_controller.rb
+++ b/app/controllers/api/v1/oauth_applications_controller.rb
@@ -67,7 +67,7 @@ module Api
 
       private def application_params
         @application_params ||= params.transform_keys(&:underscore)
-          .permit(:name, :redirect_uri, :confidential, scopes: [])
+          .permit(:name, :redirect_uri, :confidential, :logo, scopes: [])
       end
 
       private def check_feature_flag

--- a/app/frontend/admin/components/OauthApplications/Actions/Items.vue
+++ b/app/frontend/admin/components/OauthApplications/Actions/Items.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import {
   type OauthApplication,
+  useApproveOauthApplication,
   useDestroyOauthApplication,
   getOauthApplicationsQueryKey,
 } from "@/services/fyAdminApi";
@@ -15,6 +16,7 @@ import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { useBreadCrumbs } from "@/shared/composables/useBreadCrumbs";
+import { useComlink } from "@/shared/composables/useComlink";
 
 type Props = {
   oauthApplication: OauthApplication;
@@ -29,7 +31,32 @@ const { t } = useI18n();
 const { displayConfirm } = useAppNotifications();
 const { extend } = useBreadCrumbs();
 
+const comlink = useComlink();
 const queryClient = useQueryClient();
+
+const approveMutation = useApproveOauthApplication();
+
+// Approving is offered whenever the application is not already approved, so a
+// refusal can be taken back without a separate control.
+const canApprove = computed(() => props.oauthApplication.state !== "approved");
+const canReject = computed(() => props.oauthApplication.state !== "rejected");
+
+const approve = async () => {
+  await approveMutation.mutateAsync({ id: props.oauthApplication.id });
+  void queryClient.invalidateQueries({
+    queryKey: getOauthApplicationsQueryKey(),
+  });
+};
+
+const reject = () => {
+  comlink.emit("open-modal", {
+    component: () =>
+      import("@/admin/components/OauthApplications/RejectModal/index.vue"),
+    props: {
+      oauthApplication: props.oauthApplication,
+    },
+  });
+};
 
 const destroyMutation = useDestroyOauthApplication();
 
@@ -47,6 +74,23 @@ const destroy = () => {
 </script>
 
 <template>
+  <Btn
+    v-if="canApprove"
+    v-tooltip="!withLabels && t('actions.oauthApplications.approve')"
+    :loading="approveMutation.isPending.value"
+    @click="approve"
+  >
+    <i class="fa-duotone fa-circle-check" />
+    <span v-if="withLabels">{{ t("actions.oauthApplications.approve") }}</span>
+  </Btn>
+  <Btn
+    v-if="canReject"
+    v-tooltip="!withLabels && t('actions.oauthApplications.reject')"
+    @click="reject"
+  >
+    <i class="fa-duotone fa-circle-xmark" />
+    <span v-if="withLabels">{{ t("actions.oauthApplications.reject") }}</span>
+  </Btn>
   <Btn
     v-tooltip="!withLabels && t('actions.edit')"
     :to="

--- a/app/frontend/admin/components/OauthApplications/RejectModal/index.vue
+++ b/app/frontend/admin/components/OauthApplications/RejectModal/index.vue
@@ -11,15 +11,28 @@ import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
 import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import {
   type OauthApplication,
+  type OauthApplicationQuery,
   useRejectOauthApplication,
+  useRejectOauthApplicationsBulk,
   getOauthApplicationsQueryKey,
 } from "@/services/fyAdminApi";
 import { useI18n } from "@/shared/composables/useI18n";
 import { useComlink } from "@/shared/composables/useComlink";
 import { useQueryClient } from "@tanstack/vue-query";
 
+type BulkPayload = {
+  ids?: string[];
+  all?: boolean;
+  q?: OauthApplicationQuery;
+};
+
 type Props = {
-  oauthApplication: OauthApplication;
+  /** One application, from the row action. */
+  oauthApplication?: OauthApplication;
+  /** A selection, from the bulk bar. Exactly one of the two is given. */
+  bulkPayload?: BulkPayload;
+  count?: number;
+  onRejected?: () => void;
 };
 
 const props = defineProps<Props>();
@@ -32,6 +45,18 @@ const rejectionReason = ref("");
 const submitting = ref(false);
 const error = ref<string | undefined>();
 
+const bulk = computed(() => !!props.bulkPayload);
+
+const title = computed(() =>
+  bulk.value
+    ? t("headlines.admin.oauthApplications.rejectBulk", {
+        count: props.count ?? 0,
+      })
+    : t("headlines.admin.oauthApplications.reject", {
+        name: props.oauthApplication?.name ?? "",
+      }),
+);
+
 // The reason is what the owner is shown, so the button stays shut until there
 // is one. The API refuses an empty reason too; this only saves the round trip.
 const canSubmit = computed(
@@ -39,6 +64,7 @@ const canSubmit = computed(
 );
 
 const rejectMutation = useRejectOauthApplication();
+const rejectBulkMutation = useRejectOauthApplicationsBulk();
 
 const submit = async () => {
   if (!canSubmit.value) return;
@@ -47,15 +73,25 @@ const submit = async () => {
   error.value = undefined;
 
   try {
-    await rejectMutation.mutateAsync({
-      id: props.oauthApplication.id,
-      data: { rejectionReason: rejectionReason.value.trim() },
-    });
+    if (props.bulkPayload) {
+      await rejectBulkMutation.mutateAsync({
+        data: {
+          ...props.bulkPayload,
+          rejectionReason: rejectionReason.value.trim(),
+        },
+      });
+    } else if (props.oauthApplication) {
+      await rejectMutation.mutateAsync({
+        id: props.oauthApplication.id,
+        data: { rejectionReason: rejectionReason.value.trim() },
+      });
+    }
 
     await queryClient.invalidateQueries({
       queryKey: getOauthApplicationsQueryKey(),
     });
 
+    props.onRejected?.();
     comlink.emit("close-modal");
   } catch (err) {
     error.value = err instanceof Error ? err.message : String(err);
@@ -66,13 +102,7 @@ const submit = async () => {
 </script>
 
 <template>
-  <Modal
-    :title="
-      t('headlines.admin.oauthApplications.reject', {
-        name: props.oauthApplication.name,
-      })
-    "
-  >
+  <Modal :title="title">
     <p class="hint">
       <i class="fa-light fa-info-circle" />
       {{ t("texts.admin.oauthApplications.rejectHint") }}

--- a/app/frontend/admin/components/OauthApplications/RejectModal/index.vue
+++ b/app/frontend/admin/components/OauthApplications/RejectModal/index.vue
@@ -1,0 +1,105 @@
+<script lang="ts">
+export default {
+  name: "OauthApplicationRejectModal",
+};
+</script>
+
+<script lang="ts" setup>
+import Modal from "@/shared/components/AppModal/Inner/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
+import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
+import {
+  type OauthApplication,
+  useRejectOauthApplication,
+  getOauthApplicationsQueryKey,
+} from "@/services/fyAdminApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useComlink } from "@/shared/composables/useComlink";
+import { useQueryClient } from "@tanstack/vue-query";
+
+type Props = {
+  oauthApplication: OauthApplication;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const comlink = useComlink();
+const queryClient = useQueryClient();
+
+const rejectionReason = ref("");
+const submitting = ref(false);
+const error = ref<string | undefined>();
+
+// The reason is what the owner is shown, so the button stays shut until there
+// is one. The API refuses an empty reason too; this only saves the round trip.
+const canSubmit = computed(
+  () => rejectionReason.value.trim().length > 0 && !submitting.value,
+);
+
+const rejectMutation = useRejectOauthApplication();
+
+const submit = async () => {
+  if (!canSubmit.value) return;
+
+  submitting.value = true;
+  error.value = undefined;
+
+  try {
+    await rejectMutation.mutateAsync({
+      id: props.oauthApplication.id,
+      data: { rejectionReason: rejectionReason.value.trim() },
+    });
+
+    await queryClient.invalidateQueries({
+      queryKey: getOauthApplicationsQueryKey(),
+    });
+
+    comlink.emit("close-modal");
+  } catch (err) {
+    error.value = err instanceof Error ? err.message : String(err);
+  } finally {
+    submitting.value = false;
+  }
+};
+</script>
+
+<template>
+  <Modal
+    :title="
+      t('headlines.admin.oauthApplications.reject', {
+        name: props.oauthApplication.name,
+      })
+    "
+  >
+    <p class="hint">
+      <i class="fa-light fa-info-circle" />
+      {{ t("texts.admin.oauthApplications.rejectHint") }}
+    </p>
+
+    <form id="oauth-application-reject" @submit.prevent="submit">
+      <FormTextarea
+        v-model="rejectionReason"
+        name="rejectionReason"
+        translation-key="oauthApplications.rejectionReason"
+      />
+
+      <p v-if="error" class="text-danger">{{ error }}</p>
+    </form>
+
+    <template #footer>
+      <div class="modal-actions">
+        <Btn
+          :loading="submitting"
+          :disabled="!canSubmit"
+          :tone="BtnTonesEnum.DANGER"
+          :size="BtnSizesEnum.LG"
+          @click="submit"
+        >
+          {{ t("actions.oauthApplications.reject") }}
+        </Btn>
+      </div>
+    </template>
+  </Modal>
+</template>

--- a/app/frontend/admin/pages/oauth-applications/index.vue
+++ b/app/frontend/admin/pages/oauth-applications/index.vue
@@ -42,6 +42,10 @@ const columns: BaseTableCol<OauthApplication>[] = [
     label: "Name",
   },
   {
+    name: "state",
+    label: "Status",
+  },
+  {
     name: "ownerName",
     label: "Owner",
   },

--- a/app/frontend/admin/pages/oauth-applications/index.vue
+++ b/app/frontend/admin/pages/oauth-applications/index.vue
@@ -20,6 +20,11 @@ import { usePagination } from "@/shared/composables/usePagination";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import OauthApplicationActions from "@/admin/components/OauthApplications/Actions/index.vue";
+import OauthApplicationState from "@/shared/components/OauthApplicationState/index.vue";
+import BulkSelectionBar from "@/shared/components/BulkSelectionBar/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { useBulkSelection } from "@/shared/composables/useBulkSelection";
+import { useComlink } from "@/shared/composables/useComlink";
 
 const queryKey = computed(() => {
   return getOauthApplicationsQueryKey(queryParams.value);
@@ -30,11 +35,50 @@ const { perPage, page, updatePerPage } = usePagination(queryKey);
 const queryParams = computed(() => {
   return {
     page: page.value,
+    q: {},
   };
 });
 
 const { data: oauthApplications, ...asyncStatus } =
   useOauthApplications(queryParams);
+
+const records = computed(() => oauthApplications.value?.items || []);
+
+const totalCount = computed(
+  () => oauthApplications.value?.meta.pagination?.totalCount,
+);
+
+const {
+  selectedIds,
+  allMatchingSelected,
+  selectedCount,
+  matchingCount,
+  pageSelected,
+  pagePartiallySelected,
+  canSelectAllMatching,
+  togglePage,
+  selectAllMatching,
+  clear: clearSelection,
+  payload: bulkPayload,
+} = useBulkSelection(records, () => queryParams.value.q, totalCount);
+
+const comlink = useComlink();
+
+// The modal owns the reason, because it is required and there is nowhere on a
+// toolbar to type one.
+const rejectSelected = () => {
+  if (!selectedCount.value) return;
+
+  comlink.emit("open-modal", {
+    component: () =>
+      import("@/admin/components/OauthApplications/RejectModal/index.vue"),
+    props: {
+      bulkPayload: bulkPayload.value,
+      count: selectedCount.value,
+      onRejected: clearSelection,
+    },
+  });
+};
 
 const columns: BaseTableCol<OauthApplication>[] = [
   {
@@ -102,14 +146,41 @@ const { t, l } = useI18n();
     hide-empty
   >
     <template #default="{ loading, refetching, emptyVisible }">
+      <BulkSelectionBar
+        :disabled="!records.length"
+        :selected-count="selectedCount"
+        :matching-count="matchingCount"
+        :page-selected="pageSelected"
+        :page-partially-selected="pagePartiallySelected"
+        :can-select-all-matching="canSelectAllMatching"
+        :all-matching-selected="allMatchingSelected"
+        @toggle-page="togglePage"
+        @select-all-matching="selectAllMatching"
+        @clear="clearSelection"
+      >
+        <Btn
+          v-tooltip="t('actions.oauthApplications.rejectSelected')"
+          :aria-label="t('actions.oauthApplications.rejectSelected')"
+          data-test="bulk-reject"
+          @click="rejectSelected"
+        >
+          <i class="fa-duotone fa-circle-xmark" />
+        </Btn>
+      </BulkSelectionBar>
+
       <BaseTable
         :records="oauthApplications?.items || []"
         primary-key="id"
         :columns="columns"
         :loading="loading || refetching"
         :empty-visible="emptyVisible"
+        :selected="selectedIds"
         selectable
+        @selected-change="selectedIds = $event"
       >
+        <template #col-state="{ record }">
+          <OauthApplicationState :state="record.state" />
+        </template>
         <template #col-name="{ record }">
           {{ record.name }}
         </template>

--- a/app/frontend/frontend/pages/oauth/authorize.vue
+++ b/app/frontend/frontend/pages/oauth/authorize.vue
@@ -118,6 +118,13 @@ async function deny() {
     </template>
 
     <template v-else-if="preAuth">
+      <img
+        v-if="preAuth.clientLogo?.smallUrl"
+        :src="preAuth.clientLogo.smallUrl"
+        :alt="preAuth.clientName"
+        class="authorize-logo"
+      />
+
       <p class="authorize-info">
         {{
           t("texts.oauthAuthorize.requestingAccess", {
@@ -156,6 +163,17 @@ async function deny() {
 </template>
 
 <style lang="scss" scoped>
+// The logo identifies who is asking, so it sits above the sentence naming them
+// rather than beside it.
+.authorize-logo {
+  display: block;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 1rem;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
 .authorize-info {
   margin-bottom: 15px;
 }

--- a/app/frontend/frontend/pages/settings/oauth-applications/[id]/edit.vue
+++ b/app/frontend/frontend/pages/settings/oauth-applications/[id]/edit.vue
@@ -16,12 +16,14 @@ import {
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
 import Heading from "@/shared/components/base/Heading/index.vue";
+import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
 import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
 import FormToggle from "@/shared/components/base/FormToggle/index.vue";
 import FormActions from "@/shared/components/base/FormActions/index.vue";
 import { useQueryClient } from "@tanstack/vue-query";
+import { AllowedFileTypes } from "@/shared/components/DirectUpload/types";
 import { useForm } from "vee-validate";
 import {
   AVAILABLE_SCOPES,
@@ -59,6 +61,7 @@ const { defineField, handleSubmit, meta } = useForm<OauthApplicationInput>({
 const [name, nameProps] = defineField("name");
 const [redirectUri, redirectUriProps] = defineField("redirectUri");
 const [confidential, confidentialProps] = defineField("confidential");
+const [logo, logoProps] = defineField("logo");
 defineField("scopes");
 
 const submitting = ref(false);
@@ -128,6 +131,18 @@ const handleCancel = async () => {
           name="name"
           translation-key="oauthApplication.name"
         />
+        <FormFileInput
+          v-model="logo"
+          v-bind="logoProps"
+          name="logo"
+          translation-key="oauthApplication.logo"
+          :allowed-types="AllowedFileTypes.IMAGE"
+          :file="oauthApplication.logo"
+          clearable
+        />
+        <p class="field-hint">
+          {{ t("labels.oauthApplication.logoHint") }}
+        </p>
         <FormTextarea
           v-model="redirectUri"
           v-bind="redirectUriProps"

--- a/app/frontend/frontend/pages/settings/oauth-applications/[id]/index.vue
+++ b/app/frontend/frontend/pages/settings/oauth-applications/[id]/index.vue
@@ -7,6 +7,7 @@ export default {
 <script lang="ts" setup>
 import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import OauthApplicationState from "@/shared/components/OauthApplicationState/index.vue";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import Panel from "@/shared/components/base/Panel/index.vue";
@@ -155,6 +156,25 @@ const confirmDestroy = () => {
     </BtnGroup>
   </div>
 
+  <div
+    v-if="oauthApplication.state !== 'approved'"
+    class="oauth-state-banner"
+    :class="`oauth-state-banner--${oauthApplication.state}`"
+  >
+    <OauthApplicationState :state="oauthApplication.state" />
+    <p class="oauth-state-text">
+      {{
+        oauthApplication.state === "rejected"
+          ? t("texts.oauthApplications.rejected")
+          : t("texts.oauthApplications.pendingReview")
+      }}
+    </p>
+    <p v-if="oauthApplication.rejectionReason" class="oauth-state-reason">
+      <strong>{{ t("labels.oauthApplications.rejectionReason") }}:</strong>
+      {{ oauthApplication.rejectionReason }}
+    </p>
+  </div>
+
   <div v-if="visibleSecret" class="oauth-secret-banner">
     <div class="oauth-secret-banner-header">
       <strong>{{ t("labels.oauthApplications.clientSecret") }}</strong>
@@ -248,6 +268,26 @@ const confirmDestroy = () => {
 </template>
 
 <style lang="scss" scoped>
+.oauth-state-banner {
+  padding: 1rem;
+  margin-bottom: 1rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  border-left: 3px solid var(--color-warning, #d9a441);
+}
+
+.oauth-state-banner--rejected {
+  border-left-color: var(--color-danger, #c0392b);
+}
+
+.oauth-state-text {
+  margin: 0.5rem 0 0;
+}
+
+.oauth-state-reason {
+  margin: 0.5rem 0 0;
+}
+
 .oauth-detail-header {
   display: flex;
   align-items: center;

--- a/app/frontend/frontend/pages/settings/oauth-applications/create.vue
+++ b/app/frontend/frontend/pages/settings/oauth-applications/create.vue
@@ -9,6 +9,7 @@ import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
 import Heading from "@/shared/components/base/Heading/index.vue";
+import FormFileInput from "@/shared/components/base/FormFileInput/index.vue";
 import FormInput from "@/shared/components/base/FormInput/index.vue";
 import FormTextarea from "@/shared/components/base/FormTextarea/index.vue";
 import FormCheckbox from "@/shared/components/base/FormCheckbox/index.vue";
@@ -20,6 +21,7 @@ import {
   getOauthApplicationsQueryKey,
 } from "@/services/fyApi";
 import { useQueryClient } from "@tanstack/vue-query";
+import { AllowedFileTypes } from "@/shared/components/DirectUpload/types";
 import { useForm } from "vee-validate";
 import {
   AVAILABLE_SCOPES,
@@ -49,6 +51,7 @@ const { defineField, handleSubmit, meta } = useForm<OauthApplicationInput>({
 const [name, nameProps] = defineField("name");
 const [redirectUri, redirectUriProps] = defineField("redirectUri");
 const [confidential, confidentialProps] = defineField("confidential");
+const [logo, logoProps] = defineField("logo");
 defineField("scopes");
 
 const submitting = ref(false);
@@ -104,6 +107,17 @@ const handleCancel = async () => {
           name="name"
           translation-key="oauthApplication.name"
         />
+        <FormFileInput
+          v-model="logo"
+          v-bind="logoProps"
+          name="logo"
+          translation-key="oauthApplication.logo"
+          :allowed-types="AllowedFileTypes.IMAGE"
+          clearable
+        />
+        <p class="field-hint">
+          {{ t("labels.oauthApplication.logoHint") }}
+        </p>
         <FormTextarea
           v-model="redirectUri"
           v-bind="redirectUriProps"

--- a/app/frontend/frontend/pages/settings/oauth-applications/index.vue
+++ b/app/frontend/frontend/pages/settings/oauth-applications/index.vue
@@ -9,6 +9,7 @@ import { useI18n } from "@/shared/composables/useI18n";
 import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import BreadCrumbs from "@/shared/components/BreadCrumbs/index.vue";
 import Heading from "@/shared/components/base/Heading/index.vue";
+import OauthApplicationState from "@/shared/components/OauthApplicationState/index.vue";
 import ListGroup from "@/shared/components/ListGroup/index.vue";
 import { BtnTonesEnum } from "@/shared/components/base/Btn/types";
 import {
@@ -94,6 +95,7 @@ const formatScopes = (scopes: string) => {
           {{ item.name }}
         </router-link>
         <div class="oauth-app-meta">
+          <OauthApplicationState :state="item.state" />
           <span
             class="oauth-app-meta-item oauth-app-meta-item--copyable"
             @click.stop.prevent="copyToClipboard(item.uid)"

--- a/app/frontend/shared/components/OauthApplicationState/index.vue
+++ b/app/frontend/shared/components/OauthApplicationState/index.vue
@@ -1,0 +1,47 @@
+<script lang="ts">
+export default {
+  name: "OauthApplicationState",
+};
+</script>
+
+<script lang="ts" setup>
+import Pill from "@/shared/components/base/Pill/index.vue";
+import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
+import { useI18n } from "@/shared/composables/useI18n";
+
+type Props = {
+  state: string;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+
+// Awaiting review is a warning rather than neutral: the application does not
+// work yet, and that is something the reader has to act on or wait out.
+const variant = computed(() => {
+  switch (props.state) {
+    case "approved":
+      return PillVariantsEnum.SUCCESS;
+    case "rejected":
+      return PillVariantsEnum.DANGER;
+    default:
+      return PillVariantsEnum.WARNING;
+  }
+});
+
+const label = computed(() => {
+  switch (props.state) {
+    case "approved":
+      return t("labels.oauthApplications.stateApproved");
+    case "rejected":
+      return t("labels.oauthApplications.stateRejected");
+    default:
+      return t("labels.oauthApplications.statePending");
+  }
+});
+</script>
+
+<template>
+  <Pill :variant="variant" uppercase>{{ label }}</Pill>
+</template>

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -113,7 +113,8 @@
         "create": "Neue Anwendung",
         "regenerateSecret": "Schlüssel neu generieren",
         "approve": "Freigeben",
-        "reject": "Ablehnen"
+        "reject": "Ablehnen",
+        "rejectSelected": "Auswahl ablehnen"
       },
       "oauthAuthorize": {
         "authorize": "Autorisieren",

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -111,7 +111,9 @@
       "syncRsiHangar": "RSI-Hangar synchronisieren",
       "oauthApplications": {
         "create": "Neue Anwendung",
-        "regenerateSecret": "Schlüssel neu generieren"
+        "regenerateSecret": "Schlüssel neu generieren",
+        "approve": "Freigeben",
+        "reject": "Ablehnen"
       },
       "oauthAuthorize": {
         "authorize": "Autorisieren",

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -128,7 +128,8 @@
         "oauthApplications": {
           "index": "OAuth-Anwendungen",
           "new": "Neue OAuth-Anwendung",
-          "edit": "OAuth-Anwendung bearbeiten"
+          "edit": "OAuth-Anwendung bearbeiten",
+          "reject": "%{name} ablehnen"
         },
         "features": {
           "index": "Feature-Flags",

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -129,7 +129,8 @@
           "index": "OAuth-Anwendungen",
           "new": "Neue OAuth-Anwendung",
           "edit": "OAuth-Anwendung bearbeiten",
-          "reject": "%{name} ablehnen"
+          "reject": "%{name} ablehnen",
+          "rejectBulk": "%{count} Anwendungen ablehnen"
         },
         "features": {
           "index": "Feature-Flags",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -81,7 +81,9 @@
         "redirectUriHint": "Verwenden Sie eine URI pro Zeile.",
         "confidential": "Vertraulich",
         "scopes": "Berechtigungen",
-        "scopesHint": "Wenn keine Berechtigungen ausgewählt sind, werden die Standardberechtigungen verwendet: %{scopes}"
+        "scopesHint": "Wenn keine Berechtigungen ausgewählt sind, werden die Standardberechtigungen verwendet: %{scopes}",
+        "logo": "Logo",
+        "logoHint": "Wird auf der Zustimmungsseite angezeigt, damit Nutzer deine Anwendung erkennen. PNG, JPG, GIF oder WebP."
       },
       "rsiRequestLogs": {
         "resolved": "Gelöst",
@@ -121,7 +123,15 @@
         "scopes": "Berechtigungen",
         "defaultScopes": "Standard-Berechtigungen",
         "confidentialShort": "Vertraulich",
-        "publicShort": "Öffentlich"
+        "publicShort": "Öffentlich",
+        "logo": "Logo",
+        "state": "Status",
+        "rejectionReason": "Ablehnungsgrund",
+        "statePending": "Wartet auf Prüfung",
+        "stateApproved": "Freigegeben",
+        "stateRejected": "Abgelehnt",
+        "reviewedBy": "Geprüft von",
+        "owner": "Registriert von"
       },
       "fleetInviteToken": "Flotteneinladung",
       "inviteToken": "Einladungscode",

--- a/app/frontend/translations/de/texts.json
+++ b/app/frontend/translations/de/texts.json
@@ -49,6 +49,9 @@
             },
             "ignored": "Ignoriert: %{files}"
           }
+        },
+        "oauthApplications": {
+          "rejectHint": "Der Grund wird der Person angezeigt, die die Anwendung registriert hat — benenne also, was sich ändern muss."
         }
       },
       "hangarGuide": {
@@ -165,6 +168,11 @@
           "info": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
           "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension."
         }
+      },
+      "oauthApplications": {
+        "pendingReview": "Diese Anwendung ist registriert und wartet auf die Prüfung. Bis zur Freigabe kann sie keinen Zugriff anfragen.",
+        "rejected": "Diese Anwendung wurde abgelehnt und kann keinen Zugriff anfragen. Wer behebt, was im Grund steht, landet wieder in der Warteschlange.",
+        "returnedToReview": "Wird die Redirect-URI oder werden die Scopes geändert, geht eine freigegebene Anwendung zurück in die Prüfung."
       }
     }
   }

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -111,7 +111,9 @@
       "syncRsiHangar": "Sync RSI Hangar",
       "oauthApplications": {
         "create": "New Application",
-        "regenerateSecret": "Regenerate Secret"
+        "regenerateSecret": "Regenerate Secret",
+        "approve": "Approve",
+        "reject": "Refuse"
       },
       "oauthAuthorize": {
         "authorize": "Authorize",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -113,7 +113,8 @@
         "create": "New Application",
         "regenerateSecret": "Regenerate Secret",
         "approve": "Approve",
-        "reject": "Refuse"
+        "reject": "Refuse",
+        "rejectSelected": "Refuse selected"
       },
       "oauthAuthorize": {
         "authorize": "Authorize",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -121,7 +121,8 @@
           "index": "OAuth Applications",
           "new": "New OAuth Application",
           "edit": "Edit OAuth Application",
-          "reject": "Refuse %{name}"
+          "reject": "Refuse %{name}",
+          "rejectBulk": "Refuse %{count} applications"
         },
         "features": {
           "index": "Feature Flags",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -120,7 +120,8 @@
         "oauthApplications": {
           "index": "OAuth Applications",
           "new": "New OAuth Application",
-          "edit": "Edit OAuth Application"
+          "edit": "Edit OAuth Application",
+          "reject": "Refuse %{name}"
         },
         "features": {
           "index": "Feature Flags",

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -81,7 +81,9 @@
         "redirectUriHint": "Use one URI per line.",
         "confidential": "Confidential",
         "scopes": "Scopes",
-        "scopesHint": "If no scopes are selected, the default scopes will be used: %{scopes}"
+        "scopesHint": "If no scopes are selected, the default scopes will be used: %{scopes}",
+        "logo": "Logo",
+        "logoHint": "Shown on the consent screen so people recognise your application. PNG, JPG, GIF or WebP."
       },
       "rsiRequestLogs": {
         "resolved": "Resolved",
@@ -121,7 +123,15 @@
         "scopes": "Scopes",
         "defaultScopes": "Default scopes",
         "confidentialShort": "Confidential",
-        "publicShort": "Public"
+        "publicShort": "Public",
+        "logo": "Logo",
+        "state": "Status",
+        "rejectionReason": "Reason for refusal",
+        "statePending": "Awaiting review",
+        "stateApproved": "Approved",
+        "stateRejected": "Refused",
+        "reviewedBy": "Reviewed by",
+        "owner": "Registered by"
       },
       "fleetInviteToken": "Fleet Invite",
       "inviteToken": "Invite code",

--- a/app/frontend/translations/en/texts.json
+++ b/app/frontend/translations/en/texts.json
@@ -49,6 +49,9 @@
             },
             "ignored": "Ignored: %{files}"
           }
+        },
+        "oauthApplications": {
+          "rejectHint": "The reason is shown to whoever registered the application, so name what has to change."
         }
       },
       "hangarGuide": {
@@ -159,7 +162,12 @@
         "info": "We will try to match the ships from your RSI Hangar with your exisiting ships in your Fleetyards Hangar by using the name and the pledge-id. Ships from the RSI Hangar without a match will be added to your Fleetyards Hangar and ships from your Fleetyards Hangar which could not be found in your RSI Hangar will be moved to your Wishlist.<br><br>Do you want to continue?",
         "alreadyRunning": "A Hangar Sync is already in progress. Please wait for it to finish."
       },
-      "setEmail": "To set a password, enable two-factor authentication, or receive email notifications, you need to add an email address to your account. You will receive a confirmation email to verify the address."
+      "setEmail": "To set a password, enable two-factor authentication, or receive email notifications, you need to add an email address to your account. You will receive a confirmation email to verify the address.",
+      "oauthApplications": {
+        "pendingReview": "This application has been registered and is waiting to be reviewed. It cannot request access until it is approved.",
+        "rejected": "This application was refused and cannot request access. Correcting what the reason names puts it back in the queue.",
+        "returnedToReview": "Changing the redirect URI or the scopes returns an approved application to review."
+      }
     }
   }
 }

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -111,7 +111,9 @@
       "syncRsiHangar": "Sincronizar hangar RSI",
       "oauthApplications": {
         "create": "Nueva aplicación",
-        "regenerateSecret": "Regenerar secreto"
+        "regenerateSecret": "Regenerar secreto",
+        "approve": "Aprobar",
+        "reject": "Rechazar"
       },
       "oauthAuthorize": {
         "authorize": "Autorizar",

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -113,7 +113,8 @@
         "create": "Nueva aplicación",
         "regenerateSecret": "Regenerar secreto",
         "approve": "Aprobar",
-        "reject": "Rechazar"
+        "reject": "Rechazar",
+        "rejectSelected": "Rechazar seleccionadas"
       },
       "oauthAuthorize": {
         "authorize": "Autorizar",

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -128,7 +128,8 @@
         "oauthApplications": {
           "index": "Aplicaciones OAuth",
           "new": "Nueva aplicación OAuth",
-          "edit": "Editar aplicación OAuth"
+          "edit": "Editar aplicación OAuth",
+          "reject": "Rechazar %{name}"
         },
         "features": {
           "index": "Indicadores de características",

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -129,7 +129,8 @@
           "index": "Aplicaciones OAuth",
           "new": "Nueva aplicación OAuth",
           "edit": "Editar aplicación OAuth",
-          "reject": "Rechazar %{name}"
+          "reject": "Rechazar %{name}",
+          "rejectBulk": "Rechazar %{count} aplicaciones"
         },
         "features": {
           "index": "Indicadores de características",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -81,7 +81,9 @@
         "redirectUriHint": "Use una URI por línea.",
         "confidential": "Confidencial",
         "scopes": "Alcances",
-        "scopesHint": "Si no se seleccionan alcances, se usarán los alcances predeterminados: %{scopes}"
+        "scopesHint": "Si no se seleccionan alcances, se usarán los alcances predeterminados: %{scopes}",
+        "logo": "Logotipo",
+        "logoHint": "Se muestra en la pantalla de consentimiento para que la gente reconozca tu aplicación. PNG, JPG, GIF o WebP."
       },
       "rsiRequestLogs": {
         "resolved": "Resuelto",
@@ -121,7 +123,15 @@
         "scopes": "Alcances",
         "defaultScopes": "Alcances predeterminados",
         "confidentialShort": "Confidencial",
-        "publicShort": "Público"
+        "publicShort": "Público",
+        "logo": "Logotipo",
+        "state": "Estado",
+        "rejectionReason": "Motivo del rechazo",
+        "statePending": "Pendiente de revisión",
+        "stateApproved": "Aprobada",
+        "stateRejected": "Rechazada",
+        "reviewedBy": "Revisada por",
+        "owner": "Registrada por"
       },
       "fleetInviteToken": "Invitación de flota",
       "inviteToken": "Código de invitación",

--- a/app/frontend/translations/es/texts.json
+++ b/app/frontend/translations/es/texts.json
@@ -49,6 +49,9 @@
             },
             "ignored": "Ignorados: %{files}"
           }
+        },
+        "oauthApplications": {
+          "rejectHint": "El motivo se muestra a quien registró la aplicación, así que indica qué debe cambiar."
         }
       },
       "hangarGuide": {
@@ -165,6 +168,11 @@
           "info": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
           "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension."
         }
+      },
+      "oauthApplications": {
+        "pendingReview": "Esta aplicación está registrada y espera revisión. No puede solicitar acceso hasta que sea aprobada.",
+        "rejected": "Esta aplicación fue rechazada y no puede solicitar acceso. Corregir lo que indica el motivo la devuelve a la cola.",
+        "returnedToReview": "Cambiar la URI de redirección o los permisos devuelve a revisión una aplicación aprobada."
       }
     }
   }

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -111,7 +111,9 @@
       "syncRsiHangar": "Synchroniser le hangar RSI",
       "oauthApplications": {
         "create": "Nouvelle application",
-        "regenerateSecret": "Régénérer le secret"
+        "regenerateSecret": "Régénérer le secret",
+        "approve": "Approuver",
+        "reject": "Refuser"
       },
       "oauthAuthorize": {
         "authorize": "Autoriser",

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -113,7 +113,8 @@
         "create": "Nouvelle application",
         "regenerateSecret": "Régénérer le secret",
         "approve": "Approuver",
-        "reject": "Refuser"
+        "reject": "Refuser",
+        "rejectSelected": "Refuser la sélection"
       },
       "oauthAuthorize": {
         "authorize": "Autoriser",

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -129,7 +129,8 @@
           "index": "Applications OAuth",
           "new": "Nouvelle application OAuth",
           "edit": "Modifier l'application OAuth",
-          "reject": "Refuser %{name}"
+          "reject": "Refuser %{name}",
+          "rejectBulk": "Refuser %{count} applications"
         },
         "features": {
           "index": "Indicateurs de fonctionnalités",

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -128,7 +128,8 @@
         "oauthApplications": {
           "index": "Applications OAuth",
           "new": "Nouvelle application OAuth",
-          "edit": "Modifier l'application OAuth"
+          "edit": "Modifier l'application OAuth",
+          "reject": "Refuser %{name}"
         },
         "features": {
           "index": "Indicateurs de fonctionnalités",

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -81,7 +81,9 @@
         "redirectUriHint": "Utilisez une URI par ligne.",
         "confidential": "Confidentiel",
         "scopes": "Portées",
-        "scopesHint": "Si aucune portée n'est sélectionnée, les portées par défaut seront utilisées : %{scopes}"
+        "scopesHint": "Si aucune portée n'est sélectionnée, les portées par défaut seront utilisées : %{scopes}",
+        "logo": "Logo",
+        "logoHint": "Affiché sur l'écran de consentement afin que les utilisateurs reconnaissent votre application. PNG, JPG, GIF ou WebP."
       },
       "rsiRequestLogs": {
         "resolved": "Résolu",
@@ -121,7 +123,15 @@
         "scopes": "Portées",
         "defaultScopes": "Portées par défaut",
         "confidentialShort": "Confidentiel",
-        "publicShort": "Public"
+        "publicShort": "Public",
+        "logo": "Logo",
+        "state": "Statut",
+        "rejectionReason": "Motif du refus",
+        "statePending": "En attente d'examen",
+        "stateApproved": "Approuvée",
+        "stateRejected": "Refusée",
+        "reviewedBy": "Examinée par",
+        "owner": "Enregistrée par"
       },
       "fleetInviteToken": "invitation de la flotte",
       "inviteToken": "Code d'invitation",

--- a/app/frontend/translations/fr/texts.json
+++ b/app/frontend/translations/fr/texts.json
@@ -49,6 +49,9 @@
             },
             "ignored": "Ignorés : %{files}"
           }
+        },
+        "oauthApplications": {
+          "rejectHint": "Le motif est montré à la personne qui a enregistré l'application : indiquez donc ce qui doit changer."
         }
       },
       "hangarGuide": {
@@ -165,6 +168,11 @@
           "info": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
           "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension."
         }
+      },
+      "oauthApplications": {
+        "pendingReview": "Cette application est enregistrée et attend son examen. Elle ne peut demander aucun accès avant d'être approuvée.",
+        "rejected": "Cette application a été refusée et ne peut demander aucun accès. Corriger ce que le motif indique la remet dans la file.",
+        "returnedToReview": "Modifier l'URI de redirection ou les portées renvoie une application approuvée à l'examen."
       }
     }
   }

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -113,7 +113,8 @@
         "create": "Nuova applicazione",
         "regenerateSecret": "Rigenera segreto",
         "approve": "Approva",
-        "reject": "Rifiuta"
+        "reject": "Rifiuta",
+        "rejectSelected": "Rifiuta selezionate"
       },
       "oauthAuthorize": {
         "authorize": "Autorizza",

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -111,7 +111,9 @@
       "syncRsiHangar": "Sincronizza hangar RSI",
       "oauthApplications": {
         "create": "Nuova applicazione",
-        "regenerateSecret": "Rigenera segreto"
+        "regenerateSecret": "Rigenera segreto",
+        "approve": "Approva",
+        "reject": "Rifiuta"
       },
       "oauthAuthorize": {
         "authorize": "Autorizza",

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -128,7 +128,8 @@
         "oauthApplications": {
           "index": "Applicazioni OAuth",
           "new": "Nuova applicazione OAuth",
-          "edit": "Modifica applicazione OAuth"
+          "edit": "Modifica applicazione OAuth",
+          "reject": "Rifiuta %{name}"
         },
         "features": {
           "index": "Flag funzionalità",

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -129,7 +129,8 @@
           "index": "Applicazioni OAuth",
           "new": "Nuova applicazione OAuth",
           "edit": "Modifica applicazione OAuth",
-          "reject": "Rifiuta %{name}"
+          "reject": "Rifiuta %{name}",
+          "rejectBulk": "Rifiuta %{count} applicazioni"
         },
         "features": {
           "index": "Flag funzionalità",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -81,7 +81,9 @@
         "redirectUriHint": "Usare un URI per riga.",
         "confidential": "Riservato",
         "scopes": "Ambiti",
-        "scopesHint": "Se non vengono selezionati ambiti, verranno utilizzati quelli predefiniti: %{scopes}"
+        "scopesHint": "Se non vengono selezionati ambiti, verranno utilizzati quelli predefiniti: %{scopes}",
+        "logo": "Logo",
+        "logoHint": "Mostrato nella schermata di consenso perché le persone riconoscano la tua applicazione. PNG, JPG, GIF o WebP."
       },
       "rsiRequestLogs": {
         "resolved": "Risolto",
@@ -121,7 +123,15 @@
         "scopes": "Ambiti",
         "defaultScopes": "Ambiti predefiniti",
         "confidentialShort": "Riservato",
-        "publicShort": "Pubblico"
+        "publicShort": "Pubblico",
+        "logo": "Logo",
+        "state": "Stato",
+        "rejectionReason": "Motivo del rifiuto",
+        "statePending": "In attesa di revisione",
+        "stateApproved": "Approvata",
+        "stateRejected": "Rifiutata",
+        "reviewedBy": "Revisionata da",
+        "owner": "Registrata da"
       },
       "fleetInviteToken": "Inviti Alla Flotta",
       "inviteToken": "Codice di invito",

--- a/app/frontend/translations/it/texts.json
+++ b/app/frontend/translations/it/texts.json
@@ -49,6 +49,9 @@
             },
             "ignored": "Ignorati: %{files}"
           }
+        },
+        "oauthApplications": {
+          "rejectHint": "Il motivo viene mostrato a chi ha registrato l'applicazione, quindi indica cosa deve cambiare."
         }
       },
       "hangarGuide": {
@@ -165,6 +168,11 @@
           "info": "You can add Ships to your Hangar by clicking on the bookmark icon in the top right corner of a Ship or by using the Plus Button in the bottom right corner.",
           "extension": "Additionally you can import your Hangar from the RSI Website via the Fleetyards Sync Browser extension."
         }
+      },
+      "oauthApplications": {
+        "pendingReview": "Questa applicazione è registrata e attende la revisione. Non può richiedere accessi finché non è approvata.",
+        "rejected": "Questa applicazione è stata rifiutata e non può richiedere accessi. Correggere quanto indicato nel motivo la rimette in coda.",
+        "returnedToReview": "Modificare l'URI di reindirizzamento o gli ambiti riporta in revisione un'applicazione approvata."
       }
     }
   }

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -113,7 +113,8 @@
         "create": "新建应用",
         "regenerateSecret": "重新生成密钥",
         "approve": "批准",
-        "reject": "拒绝"
+        "reject": "拒绝",
+        "rejectSelected": "拒绝所选"
       },
       "oauthAuthorize": {
         "authorize": "授权",

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -111,7 +111,9 @@
       "syncRsiHangar": "同步RSI机库",
       "oauthApplications": {
         "create": "新建应用",
-        "regenerateSecret": "重新生成密钥"
+        "regenerateSecret": "重新生成密钥",
+        "approve": "批准",
+        "reject": "拒绝"
       },
       "oauthAuthorize": {
         "authorize": "授权",

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -128,7 +128,8 @@
         "oauthApplications": {
           "index": "OAuth 应用",
           "new": "新建 OAuth 应用",
-          "edit": "编辑 OAuth 应用"
+          "edit": "编辑 OAuth 应用",
+          "reject": "拒绝 %{name}"
         },
         "features": {
           "index": "功能标志",

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -129,7 +129,8 @@
           "index": "OAuth 应用",
           "new": "新建 OAuth 应用",
           "edit": "编辑 OAuth 应用",
-          "reject": "拒绝 %{name}"
+          "reject": "拒绝 %{name}",
+          "rejectBulk": "拒绝 %{count} 个应用"
         },
         "features": {
           "index": "功能标志",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -81,7 +81,9 @@
         "redirectUriHint": "每行一个 URI。",
         "confidential": "机密",
         "scopes": "权限范围",
-        "scopesHint": "如果未选择权限范围，将使用默认范围: %{scopes}"
+        "scopesHint": "如果未选择权限范围，将使用默认范围: %{scopes}",
+        "logo": "图标",
+        "logoHint": "显示在授权页面上，方便用户辨认你的应用。支持 PNG、JPG、GIF 或 WebP。"
       },
       "rsiRequestLogs": {
         "resolved": "已解决",
@@ -121,7 +123,15 @@
         "scopes": "权限范围",
         "defaultScopes": "默认权限范围",
         "confidentialShort": "机密",
-        "publicShort": "公开"
+        "publicShort": "公开",
+        "logo": "图标",
+        "state": "状态",
+        "rejectionReason": "拒绝原因",
+        "statePending": "等待审核",
+        "stateApproved": "已批准",
+        "stateRejected": "已拒绝",
+        "reviewedBy": "审核人",
+        "owner": "注册者"
       },
       "fleetInviteToken": "舰队邀请",
       "inviteToken": "邀请码",

--- a/app/frontend/translations/zh-CN/texts.json
+++ b/app/frontend/translations/zh-CN/texts.json
@@ -49,6 +49,9 @@
             },
             "ignored": "已忽略: %{files}"
           }
+        },
+        "oauthApplications": {
+          "rejectHint": "该原因会展示给注册此应用的人，请说明需要修改什么。"
         }
       },
       "hangarGuide": {
@@ -168,6 +171,11 @@
         "wishlist": {
           "info": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship."
         }
+      },
+      "oauthApplications": {
+        "pendingReview": "此应用已注册，正在等待审核。在获得批准前无法请求访问权限。",
+        "rejected": "此应用已被拒绝，无法请求访问权限。按照原因中所述修改后会重新进入审核队列。",
+        "returnedToReview": "修改重定向 URI 或权限范围会使已批准的应用重新进入审核。"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -111,7 +111,9 @@
       "syncRsiHangar": "同步RSI機庫",
       "oauthApplications": {
         "create": "新增應用程式",
-        "regenerateSecret": "重新產生密鑰"
+        "regenerateSecret": "重新產生密鑰",
+        "approve": "核准",
+        "reject": "拒絕"
       },
       "oauthAuthorize": {
         "authorize": "授權",

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -113,7 +113,8 @@
         "create": "新增應用程式",
         "regenerateSecret": "重新產生密鑰",
         "approve": "核准",
-        "reject": "拒絕"
+        "reject": "拒絕",
+        "rejectSelected": "拒絕所選"
       },
       "oauthAuthorize": {
         "authorize": "授權",

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -128,7 +128,8 @@
         "oauthApplications": {
           "index": "OAuth 應用程式",
           "new": "新增 OAuth 應用程式",
-          "edit": "編輯 OAuth 應用程式"
+          "edit": "編輯 OAuth 應用程式",
+          "reject": "拒絕 %{name}"
         },
         "features": {
           "index": "功能標誌",

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -129,7 +129,8 @@
           "index": "OAuth 應用程式",
           "new": "新增 OAuth 應用程式",
           "edit": "編輯 OAuth 應用程式",
-          "reject": "拒絕 %{name}"
+          "reject": "拒絕 %{name}",
+          "rejectBulk": "拒絕 %{count} 個應用程式"
         },
         "features": {
           "index": "功能標誌",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -81,7 +81,9 @@
         "redirectUriHint": "每行一個 URI。",
         "confidential": "機密",
         "scopes": "權限範圍",
-        "scopesHint": "如果未選擇權限範圍，將使用預設範圍: %{scopes}"
+        "scopesHint": "如果未選擇權限範圍，將使用預設範圍: %{scopes}",
+        "logo": "圖示",
+        "logoHint": "顯示在授權頁面上，方便使用者辨認你的應用程式。支援 PNG、JPG、GIF 或 WebP。"
       },
       "rsiRequestLogs": {
         "resolved": "已解決",
@@ -121,7 +123,15 @@
         "scopes": "權限範圍",
         "defaultScopes": "預設權限範圍",
         "confidentialShort": "機密",
-        "publicShort": "公開"
+        "publicShort": "公開",
+        "logo": "圖示",
+        "state": "狀態",
+        "rejectionReason": "拒絕原因",
+        "statePending": "等待審核",
+        "stateApproved": "已核准",
+        "stateRejected": "已拒絕",
+        "reviewedBy": "審核者",
+        "owner": "註冊者"
       },
       "fleetInviteToken": "艦隊邀請",
       "inviteToken": "邀請碼",

--- a/app/frontend/translations/zh-TW/texts.json
+++ b/app/frontend/translations/zh-TW/texts.json
@@ -49,6 +49,9 @@
             },
             "ignored": "已忽略：%{files}"
           }
+        },
+        "oauthApplications": {
+          "rejectHint": "此原因會顯示給註冊此應用程式的人，請說明需要修改什麼。"
         }
       },
       "hangarGuide": {
@@ -168,6 +171,11 @@
         "wishlist": {
           "info": "You can add Ships to your Wishlist by clicking on the bookmark icon in the top right corner of a Ship."
         }
+      },
+      "oauthApplications": {
+        "pendingReview": "此應用程式已註冊，正在等待審核。在獲得核准前無法請求存取權限。",
+        "rejected": "此應用程式已被拒絕，無法請求存取權限。依照原因所述修改後會重新進入審核佇列。",
+        "returnedToReview": "修改重新導向 URI 或權限範圍會使已核准的應用程式重新進入審核。"
       }
     }
   }

--- a/app/models/admin_notification.rb
+++ b/app/models/admin_notification.rb
@@ -54,7 +54,8 @@ class AdminNotification < ApplicationRecord
     ship_matrix_import: "ship_matrix_import",
     sc_data_import: "sc_data_import",
     sc_data_unlisted_models: "sc_data_unlisted_models",
-    import_run: "import_run"
+    import_run: "import_run",
+    oauth_application_review: "oauth_application_review"
   }
 
   enum :severity, {
@@ -129,6 +130,11 @@ class AdminNotification < ApplicationRecord
     },
     # The status line every other import leaves behind, at info when it
     # finished and at error when it did not.
+    oauth_application_review: {
+      retention: 90.days,
+      access: [:oauth_applications],
+      icon: "fa-duotone fa-key"
+    },
     import_run: {
       retention: 30.days,
       access: [:imports],

--- a/app/models/oauth/application.rb
+++ b/app/models/oauth/application.rb
@@ -75,6 +75,13 @@ module Oauth
       end
     end
 
+    # Deliberately not what ransack suggests, which includes `secret`. Only the
+    # columns the admin list actually filters on: the list took `q` before this
+    # existed, so any real filter raised.
+    def self.ransackable_attributes(auth_object = nil)
+      %w[aasm_state created_at name owner_id updated_at]
+    end
+
     def self.policy_class
       OauthApplicationPolicy
     end
@@ -97,17 +104,24 @@ module Oauth
     end
 
     # The operator finds out from the notification center rather than by
-    # happening to open the admin page. `dedupe_key` on the record keeps a
-    # re-edited application to one row in the inbox.
+    # happening to open the admin page.
+    #
+    # One row for the whole queue, not one per application: the dedupe key is
+    # per recipient rather than per record, so the existing unread row is
+    # rewritten with the new count. Keying it on the id instead would turn a
+    # registration spree into an inbox nobody can read — and since anyone can
+    # sign up, a per-user cap would not prevent that.
     private def report_for_review
+      waiting = self.class.pending_review.count
+
       AdminNotification.notify!(
         type: :oauth_application_review,
-        title: "OAuth application awaiting review: #{name}",
-        body: owner.is_a?(User) ? "Registered by #{owner.username}" : nil,
+        title: "#{waiting} OAuth #{"application".pluralize(waiting)} awaiting review",
+        body: owner.is_a?(User) ? "Most recent: #{name}, registered by #{owner.username}" : "Most recent: #{name}",
         severity: :info,
-        link: "/oauth-applications/#{id}",
+        link: "/oauth-applications?q[aasm_state_eq]=pending",
         record: self,
-        dedupe_key: "oauth_application_review:#{id}"
+        dedupe_key: "oauth_application_review"
       )
     end
   end

--- a/app/models/oauth/application.rb
+++ b/app/models/oauth/application.rb
@@ -2,33 +2,113 @@
 #
 # Table name: oauth_applications
 #
-#  id           :uuid             not null, primary key
-#  confidential :boolean          default(TRUE), not null
-#  name         :string           not null
-#  owner_type   :string
-#  redirect_uri :text
-#  scopes       :string           default(""), not null
-#  secret       :string(512)      not null
-#  uid          :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  owner_id     :uuid
+#  id               :uuid             not null, primary key
+#  aasm_state       :string           default("pending"), not null
+#  approved_at      :datetime
+#  confidential     :boolean          default(TRUE), not null
+#  name             :string           not null
+#  owner_type       :string
+#  redirect_uri     :text
+#  rejected_at      :datetime
+#  rejection_reason :text
+#  scopes           :string           default(""), not null
+#  secret           :string(512)      not null
+#  uid              :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  owner_id         :uuid
+#  reviewed_by_id   :uuid
 #
 # Indexes
 #
+#  index_oauth_applications_on_aasm_state               (aasm_state)
 #  index_oauth_applications_on_owner_id_and_owner_type  (owner_id,owner_type)
+#  index_oauth_applications_on_reviewed_by_id           (reviewed_by_id)
 #  index_oauth_applications_on_uid                      (uid) UNIQUE
 #
 module Oauth
   class Application < ApplicationRecord
     include ::Doorkeeper::Orm::ActiveRecord::Mixins::Application
+    include AASM
 
     belongs_to :owner, polymorphic: true, optional: true
+    belongs_to :reviewed_by, class_name: "AdminUser", optional: true
 
     encrypts :secret
 
+    # Shown on the consent screen, so the person granting access can recognise
+    # who is asking. `no_vector_image` is not optional on anything a user
+    # uploads: an SVG can carry script, and this one is rendered to strangers.
+    has_one_attached :logo
+    validates :logo, no_vector_image: true
+
+    # A refusal the owner cannot act on is worse than no answer at all, so the
+    # reason is part of the transition rather than an optional note beside it.
+    validates :rejection_reason, presence: true, if: :rejected?
+
+    scope :pending_review, -> { where(aasm_state: "pending") }
+
+    # Approval is granted for one redirect target and one set of scopes. Without
+    # this, an application could be approved while harmless and then be pointed
+    # somewhere else, carrying a review nobody performed. Model-level rather than
+    # in the controller so no future write path can skip it.
+    before_update :return_to_review,
+      if: -> { approved? && (redirect_uri_changed? || scopes_changed?) }
+
+    after_create_commit :report_for_review, if: :pending?
+
+    # `whiny_transitions: false` matches the other state machines here, and
+    # timestamps fill `approved_at` / `rejected_at`. Both events transition with
+    # validation, so a reject without a reason fails rather than writing the
+    # state and dropping the note.
+    aasm timestamps: true, whiny_transitions: false do
+      state :pending, initial: true
+      state :approved
+      state :rejected
+
+      event :approve do
+        transitions from: %i[pending rejected], to: :approved, after: :clear_rejection
+      end
+
+      event :reject do
+        transitions from: %i[pending approved], to: :rejected
+      end
+    end
+
     def self.policy_class
       OauthApplicationPolicy
+    end
+
+    # What `allow_grant_flow_for_client` asks. Kept as a predicate rather than a
+    # bare state comparison because the initializer is the one place a wrong
+    # answer hands a stranger a working client.
+    def usable_as_client?
+      approved?
+    end
+
+    private def clear_rejection
+      self.rejection_reason = nil
+      self.rejected_at = nil
+    end
+
+    private def return_to_review
+      self.aasm_state = "pending"
+      self.approved_at = nil
+    end
+
+    # The operator finds out from the notification center rather than by
+    # happening to open the admin page. `dedupe_key` on the record keeps a
+    # re-edited application to one row in the inbox.
+    private def report_for_review
+      AdminNotification.notify!(
+        type: :oauth_application_review,
+        title: "OAuth application awaiting review: #{name}",
+        body: owner.is_a?(User) ? "Registered by #{owner.username}" : nil,
+        severity: :info,
+        link: "/oauth-applications/#{id}",
+        record: self,
+        dedupe_key: "oauth_application_review:#{id}"
+      )
     end
   end
 end

--- a/app/views/admin/api/v1/oauth_applications/_base.jbuilder
+++ b/app/views/admin/api/v1/oauth_applications/_base.jbuilder
@@ -9,4 +9,14 @@ json.redirect_uri oauth_application.redirect_uri
 json.scopes oauth_application.scopes.to_s
 json.owner_name oauth_application.owner&.username
 json.owner_id oauth_application.owner_id
+json.state oauth_application.aasm_state
+json.rejection_reason oauth_application.rejection_reason
+json.approved_at oauth_application.approved_at
+json.rejected_at oauth_application.rejected_at
+json.reviewed_by_name oauth_application.reviewed_by&.username
+if oauth_application.logo.attached?
+  json.logo do
+    json.partial! "api/v1/shared/file", record: oauth_application, attr: :logo
+  end
+end
 json.partial! "api/shared/dates", record: oauth_application

--- a/app/views/admin/api/v1/oauth_applications/reject_bulk.jbuilder
+++ b/app/views/admin/api/v1/oauth_applications/reject_bulk.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.count @count

--- a/app/views/api/v1/oauth_applications/_base.jbuilder
+++ b/app/views/api/v1/oauth_applications/_base.jbuilder
@@ -6,4 +6,11 @@ json.uid application.uid
 json.confidential application.confidential
 json.redirect_uri application.redirect_uri
 json.scopes application.scopes.to_s
+json.state application.aasm_state
+json.rejection_reason application.rejection_reason
+if application.logo.attached?
+  json.logo do
+    json.partial! "api/v1/shared/file", record: application, attr: :logo
+  end
+end
 json.partial! "api/shared/dates", record: application

--- a/app/views/oauth/authorizations/pre_authorization.jbuilder
+++ b/app/views/oauth/authorizations/pre_authorization.jbuilder
@@ -1,6 +1,13 @@
 json.client_id @pre_auth.client.uid
 json.client_name @pre_auth.client.name
 json.redirect_uri @pre_auth.redirect_uri
+# `client` is Doorkeeper's wrapper; the record carrying the attachment is the
+# application behind it.
+if @pre_auth.client.application.logo.attached?
+  json.client_logo do
+    json.partial! "api/v1/shared/file", record: @pre_auth.client.application, attr: :logo
+  end
+end
 json.state @pre_auth.state
 json.response_type @pre_auth.response_type
 json.response_mode @pre_auth.response_mode

--- a/asyncapi/cable/admin/v1/schema.yaml
+++ b/asyncapi/cable/admin/v1/schema.yaml
@@ -127,6 +127,7 @@ components:
       - sc_data_import
       - sc_data_unlisted_models
       - import_run
+      - oauth_application_review
       x-enumNames:
       - PAINTS_IMPORT
       - MODULES_IMPORT
@@ -141,6 +142,7 @@ components:
       - SC_DATA_IMPORT
       - SC_DATA_UNLISTED_MODELS
       - IMPORT_RUN
+      - OAUTH_APPLICATION_REVIEW
     Import:
       type: object
       properties:

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -305,6 +305,15 @@ Doorkeeper.configure do
   #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
   #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
   #
+  # An application a user registered is inert until an admin approves it.
+  # Doorkeeper answers :unauthorized_client and stops the request, and this hook
+  # sees the token exchange and the refresh as well as the authorization -- which
+  # is why the check lives here rather than in the endpoints, where one forgotten
+  # guard would be a working client for a stranger.
+  allow_grant_flow_for_client do |_grant_flow, client|
+    client.usable_as_client?
+  end
+
   handle_auth_errors :raise
 
   # Customize token introspection response.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -27,6 +27,18 @@ Rack::Attack.throttle("api", limit: limit_proc, period: 1.hour) do |req|
   end
 end
 
+# Registering an OAuth application is a deliberate act nobody performs in bulk,
+# and the blanket API throttle above allows thousands an hour. This does not stop
+# somebody signing up for fresh accounts -- nothing here would -- it stops one
+# account or one address producing a review queue in a single burst.
+Rack::Attack.throttle("oauth-application-registration", limit: 5, period: 1.hour) do |req|
+  if req.post? &&
+      req.path.match?(%r{^/v\d+/oauth-applications/?$}) &&
+      req.host.split(".").first == "api"
+    (req.get_header("action_dispatch.remote_ip") || req.ip).to_s
+  end
+end
+
 Rack::Attack.throttled_response_retry_after_header = true
 
 Rack::Attack.throttled_responder = lambda do |request|

--- a/config/locales/de/validation_error.yml
+++ b/config/locales/de/validation_error.yml
@@ -84,6 +84,8 @@ de:
       update: OAuth-Anwendung konnte nicht aktualisiert werden.
       destroy: OAuth-Anwendung konnte nicht gelöscht werden.
       regenerate_secret: Secret konnte nicht neu erzeugt werden.
+      approve: OAuth-Anwendung konnte nicht freigegeben werden.
+      reject: OAuth-Anwendung konnte nicht abgelehnt werden.
     user:
       destroy: Benutzer konnte nicht gelöscht werden.
       update: Benutzer konnte nicht aktualisiert werden.

--- a/config/locales/en/validation_error.yml
+++ b/config/locales/en/validation_error.yml
@@ -108,6 +108,8 @@ en:
       update: OAuth application could not be updated.
       destroy: OAuth application could not be destroyed.
       regenerate_secret: Secret could not be regenerated.
+      approve: OAuth application could not be approved.
+      reject: OAuth application could not be rejected.
     user:
       destroy: User could not be destroyed.
       update: User could not be updated.

--- a/config/locales/es/validation_error.yml
+++ b/config/locales/es/validation_error.yml
@@ -79,6 +79,8 @@ es:
       update: La aplicación OAuth no pudo ser actualizada.
       destroy: La aplicación OAuth no pudo ser eliminada.
       regenerate_secret: No se pudo regenerar el secreto.
+      approve: La aplicación OAuth no pudo ser aprobada.
+      reject: La aplicación OAuth no pudo ser rechazada.
     user:
       destroy: El usuario no pudo ser eliminado.
       update: No se pudo actualizar el usuario.

--- a/config/locales/fr/validation_error.yml
+++ b/config/locales/fr/validation_error.yml
@@ -76,6 +76,8 @@ fr:
       update: L'application OAuth n'a pas pu être mise à jour.
       destroy: L'application OAuth n'a pas pu être supprimée.
       regenerate_secret: Impossible de régénérer le secret.
+      approve: L'application OAuth n'a pas pu être approuvée.
+      reject: L'application OAuth n'a pas pu être refusée.
     user:
       destroy: L'utilisateur n'a pas pu être supprimé.
       update: Impossible de mettre à jour l'utilisateur.

--- a/config/locales/it/validation_error.yml
+++ b/config/locales/it/validation_error.yml
@@ -76,6 +76,8 @@ it:
       update: L'applicazione OAuth non è stata aggiornata.
       destroy: L'applicazione OAuth non è stata eliminata.
       regenerate_secret: Impossibile rigenerare il secret.
+      approve: L'applicazione OAuth non è stata approvata.
+      reject: L'applicazione OAuth non è stata rifiutata.
     user:
       destroy: L'utente non è stato eliminato.
       update: Impossibile aggiornare l'utente.

--- a/config/locales/zh-CN/validation_error.yml
+++ b/config/locales/zh-CN/validation_error.yml
@@ -75,6 +75,8 @@ zh-CN:
       update: OAuth 应用无法更新。
       destroy: OAuth 应用无法删除。
       regenerate_secret: 无法重新生成密钥。
+      approve: OAuth 应用无法批准。
+      reject: OAuth 应用无法拒绝。
     user:
       destroy: 无法删除用户。
       update: 无法更新用户。

--- a/config/locales/zh-TW/validation_error.yml
+++ b/config/locales/zh-TW/validation_error.yml
@@ -75,6 +75,8 @@ zh-TW:
       update: OAuth 應用程式無法更新。
       destroy: OAuth 應用程式無法刪除。
       regenerate_secret: 無法重新產生密鑰。
+      approve: OAuth 應用程式無法核准。
+      reject: OAuth 應用程式無法拒絕。
     user:
       destroy: 無法刪除使用者。
       update: 無法更新使用者。

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -193,7 +193,12 @@ v1_admin_api_routes = lambda do
     end
   end
 
-  resources :oauth_applications, path: "oauth-applications", only: %i[index show create update destroy]
+  resources :oauth_applications, path: "oauth-applications", only: %i[index show create update destroy] do
+    member do
+      put :approve
+      put :reject
+    end
+  end
 
   resources :rsi_request_logs, path: "rsi-request-logs", only: %i[index] do
     member do

--- a/config/routes/admin/api/v1_routes.rb
+++ b/config/routes/admin/api/v1_routes.rb
@@ -194,6 +194,10 @@ v1_admin_api_routes = lambda do
   end
 
   resources :oauth_applications, path: "oauth-applications", only: %i[index show create update destroy] do
+    collection do
+      put "reject-bulk", to: "oauth_applications#reject_bulk"
+    end
+
     member do
       put :approve
       put :reject

--- a/db/migrate/20260910151520_add_approval_to_oauth_applications.rb
+++ b/db/migrate/20260910151520_add_approval_to_oauth_applications.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class AddApprovalToOauthApplications < ActiveRecord::Migration[8.1]
+  def up
+    add_column :oauth_applications, :aasm_state, :string, null: false, default: "pending"
+    add_column :oauth_applications, :approved_at, :datetime
+    add_column :oauth_applications, :rejected_at, :datetime
+    add_column :oauth_applications, :rejection_reason, :text
+    add_column :oauth_applications, :reviewed_by_id, :uuid
+
+    add_index :oauth_applications, :aasm_state
+    add_index :oauth_applications, :reviewed_by_id
+
+    # Everything that exists predates the gate and was created by an operator,
+    # so it keeps working. `approved_at` stays null: nobody approved these, and
+    # a fabricated timestamp would claim a review that never happened.
+    up_only do
+      execute("UPDATE oauth_applications SET aasm_state = 'approved'")
+    end
+  end
+
+  def down
+    remove_index :oauth_applications, :reviewed_by_id
+    remove_index :oauth_applications, :aasm_state
+
+    remove_column :oauth_applications, :reviewed_by_id
+    remove_column :oauth_applications, :rejection_reason
+    remove_column :oauth_applications, :rejected_at
+    remove_column :oauth_applications, :approved_at
+    remove_column :oauth_applications, :aasm_state
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_08_170000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_10_151520) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1404,17 +1404,24 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_08_170000) do
   end
 
   create_table "oauth_applications", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "aasm_state", default: "pending", null: false
+    t.datetime "approved_at"
     t.boolean "confidential", default: true, null: false
     t.datetime "created_at", null: false
     t.string "name", null: false
     t.uuid "owner_id"
     t.string "owner_type"
     t.text "redirect_uri"
+    t.datetime "rejected_at"
+    t.text "rejection_reason"
+    t.uuid "reviewed_by_id"
     t.string "scopes", default: "", null: false
     t.string "secret", limit: 512, null: false
     t.string "uid", null: false
     t.datetime "updated_at", null: false
+    t.index ["aasm_state"], name: "index_oauth_applications_on_aasm_state"
     t.index ["owner_id", "owner_type"], name: "index_oauth_applications_on_owner_id_and_owner_type"
+    t.index ["reviewed_by_id"], name: "index_oauth_applications_on_reviewed_by_id"
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 

--- a/docs/exec-plans/4842-oauth-application-approval.md
+++ b/docs/exec-plans/4842-oauth-application-approval.md
@@ -1,0 +1,120 @@
+# OAuth applications: open registration, gated by admin approval
+
+## Goal
+
+Anyone can register an OAuth application, and an application does nothing until an admin approves it — so the provider that has been live and unreachable becomes usable without handing strangers a working client.
+
+## Context
+
+The OAuth2/OIDC provider runs in production today. Probed 2026-09-10:
+
+```
+/.well-known/openid-configuration   200   full discovery document
+/oauth/authorize                    401   exists, wants a login
+/oauth/token                        400   live
+/oauth/discovery/keys               200   real RSA keys
+/oauth/userinfo                     401   live
+```
+
+Scopes are enforced in the controllers, the OpenAPI security schemes and the `api/auth-v1` docs pages exist, and there are integration tests. What is missing is any way to *reach* it: `oauth-applications` has no global gate, exactly one user holds an actor gate, and `feature_settings` carries no row for it, so `UserFeaturesController#enable` answers `403 This feature cannot be self-activated`. One application exists, with 0 access tokens and 0 grants.
+
+Resolves #4842. Unblocks #2557, #3310, #2457.
+
+## Decisions
+
+### D1 — Gate the application, not the ability to create one
+
+Turning the flag on without a gate would let anyone mint a working client against the API. Gating creation instead keeps the door shut. So registration opens to everyone and a new application starts `pending`.
+
+### D2 — Enforce in `allow_grant_flow_for_client`
+
+Doorkeeper's hook receives `(grant_flow, client)`, answers `:unauthorized_client` and stops the request. It sees the token exchange and the refresh as well as the authorization, so one predicate covers every way a client could be used. Guards on the endpoints would have to be complete, and one forgotten guard is a working client for a stranger.
+
+That the hook fires is not taken on trust: adding it turned two existing authorize tests red with `unauthorized_client`, because the factory built an unreviewed application.
+
+### D3 — AASM `pending / approved / rejected`, with a mandatory reason
+
+Matches `FleetMembership`, `FleetEvent` and `Import`. Rejection is a state rather than an absence so the refusal can carry a reason — the owner is shown it, and a refusal they cannot act on is worse than no answer. It also allows withdrawing an approval later.
+
+Transitions go through `event` + `save` rather than `event!`: the bang form persists with `save!`, so a reject without a reason would raise instead of returning a validation error the controller can render as a 400.
+
+### D4 — Changing the redirect target or the scopes returns an application to review
+
+Found while reading the controller, not in the report. `update` permitted `redirect_uri` and `scopes` on an approved application, so the gate was bypassable: get approved while harmless, then point the client somewhere else. Approval is granted for one redirect target and one scope set, and changing either sends the application back to `pending`.
+
+The rule lives in a `before_update` on the model rather than in the controller, so no future write path can skip it. An admin edit is caught by the same rule; re-approving is one click, and the alternative is a rule with a hole in it.
+
+### D5 — Admin-created applications skip the queue
+
+The approval exists to gate strangers, not the operator. `Admin::…::OauthApplicationsController#create` approves on creation.
+
+### D6 — The operator hears about it in the notification center
+
+`AdminNotification.notify!` with a new `oauth_application_review` type, `access: [:oauth_applications]` so it reaches exactly the admins who can act on it, and a `dedupe_key` so a re-edited application stays one row in the inbox. The alternative — a badge on the admin page — only works for somebody already looking.
+
+### D7 — A logo, and `no_vector_image` is not negotiable
+
+Shown on the consent screen so the person granting access can recognise who is asking. `validates :logo, no_vector_image: true` as `Fleet` does: an SVG can carry script, and this one is rendered to strangers.
+
+The key is emitted only when a logo is attached. `MediaFile` requires four fields, so an empty `{}` for the common no-logo case would fail the schema; absent is valid and generates `logo?: MediaFile` rather than a nullable object, which is what produces invalid TS.
+
+### D8 — The state enum is written inline, not shared
+
+A shared enum component leaks into the public schema. Three literal enums cost less than one leaked component.
+
+### D9 — The backfill approves without claiming a review
+
+The one existing application becomes `approved`; `approved_at` stays null. Nobody reviewed it, and a fabricated timestamp would say otherwise.
+
+## What changed
+
+### Phase 1 — Model and migration
+1. `aasm_state` (default `pending`), `approved_at`, `rejected_at`, `rejection_reason`, `reviewed_by_id`; existing rows approved.
+2. AASM block, mandatory reason, `usable_as_client?`, `return_to_review`, `report_for_review`.
+3. `has_one_attached :logo` with `no_vector_image`.
+
+### Phase 2 — Enforcement
+4. `allow_grant_flow_for_client` in the Doorkeeper initializer.
+
+### Phase 3 — Admin
+5. `PUT approve` / `PUT reject` with routes, `aasm_state_eq` filter, auto-approval on admin create.
+6. `oauth_application_review` notification type.
+
+### Phase 4 — API surface
+7. `state`, `rejectionReason`, `logo` on the public schema; the admin schema also carries `approvedAt`, `rejectedAt`, `reviewedByName`. `logo` accepted on both inputs.
+8. Schema regenerated, orval clients regenerated.
+
+### Phase 5 — Tests
+9. `Oauth::ApplicationTest` — transitions, the mandatory reason, both return-to-review paths, the notification, the SVG refusal.
+10. Gate tests on `POST /authorize` for a pending and a rejected application.
+11. Admin approve/reject, including the refusal without a reason.
+12. Factory approved by default with `:pending` and `:rejected` traits — nearly every test is about a working client, and the gate is its own handful of tests.
+
+## Intent Verification
+
+- [ ] **An unreviewed application is inert** — `POST /authorize` answers `unauthorized_client`
+- [ ] **So is a rejected one**
+- [ ] **A refusal explains itself** — reject without a reason is a 400, and the reason reaches the owner
+- [ ] **Approval cannot be moved** — changing redirect or scopes returns it to the queue
+- [ ] **The operator finds out** — a pending application appears in the notification center
+- [ ] **SVG is refused** on the logo
+- [ ] **Nothing existing broke** — the one production application keeps working
+
+## Not in scope (deferred)
+
+- **Turning the flag on** — an admin action, and the point of the whole change, but not code. Global boolean, or a `feature_settings` row for self-service.
+- **A per-user limit on applications** — worth having before this is wide open; the approval queue is the interim answer.
+- **Rate limiting registration.**
+
+## Discovery Log
+
+- **2026-09-10** Audited the provider rather than trusting the earlier triage, which had called this "built, needs a rollout" and pointed at `oauth-security.md` — that plan is about OAuth as a *consumer* (Discord login), not the provider. Probed production: everything answers. Found the real gap is the flag and the missing `feature_settings` row. Found D4, the bypass, while reading the controller.
+
+## Progress
+
+- [x] Phase 1 — Model and migration
+- [x] Phase 2 — Enforcement
+- [x] Phase 3 — Admin
+- [x] Phase 4 — API surface
+- [x] Phase 5 — Tests
+- [ ] Phase 6 — Frontend: consent-screen logo, settings upload and state, admin review UI

--- a/docs/exec-plans/4842-oauth-application-approval.md
+++ b/docs/exec-plans/4842-oauth-application-approval.md
@@ -66,6 +66,16 @@ A shared enum component leaks into the public schema. Three literal enums cost l
 
 The one existing application becomes `approved`; `approved_at` stays null. Nobody reviewed it, and a fabricated timestamp would say otherwise.
 
+### D11 — A per-user limit is not the answer; the queue being survivable is
+
+Anyone can sign up, so a cap on applications per account does not stop a determined registration spree — it only makes the accidental case deliberate. What a spree actually costs is the operator's attention, so the protections aim there instead:
+
+- the review notification aggregates to one row carrying a count, where keying the dedupe on the record id would have made a spree an unreadable inbox;
+- registration is throttled to 5 per hour per address, which stops the burst without pretending to stop account farming;
+- refusing is a bulk action, so clearing junk is one gesture rather than fifty.
+
+A cap is still available later, and would be a guardrail against accidents rather than a security control. It is not worth the validation, the message in seven locales and the UI affordance until there is a reason.
+
 ### D10 — The consent screen describes its logo inline
 
 `clientLogo` cannot `$ref` the shared `MediaFile`: the OAuth schema is its own document and does not carry the shared components, so orval fails with `INVALID_REFERENCE`. The consent screen draws one image, so the inline object carries the three URLs it might use and nothing else.
@@ -101,6 +111,12 @@ The one existing application becomes `approved`; `approved_at` stays null. Nobod
 16. Consent screen draws the logo above the sentence naming the application.
 17. Admin list gains a state column and approve/reject actions; refusing opens a modal, because the reason is required and `displayConfirm` takes no input.
 
+### Phase 7 — Surviving the queue
+18. The review notification is one row for the whole queue, not one per application: the dedupe key is per recipient, and the title carries the count.
+19. A rack-attack throttle on `POST /v1/oauth-applications`, 5 per hour per address.
+20. `PUT /oauth-applications/reject-bulk`, and a bulk bar on the admin list.
+21. `Oauth::Application.ransackable_attributes` — the admin list accepted `q` before this existed, so any real filter raised. Deliberately not what ransack suggests, which includes `secret`.
+
 ## Intent Verification
 
 - [ ] **An unreviewed application is inert** — `POST /authorize` answers `unauthorized_client`
@@ -114,11 +130,12 @@ The one existing application becomes `approved`; `approved_at` stays null. Nobod
 ## Not in scope (deferred)
 
 - **Turning the flag on** — an admin action, and the point of the whole change, but not code. Global boolean, or a `feature_settings` row for self-service.
-- **A per-user limit on applications** — worth having before this is wide open; the approval queue is the interim answer.
-- **Rate limiting registration.**
+- **A per-user limit on applications** — see D11. Available later, but it protects against accidents rather than abuse, and nothing here needs it yet.
+- **Bulk approve** — refusing in bulk is how a spree gets cleared; approving is a judgement made one application at a time.
 
 ## Discovery Log
 
+- **2026-09-10** Queue hardening after a fair challenge: a per-user cap does not survive "anyone can make an account". Recorded as D11 and built the three things that do help. Found while adding the state filter that `Oauth::Application` had no `ransackable_attributes`, so the admin list's existing `q` support raised on any real filter.
 - **2026-09-10** Frontend built. Hit the cross-document `$ref` limit on `MediaFile` in the OAuth schema — recorded as D10. UI copy added by hand across seven locales; a Ruby-side test enforces the same for validation error codes, which is how the two new codes were caught.
 - **2026-09-10** Audited the provider rather than trusting the earlier triage, which had called this "built, needs a rollout" and pointed at `oauth-security.md` — that plan is about OAuth as a *consumer* (Discord login), not the provider. Probed production: everything answers. Found the real gap is the flag and the missing `feature_settings` row. Found D4, the bypass, while reading the controller.
 
@@ -130,4 +147,5 @@ The one existing application becomes `approved`; `approved_at` stays null. Nobod
 - [x] Phase 4 — API surface
 - [x] Phase 5 — Tests
 - [x] Phase 6 — Frontend: consent-screen logo, settings upload and state, admin review UI
+- [x] Phase 7 — Surviving the queue
 - [ ] Turn the flag on (admin action, not code)

--- a/docs/exec-plans/4842-oauth-application-approval.md
+++ b/docs/exec-plans/4842-oauth-application-approval.md
@@ -66,6 +66,10 @@ A shared enum component leaks into the public schema. Three literal enums cost l
 
 The one existing application becomes `approved`; `approved_at` stays null. Nobody reviewed it, and a fabricated timestamp would say otherwise.
 
+### D10 — The consent screen describes its logo inline
+
+`clientLogo` cannot `$ref` the shared `MediaFile`: the OAuth schema is its own document and does not carry the shared components, so orval fails with `INVALID_REFERENCE`. The consent screen draws one image, so the inline object carries the three URLs it might use and nothing else.
+
 ## What changed
 
 ### Phase 1 — Model and migration
@@ -90,6 +94,13 @@ The one existing application becomes `approved`; `approved_at` stays null. Nobod
 11. Admin approve/reject, including the refusal without a reason.
 12. Factory approved by default with `:pending` and `:rejected` traits — nearly every test is about a working client, and the gate is its own handful of tests.
 
+### Phase 6 — Frontend
+13. `OauthApplicationState`, a shared pill, rather than the same mapping written at four call sites.
+14. Settings list carries the state; the detail page leads with a banner naming it and the refusal reason, ahead of the credentials — whether the client works at all is the first thing its owner needs.
+15. Logo upload on create and edit. `AllowedFileTypes.IMAGE` already excludes SVG, so the picker cannot offer one and `no_vector_image` is the backstop rather than the only guard.
+16. Consent screen draws the logo above the sentence naming the application.
+17. Admin list gains a state column and approve/reject actions; refusing opens a modal, because the reason is required and `displayConfirm` takes no input.
+
 ## Intent Verification
 
 - [ ] **An unreviewed application is inert** — `POST /authorize` answers `unauthorized_client`
@@ -108,6 +119,7 @@ The one existing application becomes `approved`; `approved_at` stays null. Nobod
 
 ## Discovery Log
 
+- **2026-09-10** Frontend built. Hit the cross-document `$ref` limit on `MediaFile` in the OAuth schema — recorded as D10. UI copy added by hand across seven locales; a Ruby-side test enforces the same for validation error codes, which is how the two new codes were caught.
 - **2026-09-10** Audited the provider rather than trusting the earlier triage, which had called this "built, needs a rollout" and pointed at `oauth-security.md` — that plan is about OAuth as a *consumer* (Discord login), not the provider. Probed production: everything answers. Found the real gap is the flag and the missing `feature_settings` row. Found D4, the bypass, while reading the controller.
 
 ## Progress
@@ -117,4 +129,5 @@ The one existing application becomes `approved`; `approved_at` stays null. Nobod
 - [x] Phase 3 — Admin
 - [x] Phase 4 — API surface
 - [x] Phase 5 — Tests
-- [ ] Phase 6 — Frontend: consent-screen logo, settings upload and state, admin review UI
+- [x] Phase 6 — Frontend: consent-screen logo, settings upload and state, admin review UI
+- [ ] Turn the flag on (admin action, not code)

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -6144,6 +6144,98 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/oauth-applications/{id}/approve":
+    parameters:
+    - name: id
+      in: path
+      description: OAuth Application id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    put:
+      summary: Approve OAuth Application
+      tags:
+      - OauthApplications
+      operationId: approveOauthApplication
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OauthApplication"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '400':
+          "$ref": "#/components/responses/SchemaValidationError"
+  "/oauth-applications/{id}/reject":
+    parameters:
+    - name: id
+      in: path
+      description: OAuth Application id
+      schema:
+        type: string
+        format: uuid
+      required: true
+    put:
+      summary: Reject OAuth Application
+      tags:
+      - OauthApplications
+      operationId: rejectOauthApplication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/OauthApplicationRejectInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OauthApplication"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/resource-access-catalog":
     get:
       summary: Resource Access Catalog
@@ -8612,6 +8704,7 @@ components:
       - sc_data_import
       - sc_data_unlisted_models
       - import_run
+      - oauth_application_review
       x-enumNames:
       - PAINTS_IMPORT
       - MODULES_IMPORT
@@ -8626,6 +8719,7 @@ components:
       - SC_DATA_IMPORT
       - SC_DATA_UNLISTED_MODELS
       - IMPORT_RUN
+      - OAUTH_APPLICATION_REVIEW
       title: AdminNotificationTypeEnum
     AdminNotificationUnreadCount:
       type: object
@@ -14898,6 +14992,32 @@ components:
         ownerId:
           type: string
           format: uuid
+        state:
+          type: string
+          enum:
+          - pending
+          - approved
+          - rejected
+        rejectionReason:
+          type:
+          - string
+          - 'null'
+        approvedAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        rejectedAt:
+          type:
+          - string
+          - 'null'
+          format: date-time
+        reviewedByName:
+          type:
+          - string
+          - 'null'
+        logo:
+          "$ref": "#/components/schemas/MediaFile"
         createdAt:
           type: string
           format: date-time
@@ -14913,6 +15033,7 @@ components:
       - confidential
       - redirectUri
       - scopes
+      - state
       - createdAt
       - updatedAt
       title: OauthApplication
@@ -14945,6 +15066,15 @@ components:
       additionalProperties: false
       example: {}
       title: OauthApplicationQuery
+    OauthApplicationRejectInput:
+      type: object
+      properties:
+        rejectionReason:
+          type: string
+      additionalProperties: false
+      required:
+      - rejectionReason
+      title: OauthApplicationRejectInput
     OauthApplicationUpdateInput:
       type: object
       properties:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -6033,6 +6033,43 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+  "/oauth-applications/reject-bulk":
+    put:
+      summary: Reject OAuth Applications in bulk
+      tags:
+      - OauthApplications
+      operationId: rejectOauthApplicationsBulk
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/OauthApplicationRejectBulkInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/OauthApplicationBulkResult"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/oauth-applications/{id}":
     parameters:
     - name: id
@@ -15037,6 +15074,15 @@ components:
       - createdAt
       - updatedAt
       title: OauthApplication
+    OauthApplicationBulkResult:
+      type: object
+      properties:
+        count:
+          type: integer
+      additionalProperties: false
+      required:
+      - count
+      title: OauthApplicationBulkResult
     OauthApplicationInput:
       type: object
       properties:
@@ -15063,9 +15109,36 @@ components:
         ownerIdEq:
           type: string
           format: uuid
+        aasmStateEq:
+          type: string
+          enum:
+          - pending
+          - approved
+          - rejected
       additionalProperties: false
       example: {}
       title: OauthApplicationQuery
+    OauthApplicationRejectBulkInput:
+      type: object
+      properties:
+        rejectionReason:
+          type: string
+        ids:
+          type: array
+          items:
+            type: string
+            format: uuid
+        all:
+          type: boolean
+          default: false
+          description: Apply to every application matching `q` instead of `ids`.
+        q:
+          "$ref": "#/components/schemas/OauthApplicationQuery"
+      additionalProperties: false
+      required:
+      - rejectionReason
+      description: Naming neither `ids` nor `all` selects nothing.
+      title: OauthApplicationRejectBulkInput
     OauthApplicationRejectInput:
       type: object
       properties:

--- a/swagger/oauth/v1/schema.yaml
+++ b/swagger/oauth/v1/schema.yaml
@@ -193,6 +193,21 @@ components:
           type: string
         redirectUri:
           type: string
+        clientLogo:
+          type: object
+          properties:
+            url:
+              type: string
+              format: uri
+            smallUrl:
+              type: string
+              format: uri
+            mediumUrl:
+              type: string
+              format: uri
+          additionalProperties: false
+          required:
+          - url
         state:
           type: string
         responseType:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -19451,6 +19451,18 @@ components:
           type: string
         scopes:
           type: string
+        state:
+          type: string
+          enum:
+          - pending
+          - approved
+          - rejected
+        rejectionReason:
+          type:
+          - string
+          - 'null'
+        logo:
+          "$ref": "#/components/schemas/MediaFile"
         createdAt:
           type: string
           format: date-time
@@ -19465,6 +19477,7 @@ components:
       - confidential
       - redirectUri
       - scopes
+      - state
       - createdAt
       - updatedAt
       title: OauthApplication
@@ -19477,6 +19490,10 @@ components:
           type: string
         confidential:
           type: boolean
+        logo:
+          type:
+          - string
+          - 'null'
         scopes:
           type: array
           items:
@@ -19499,6 +19516,10 @@ components:
           - 'null'
         confidential:
           type: boolean
+        logo:
+          type:
+          - string
+          - 'null'
         scopes:
           type:
           - array
@@ -19525,6 +19546,18 @@ components:
           type: string
         scopes:
           type: string
+        state:
+          type: string
+          enum:
+          - pending
+          - approved
+          - rejected
+        rejectionReason:
+          type:
+          - string
+          - 'null'
+        logo:
+          "$ref": "#/components/schemas/MediaFile"
         createdAt:
           type: string
           format: date-time
@@ -19540,6 +19573,7 @@ components:
       - confidential
       - redirectUri
       - scopes
+      - state
       - createdAt
       - updatedAt
       title: OauthApplicationWithSecret

--- a/test/factories/oauth_applications.rb
+++ b/test/factories/oauth_applications.rb
@@ -2,21 +2,28 @@
 #
 # Table name: oauth_applications
 #
-#  id           :uuid             not null, primary key
-#  confidential :boolean          default(TRUE), not null
-#  name         :string           not null
-#  owner_type   :string
-#  redirect_uri :text
-#  scopes       :string           default(""), not null
-#  secret       :string(512)      not null
-#  uid          :string           not null
-#  created_at   :datetime         not null
-#  updated_at   :datetime         not null
-#  owner_id     :uuid
+#  id               :uuid             not null, primary key
+#  aasm_state       :string           default("pending"), not null
+#  approved_at      :datetime
+#  confidential     :boolean          default(TRUE), not null
+#  name             :string           not null
+#  owner_type       :string
+#  redirect_uri     :text
+#  rejected_at      :datetime
+#  rejection_reason :text
+#  scopes           :string           default(""), not null
+#  secret           :string(512)      not null
+#  uid              :string           not null
+#  created_at       :datetime         not null
+#  updated_at       :datetime         not null
+#  owner_id         :uuid
+#  reviewed_by_id   :uuid
 #
 # Indexes
 #
+#  index_oauth_applications_on_aasm_state               (aasm_state)
 #  index_oauth_applications_on_owner_id_and_owner_type  (owner_id,owner_type)
+#  index_oauth_applications_on_reviewed_by_id           (reviewed_by_id)
 #  index_oauth_applications_on_uid                      (uid) UNIQUE
 #
 FactoryBot.define do
@@ -33,5 +40,23 @@ FactoryBot.define do
     }
     owner { create(:user) }
     redirect_uri { "#{Faker::Internet.url(scheme: "https")}\n#{Faker::Internet.url(scheme: "https")}" }
+
+    # Approved by default: almost every test is about what a working client
+    # does, and the review gate is its own handful of tests rather than a
+    # precondition every one of them has to restate.
+    aasm_state { "approved" }
+    approved_at { Time.zone.now }
+
+    trait :pending do
+      aasm_state { "pending" }
+      approved_at { nil }
+    end
+
+    trait :rejected do
+      aasm_state { "rejected" }
+      approved_at { nil }
+      rejected_at { Time.zone.now }
+      rejection_reason { "Redirect target is not under the stated domain" }
+    end
   end
 end

--- a/test/integration/admin/api/v1/oauth_applications_test.rb
+++ b/test/integration/admin/api/v1/oauth_applications_test.rb
@@ -127,8 +127,115 @@ class Admin::Api::V1::OauthApplicationsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  api_path "/oauth-applications/{id}/approve" do
+    parameter name: "id", in: :path, description: "OAuth Application id", schema: {type: :string, format: :uuid}
+
+    put("Approve OAuth Application") do
+      operationId "approveOauthApplication"
+      tags "OauthApplications"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::OauthApplication
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  api_path "/oauth-applications/{id}/reject" do
+    parameter name: "id", in: :path, description: "OAuth Application id", schema: {type: :string, format: :uuid}
+
+    put("Reject OAuth Application") do
+      operationId "rejectOauthApplication"
+      tags "OauthApplications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::OauthApplicationRejectInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::OauthApplication
+      end
+
+      response(400, "bad request") do
+        schema ::Shared::V1::Schemas::ValidationError
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
   setup do
     @user = create(:admin_user, resource_access: [:oauth_applications])
+  end
+  # APPROVE
+  test "PUT /oauth-applications/:id/approve makes the application usable" do
+    application = create(:oauth_application, :pending)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/oauth-applications/{id}/approve", path_params: {id: application.id} do
+      assert_equal "approved", parsed_body["state"]
+    end
+
+    assert application.reload.usable_as_client?
+    assert_equal @user.id, application.reviewed_by_id
+  end
+
+  test "PUT /oauth-applications/:id/approve returns 401 when not signed in" do
+    application = create(:oauth_application, :pending)
+
+    assert_api_response :put, 401, api_path: "/oauth-applications/{id}/approve", path_params: {id: application.id}
+  end
+
+  test "PUT /oauth-applications/:id/approve returns 403 for admin without access" do
+    application = create(:oauth_application, :pending)
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, api_path: "/oauth-applications/{id}/approve", path_params: {id: application.id}
+  end
+
+  # REJECT
+  test "PUT /oauth-applications/:id/reject records the reason" do
+    application = create(:oauth_application, :pending)
+    sign_in @user
+
+    body = {rejectionReason: "Redirect target is not under the stated domain"}
+    assert_api_response :put, 200, api_path: "/oauth-applications/{id}/reject", path_params: {id: application.id}, body: body do
+      assert_equal "rejected", parsed_body["state"]
+      assert_equal "Redirect target is not under the stated domain", parsed_body["rejectionReason"]
+    end
+
+    assert_not application.reload.usable_as_client?
+  end
+
+  test "PUT /oauth-applications/:id/reject without a reason is refused" do
+    application = create(:oauth_application, :pending)
+    sign_in @user
+
+    assert_api_response :put, 400, api_path: "/oauth-applications/{id}/reject", path_params: {id: application.id}, body: {rejectionReason: ""}
+
+    assert_predicate application.reload, :pending?
   end
 
   # POST
@@ -230,7 +337,7 @@ class Admin::Api::V1::OauthApplicationsTest < ActionDispatch::IntegrationTest
     app = create(:oauth_application)
     sign_in @user
 
-    assert_api_response :put, 200, path_params: {id: app.id}, body: {name: "Updated Admin App"} do
+    assert_api_response :put, 200, api_path: "/oauth-applications/{id}", path_params: {id: app.id}, body: {name: "Updated Admin App"} do
       assert_equal "Updated Admin App", parsed_body["name"]
     end
   end
@@ -238,19 +345,19 @@ class Admin::Api::V1::OauthApplicationsTest < ActionDispatch::IntegrationTest
   test "PUT /oauth-applications/:id returns 404 for missing id" do
     sign_in @user
 
-    assert_api_response :put, 404, path_params: {id: SecureRandom.uuid}, body: {name: "x"}
+    assert_api_response :put, 404, api_path: "/oauth-applications/{id}", path_params: {id: SecureRandom.uuid}, body: {name: "x"}
   end
 
   test "PUT /oauth-applications/:id returns 401 when not signed in" do
     app = create(:oauth_application)
 
-    assert_api_response :put, 401, path_params: {id: app.id}, body: {name: "x"}
+    assert_api_response :put, 401, api_path: "/oauth-applications/{id}", path_params: {id: app.id}, body: {name: "x"}
   end
 
   test "PUT /oauth-applications/:id returns 403 for admin without access" do
     app = create(:oauth_application)
     sign_in create(:admin_user, resource_access: [])
 
-    assert_api_response :put, 403, path_params: {id: app.id}, body: {name: "x"}
+    assert_api_response :put, 403, api_path: "/oauth-applications/{id}", path_params: {id: app.id}, body: {name: "x"}
   end
 end

--- a/test/integration/admin/api/v1/oauth_applications_test.rb
+++ b/test/integration/admin/api/v1/oauth_applications_test.rb
@@ -127,6 +127,33 @@ class Admin::Api::V1::OauthApplicationsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  api_path "/oauth-applications/reject-bulk" do
+    put("Reject OAuth Applications in bulk") do
+      operationId "rejectOauthApplicationsBulk"
+      tags "OauthApplications"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::Admin::V1::Schemas::Inputs::OauthApplicationRejectBulkInput
+
+      response(200, "successful") do
+        schema ::Admin::V1::Schemas::OauthApplicationBulkResult
+      end
+
+      response(400, "bad request") do
+        schema ::Shared::V1::Schemas::ValidationError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
   api_path "/oauth-applications/{id}/approve" do
     parameter name: "id", in: :path, description: "OAuth Application id", schema: {type: :string, format: :uuid}
 
@@ -189,6 +216,66 @@ class Admin::Api::V1::OauthApplicationsTest < ActionDispatch::IntegrationTest
   setup do
     @user = create(:admin_user, resource_access: [:oauth_applications])
   end
+  # REJECT BULK
+  test "PUT /oauth-applications/reject-bulk refuses the named applications" do
+    pending_applications = create_list(:oauth_application, 3, :pending)
+    untouched = create(:oauth_application, :pending)
+    sign_in @user
+
+    body = {ids: pending_applications.map(&:id), rejectionReason: "Bulk refusal"}
+    assert_api_response :put, 200, api_path: "/oauth-applications/reject-bulk", body: body do
+      assert_equal 3, parsed_body["count"]
+    end
+
+    pending_applications.each do |application|
+      assert_predicate application.reload, :rejected?
+      assert_equal "Bulk refusal", application.rejection_reason
+      assert_not application.usable_as_client?
+    end
+
+    assert_predicate untouched.reload, :pending?
+  end
+
+  # The other reading of a body naming neither is `update_all` over the table.
+  test "PUT /oauth-applications/reject-bulk selects nothing when given neither ids nor all" do
+    application = create(:oauth_application, :pending)
+    sign_in @user
+
+    assert_api_response :put, 200, api_path: "/oauth-applications/reject-bulk", body: {rejectionReason: "Bulk refusal"} do
+      assert_equal 0, parsed_body["count"]
+    end
+
+    assert_predicate application.reload, :pending?
+  end
+
+  test "PUT /oauth-applications/reject-bulk takes everything the filter matches when asked" do
+    create_list(:oauth_application, 2, :pending)
+    approved = create(:oauth_application)
+    sign_in @user
+
+    body = {all: true, q: {aasmStateEq: "pending"}, rejectionReason: "Bulk refusal"}
+    assert_api_response :put, 200, api_path: "/oauth-applications/reject-bulk", body: body do
+      assert_equal 2, parsed_body["count"]
+    end
+
+    assert_predicate approved.reload, :approved?
+  end
+
+  test "PUT /oauth-applications/reject-bulk without a reason is refused" do
+    application = create(:oauth_application, :pending)
+    sign_in @user
+
+    assert_api_response :put, 400, api_path: "/oauth-applications/reject-bulk", body: {ids: [application.id], rejectionReason: ""}
+
+    assert_predicate application.reload, :pending?
+  end
+
+  test "PUT /oauth-applications/reject-bulk returns 403 for admin without access" do
+    sign_in create(:admin_user, resource_access: [])
+
+    assert_api_response :put, 403, api_path: "/oauth-applications/reject-bulk", body: {ids: [], rejectionReason: "x"}
+  end
+
   # APPROVE
   test "PUT /oauth-applications/:id/approve makes the application usable" do
     application = create(:oauth_application, :pending)

--- a/test/integration/oauth/authorize_test.rb
+++ b/test/integration/oauth/authorize_test.rb
@@ -139,6 +139,26 @@ class Oauth::AuthorizeTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # The gate at the point a grant would be issued. 401 rather than 200 is the
+  # whole feature: an application nobody reviewed cannot mint one.
+  test "POST /authorize refuses an application still awaiting review" do
+    sign_in @user
+    @oauth_application.update_columns(aasm_state: "pending", approved_at: nil)
+
+    assert_api_response :post, 401, body: auth_body do
+      assert_equal "unauthorized_client", parsed_body["error"]
+    end
+  end
+
+  test "POST /authorize refuses a rejected application" do
+    sign_in @user
+    @oauth_application.update_columns(aasm_state: "rejected", approved_at: nil)
+
+    assert_api_response :post, 401, body: auth_body do
+      assert_equal "unauthorized_client", parsed_body["error"]
+    end
+  end
+
   test "POST /authorize returns 401 when no user is signed in" do
     new_app = create(
       :oauth_application,

--- a/test/models/oauth/application_test.rb
+++ b/test/models/oauth/application_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Oauth
+  class ApplicationTest < ActiveSupport::TestCase
+    test "is pending until somebody approves it" do
+      application = create(:oauth_application, :pending)
+
+      assert_predicate application, :pending?
+      assert_not application.usable_as_client?
+    end
+
+    test "approving makes it usable and stamps the time" do
+      application = create(:oauth_application, :pending)
+
+      application.approve
+
+      assert application.save
+
+      assert_predicate application, :approved?
+      assert_not_nil application.approved_at
+      assert application.usable_as_client?
+    end
+
+    test "rejecting without a reason is refused" do
+      application = create(:oauth_application, :pending)
+
+      application.reject
+
+      assert_not application.save
+      assert_includes application.errors.attribute_names, :rejection_reason
+      assert_predicate application.reload, :pending?
+    end
+
+    test "rejecting with a reason records it" do
+      application = create(:oauth_application, :pending)
+      application.rejection_reason = "Redirect target is not under the stated domain"
+
+      application.reject
+
+      assert application.save
+
+      assert_predicate application, :rejected?
+      assert_not_nil application.rejected_at
+      assert_not application.usable_as_client?
+    end
+
+    test "approving a rejected application clears the refusal" do
+      application = create(:oauth_application, :rejected)
+
+      application.approve
+
+      assert application.save
+
+      assert_predicate application, :approved?
+      assert_nil application.rejection_reason
+      assert_nil application.rejected_at
+    end
+
+    # Approval is granted for one redirect target and one set of scopes, so
+    # moving either afterwards would carry a review nobody performed.
+    test "changing the redirect target returns an approved application to review" do
+      application = create(:oauth_application)
+
+      application.update!(redirect_uri: "https://somewhere-else.example.com/callback")
+
+      assert_predicate application.reload, :pending?
+      assert_nil application.approved_at
+      assert_not application.usable_as_client?
+    end
+
+    test "changing the scopes returns an approved application to review" do
+      application = create(:oauth_application)
+
+      application.update!(scopes: ["public", "hangar:write"])
+
+      assert_predicate application.reload, :pending?
+    end
+
+    test "renaming an approved application leaves it approved" do
+      application = create(:oauth_application)
+
+      application.update!(name: "Renamed")
+
+      assert_predicate application.reload, :approved?
+    end
+
+    test "a pending application reports itself for review" do
+      admin_user = create(:admin_user, :super_admin)
+
+      assert_difference -> { AdminNotification.where(admin_user:, notification_type: "oauth_application_review").count }, 1 do
+        create(:oauth_application, :pending)
+      end
+    end
+
+    test "an approved application reports nothing" do
+      create(:admin_user, :super_admin)
+
+      assert_no_difference -> { AdminNotification.where(notification_type: "oauth_application_review").count } do
+        create(:oauth_application)
+      end
+    end
+
+    test "rejects a vector logo" do
+      application = build(:oauth_application)
+      application.logo.attach(
+        io: StringIO.new("<svg xmlns='http://www.w3.org/2000/svg'></svg>"),
+        filename: "logo.svg",
+        content_type: "image/svg+xml"
+      )
+
+      assert_not application.valid?
+      assert_includes application.errors.attribute_names, :logo
+    end
+  end
+end


### PR DESCRIPTION
Resolves #4842. Unblocks #2557, #3310, #2457.

## The problem

The OAuth2/OIDC provider has been live in production for months and unreachable. Probed today:

```
/.well-known/openid-configuration   200   full discovery document
/oauth/authorize                    401   exists, wants a login
/oauth/token                        400   live
/oauth/discovery/keys               200   real RSA keys
```

Scopes are enforced, the docs pages and security schemes exist, there are integration tests. What was missing is any way to *reach* it: `oauth-applications` has no global gate, one user holds an actor gate, and `feature_settings` carries no row, so self-activation answers `403 This feature cannot be self-activated`. One application exists, with zero tokens and zero grants.

Three open issues have been waiting on this — including a community developer who was told a year ago that OAuth2 was planned, while it was quietly finished around him.

## The shape

Opening the flag on its own would let anyone mint a working client against the API, so the gate moves onto the application instead of onto the ability to create one. A new application starts `pending` and does nothing until an admin approves it.

**Enforcement** is `allow_grant_flow_for_client`, which answers `:unauthorized_client` and sees the token exchange and the refresh as well as the authorization. Guards on the endpoints would have to be complete, and one forgotten guard is a working client for a stranger. That the hook fires is not taken on trust — adding it turned two existing authorize tests red.

**State** is AASM `pending / approved / rejected`, matching `FleetMembership`, `FleetEvent` and `Import`. Refusal carries a **mandatory** reason: it is shown to the owner, and a refusal they cannot act on is worse than no answer.

## One thing found while reading, not reported

`update` permitted `redirect_uri` and `scopes` on an *approved* application. The gate was bypassable: get approved while harmless, then point the client somewhere else. Approval is granted for one redirect target and one scope set, so changing either now returns the application to the queue. The rule sits in a model callback rather than the controller, so no later write path can skip it.

## Logo

Applications carry a logo, drawn on the consent screen so the person granting access can recognise who is asking. `validates :logo, no_vector_image: true` as `Fleet` does — an SVG can carry script and this one is rendered to strangers. The file picker cannot offer one either, since `AllowedFileTypes.IMAGE` lists only jpeg/jpg/png/gif/webp.

## Notes

- The key is emitted only when a logo is attached: `MediaFile` requires four fields, so an empty `{}` for the common case would fail validation, and absent generates `logo?: MediaFile` rather than a nullable object.
- `clientLogo` on the consent screen is described inline — the OAuth schema is its own document and orval fails with `INVALID_REFERENCE` on a `$ref` to the shared component.
- The migration approves the one existing application but leaves `approved_at` null. Nobody reviewed it, and a fabricated timestamp would claim otherwise.
- A Ruby-side test enforces that every validation error code is translated in all seven locales, which caught the two new codes. Frontend copy has no such test and was done by hand.

## Verification

681 tests across `test/models/`, `test/integration/oauth/` and the application endpoints pass. `bin/ruby-lint` and `pnpm lint` clean.

## Surviving the queue

A cap on applications per account was the obvious guardrail and does not survive the obvious objection: anyone can sign up. So the protections aim at what a registration spree actually costs, which is the operator's attention.

- **The review notification is one row, not one per application.** The dedupe key is per recipient and the title carries the count — `7 OAuth applications awaiting review`. Keying it on the record id, as the first draft did, would have turned a spree into an inbox nobody can read.
- **Registration is throttled** to 5 an hour per address. The blanket API throttle above it allows thousands. This does not stop somebody signing up for fresh accounts; nothing here would.
- **Refusing is a bulk action**, so clearing junk is one gesture. A body naming neither `ids` nor `all` selects nothing — the other reading of it is `update_all` over the table.

A per-user cap stays available, but it guards against accidents rather than abuse, and it is not worth a validation, a message in seven locales and a UI affordance until something needs it.

Adding the state filter also turned up that `Oauth::Application` had no `ransackable_attributes` at all, so the admin list's existing `q` support raised on any real filter. Defined now — deliberately not the list ransack suggests, which includes `secret`.

## What this does not do

**It does not turn the flag on.** That is an admin action and the point of the whole change — either a global boolean or a `feature_settings` row for self-service.

Plan: `docs/exec-plans/4842-oauth-application-approval.md`

🤖
