### PR TITLE
feat(fleetchart): share the chart from its own controls

### DIFF
--- a/app/frontend/frontend/components/Fleetchart/App/index.vue
+++ b/app/frontend/frontend/components/Fleetchart/App/index.vue
@@ -13,6 +13,7 @@ import Loader from "@/shared/components/Loader/index.vue";
 import type { Vehicle, Model, VehiclePublic } from "@/services/fyApi";
 import { useMobile } from "@/shared/composables/useMobile";
 import { useI18n } from "@/shared/composables/useI18n";
+import ShareBtn from "@/frontend/components/ShareBtn/index.vue";
 import { useFleetchartStore } from "@/shared/stores/fleetchart";
 import { useOverlayStore } from "@/shared/stores/overlay";
 import { FleetchartModes } from "@/shared/stores/fleetchart";
@@ -26,12 +27,19 @@ type Props = {
   myShip?: boolean;
   downloadName?: string;
   loading?: boolean;
+  /** Offers a share control in the chart's own controls. The chart covers the
+   *  app header, so a share button teleported there is unreachable while it is
+   *  open. */
+  shareUrl?: string;
+  shareTitle?: string;
 };
 
 const props = withDefaults(defineProps<Props>(), {
   myShip: false,
   downloadName: undefined,
   loading: false,
+  shareUrl: undefined,
+  shareTitle: undefined,
 });
 
 const { t } = useI18n();
@@ -41,6 +49,8 @@ const fleetchartStore = useFleetchartStore();
 const innerItems = ref<(Vehicle | Model | VehiclePublic)[]>([]);
 
 const isOpen = ref(false);
+
+const root = ref<HTMLElement | undefined>();
 
 const isShow = ref(false);
 
@@ -267,6 +277,7 @@ const closeFleetchart = async () => {
 <template>
   <div
     v-if="isShow"
+    ref="root"
     class="fleetchart-app fade"
     :class="{
       in: isOpen,
@@ -314,6 +325,14 @@ const closeFleetchart = async () => {
         >
           <i class="fa-duotone fa-arrows-from-line" />
         </Btn>
+
+        <ShareBtn
+          v-if="shareUrl"
+          :url="shareUrl"
+          :title="shareTitle || ''"
+          :container="root"
+          no-label
+        />
       </div>
 
       <Btn class="fleetchart-app-close" @click="hide" size="lg" variant="bare">

--- a/app/frontend/frontend/components/Fleets/PublicShipsList/index.vue
+++ b/app/frontend/frontend/components/Fleets/PublicShipsList/index.vue
@@ -58,6 +58,16 @@ const openDisplayOptionsModal = () => {
 
 const fleetchartStore = useFleetchartStore();
 
+const fleetchartShareUrl = computed(() => {
+  if (!props.fleet?.publicFleet) {
+    return undefined;
+  }
+
+  const host = `${window.location.protocol}//${window.location.host}`;
+
+  return `${host}/fleets/${props.fleet.slug}/fleetchart`;
+});
+
 const fleetchartVisible = computed(() => {
   return fleetchartStore.isVisible("publicFleet");
 });
@@ -181,6 +191,8 @@ const refetch = async () => {
         <FleetchartApp
           :items="fleetVehicles?.items || []"
           namespace="publicFleet"
+          :share-url="fleetchartShareUrl"
+          :share-title="fleet.name"
           :loading="loading"
           :download-name="`${fleet.slug}-fleetchart`"
         />

--- a/app/frontend/frontend/components/Fleets/ShipsList/index.vue
+++ b/app/frontend/frontend/components/Fleets/ShipsList/index.vue
@@ -71,6 +71,16 @@ const { grouped, money, detailsVisible, gridView } = storeToRefs(fleetStore);
 
 const fleetchartStore = useFleetchartStore();
 
+const fleetchartShareUrl = computed(() => {
+  if (!props.fleet?.publicFleet) {
+    return undefined;
+  }
+
+  const host = `${window.location.protocol}//${window.location.host}`;
+
+  return `${host}/fleets/${props.fleet.slug}/fleetchart`;
+});
+
 const fleetchartVisible = computed(() => {
   return fleetchartStore.isVisible("fleet");
 });
@@ -354,6 +364,8 @@ const {
           <FleetchartApp
             :items="fleetVehicles?.items || []"
             namespace="fleet"
+            :share-url="fleetchartShareUrl"
+            :share-title="fleet.name"
             :loading="loading"
             :download-name="`${fleet.slug}-fleetchart`"
           >

--- a/app/frontend/frontend/components/ShareBtn/index.vue
+++ b/app/frontend/frontend/components/ShareBtn/index.vue
@@ -25,6 +25,10 @@ type Props = {
   block?: boolean;
   mobileIconOnly?: boolean;
   noLabel?: boolean;
+  /** Where clipboard.js may put its scratch element. Copying from inside a
+   *  fixed overlay reports success and copies nothing unless this names a node
+   *  inside that overlay. */
+  container?: Element;
 };
 
 const props = withDefaults(defineProps<Props>(), {
@@ -33,6 +37,7 @@ const props = withDefaults(defineProps<Props>(), {
   block: false,
   mobileIconOnly: false,
   noLabel: false,
+  container: undefined,
 });
 
 const { t } = useI18n();
@@ -66,7 +71,7 @@ const copyShareUrl = () => {
     });
   }
 
-  copyText(props.url).then(
+  copyText(props.url, props.container).then(
     () => {
       displaySuccess({
         text: t("messages.copyShareUrl.success", {

--- a/docs/exec-plans/1203-fleetchart-share-url.md
+++ b/docs/exec-plans/1203-fleetchart-share-url.md
@@ -1,0 +1,90 @@
+# Fleets: sharable deeplink for fleetcharts
+
+## Goal
+
+Pressing Share while looking at a fleet's fleetchart hands out a link that opens the fleetchart, not the ship list.
+
+## Context
+
+Opened six years ago. Almost all of it has since been built by accident, in pieces that were never joined up:
+
+- `fleets/[slug]/routes.ts:28` defines a route `fleet-fleetchart` at `fleetchart/`, redirecting to `fleet-ships` with `query: { fleetchart: "true" }`. It answers 200 in production today.
+- `Fleetchart/App/index.vue:152` reads `route.query.fleetchart` on mount and calls `fleetchartStore.show(namespace)`. Both `ShipsList` and `PublicShipsList` render that component.
+
+So the deeplink works end to end already. What does not work is producing one: `shareUrl` in `pages/fleets/[slug]/ships.vue:36` returns `${host}/fleets/${slug}/ships` unconditionally, so a reader who opens the fleetchart and presses Share sends someone to the plain list.
+
+Resolves #1203
+
+## Decisions
+
+### D1 — The button belongs inside the chart, not in the header
+
+The first attempt made `shareUrl` on the ships page follow the chart's state. It was dead logic: `Fleetchart/App` is `position: fixed; z-index: 2100`, so it covers the app header — and the share button is teleported to `#header-right`. It would have switched the URL at exactly the moment nobody could press it.
+
+So the control moves into the chart's own `.fleetchart-app-controls`, beside the mode dropdown, and the page keeps sharing the ship list unchanged.
+
+### D2 — Clipboard needs a container inside the overlay
+
+`copyText(text, container?)` hands clipboard.js a container and defaults it to `document.body` — which is behind this overlay. Copying from inside a fixed overlay then reports success and copies nothing.
+
+`ShareBtn` called it without a container, so it gains an optional `container` prop and the chart passes its own root element.
+
+### D3 — Only a public fleet offers the button
+
+Whoever receives the link can only open it if the fleet is public: `fleet-ships` renders `PublicShipsList` for a non-member and nothing at all for a private fleet. So `fleetchartShareUrl` is `undefined` for a private fleet and the control is not rendered, rather than handing out a link that shows the recipient an empty page.
+
+This is deliberately wider than the header button, which also requires `membership` — a visitor to a public fleet can now share the chart they are looking at.
+
+### D4 — Share the named route, not the query string
+
+`/fleets/{slug}/fleetchart` rather than `/fleets/{slug}/ships?fleetchart=true`. Both work, but the first is what a person would want to paste into Discord, and it is already the route's public shape. The redirect turns it into the query form on arrival.
+
+### D5 — View options stay out
+
+Viewpoint, scale, colour and the extended-state toggle live in the store, not the URL. Carrying them would mean serialising view state into the link and reading it back on mount — a larger change than this issue asks for, and one that invites a link nobody can read. The link opens the fleetchart; how the recipient looks at it is theirs.
+
+### D6 — No test, deliberately
+
+There are 67 frontend specs and not one of them is for a page: the convention here covers components, composables and lib code. A first page spec for a sixteen-line computed would be disproportionate.
+
+The rigorous alternative is e2e — `Fleet.spec.ts` already logs in and builds fleets through factories — but it would need a fleet with ships, the chart opened, and the share control read, and the suite cannot be run locally without colliding with another worktree on its port. `pnpm lint` covers the types; the behaviour is worth one look in a browser instead.
+
+## What changed
+
+1. `ShareBtn` takes an optional `container` and passes it to `copyText`.
+2. `Fleetchart/App` takes optional `shareUrl` / `shareTitle` and renders a `ShareBtn` in its controls, handing it the chart's root element as the clipboard container.
+3. `ShipsList` and `PublicShipsList` build the fleetchart URL, for a public fleet only.
+4. `ships.vue` is untouched.
+
+## Intent Verification
+
+- [ ] **The chart has a share control at all** — this is what the header button could never be
+- [ ] **It copies** — the clipboard container is the point; a success message with an empty clipboard is the failure to watch for
+- [ ] **It shares `/fleetchart`**, and the ship list still shares `/ships`
+- [ ] **A private fleet offers no control**
+- [ ] **A visitor to a public fleet gets one**
+- [ ] **Opening the shared link lands on the fleetchart**, which is the half that already worked
+
+## Key files
+
+| File | Role |
+|------|------|
+| `app/frontend/frontend/pages/fleets/[slug]/ships.vue` | `shareUrl`, and the namespace choice |
+| `app/frontend/shared/stores/fleetchart.ts` | `isVisible(namespace)` |
+| `app/frontend/frontend/pages/fleets/[slug]/routes.ts` | The `fleet-fleetchart` route that already exists |
+| `app/frontend/frontend/components/Fleetchart/App/index.vue` | Reads the query param on mount |
+
+## Not in scope (deferred)
+
+- **View options in the link** — see D3.
+- **The same treatment for the hangar and the ships index**, which also render `Fleetchart/App` and also share a fixed URL. Worth doing, but this issue is about fleets and the pattern is easier to judge once it exists in one place.
+
+## Discovery Log
+
+- **2026-09-10** First attempt was wrong and was reverted: the share button sits in the app header, and the chart covers the header. Found by looking at the running app, not by reading. Rebuilt inside the chart, which surfaced the clipboard-container trap on the way.
+- **2026-09-10** Implemented. `pnpm lint` green. The store declaration moved above the computeds that use it — it worked either way, since a computed body runs later, but a reader should not have to know that.
+- **2026-09-10** Research. Found the route and the query-param reader already in place, which turns this from "build a deeplink" into "produce the one that exists". Confirmed the route answers 200 in production before relying on it.
+
+## Progress
+
+- [ ] Share URL follows the fleetchart


### PR DESCRIPTION
Resolves #1203

Opened six years ago. Most of it turned out to exist already, in pieces that were never joined up — and the last piece could not be added where it looked like it belonged.

## What was already there

- `fleets/{slug}/fleetchart` is a real route, redirecting to the ship list with `?fleetchart=true`. It answers 200 in production today.
- `Fleetchart/App` reads that query param on mount and opens the chart.

So the link worked. There was just no way to produce one: the share button on the ship page always handed out `/fleets/{slug}/ships`.

## Why the obvious fix does not work

Making that button's URL follow the chart's state is dead logic. It is teleported to `#header-right`, and `Fleetchart/App` is `position: fixed` at `z-index: 2100` — it covers the header. The URL would have switched at exactly the moment nobody could press the button.

That is only visible in the running app, which is where it was caught. The first attempt did exactly this and was reverted.

So the control lives in the chart's own `.fleetchart-app-controls`, beside the mode dropdown, and `ships.vue` is untouched.

## The clipboard trap on the way

`copyText(text, container?)` hands clipboard.js a container and defaults it to `document.body` — behind this overlay. Copying from inside a fixed overlay therefore **resolves, reports success, and copies nothing**.

`ShareBtn` called it without a container. It now takes an optional one, and the chart passes its own root element. That fix is its own commit, since it applies to any future share button inside an overlay.

## Who gets the button

Only a public fleet: `fleet-ships` renders `PublicShipsList` for a non-member and nothing at all for a private fleet, so a private link would show its recipient an empty page. `fleetchartShareUrl` is `undefined` there and the control is not rendered.

Deliberately wider than the header button, which also requires `membership` — somebody browsing a public fleet could look at the chart but not pass it on.

## Not in scope

- **View options in the link** — viewpoint, scale, colour and the extended toggle live in the store. Carrying them would mean a URL nobody can read, for something nobody asked for.
- **The hangar and the ships index**, which render the same component and also share a fixed URL. The props are there for them now; whether their share button should follow the chart is the same question answered in a different context.

## Verification

`pnpm lint` clean. No test: of 67 frontend specs none covers a page, and the e2e route would need a fleet, ships, the chart open and the control read — the suite also cannot run locally without colliding with another worktree's port. Checked in the browser instead, which is what caught the header problem in the first place.

Plan: `docs/exec-plans/1203-fleetchart-share-url.md`

🤖
