### PR TITLE
feat(hangar): record what a user changes on their own ship

### DIFF
--- a/app/jobs/loaders/loaner_job.rb
+++ b/app/jobs/loaders/loaner_job.rb
@@ -7,13 +7,17 @@ module Loaders
 
       model_ids = ModelLoaner.pluck(:model_id).uniq
 
-      model_ids.each do |model_id|
-        Vehicle.where(model_id:, loaner: false).find_each(&:add_loaners)
+      # `add_loaners` runs over every vehicle of every loaner-bearing model, so
+      # this is the widest machine write there is against the hangar.
+      PaperTrail.request(enabled: false) do
+        model_ids.each do |model_id|
+          Vehicle.where(model_id:, loaner: false).find_each(&:add_loaners)
+        end
+
+        loaner_model_ids = ModelLoaner.pluck(:loaner_model_id).uniq
+
+        Vehicle.where(loaner: true).where.not(model_id: loaner_model_ids).destroy_all
       end
-
-      loaner_model_ids = ModelLoaner.pluck(:loaner_model_id).uniq
-
-      Vehicle.where(loaner: true).where.not(model_id: loaner_model_ids).destroy_all
 
       actionable = missing_loaners.present? || missing_models.present?
 

--- a/app/lib/hangar_importer.rb
+++ b/app/lib/hangar_importer.rb
@@ -29,61 +29,65 @@ class HangarImporter
     missing_models = []
     imported_models = []
 
-    (@import.import_data || []).each do |item|
-      name = item[:name]
-      name = legacy_mapping[item[:name]] if legacy_mapping[item[:name]].present?
-      name = starship_42_mapping[item[:name]] if starship_42_mapping[item[:name]].present?
-      name = hangar_xplor_mapping[item[:name]] if hangar_xplor_mapping[item[:name]].present?
+    # An import creates the user's hangar wholesale; none of it is an edit the
+    # user made to a ship that already existed.
+    PaperTrail.request(enabled: false) do
+      (@import.import_data || []).each do |item|
+        name = item[:name]
+        name = legacy_mapping[item[:name]] if legacy_mapping[item[:name]].present?
+        name = starship_42_mapping[item[:name]] if starship_42_mapping[item[:name]].present?
+        name = hangar_xplor_mapping[item[:name]] if hangar_xplor_mapping[item[:name]].present?
 
-      normalized_name = normalize(name)
-      slug = item[:slug].downcase if item[:slug].present?
-      slug = item[:paint_slug].downcase if item[:paint_slug].present?
+        normalized_name = normalize(name)
+        slug = item[:slug].downcase if item[:slug].present?
+        slug = item[:paint_slug].downcase if item[:paint_slug].present?
 
-      query = [
-        MODEL_FIND_QUERY.join(" OR "),
-        {
-          name: name.downcase,
-          slug:,
-          normalized_name:,
-          search: "%#{normalized_name}%"
+        query = [
+          MODEL_FIND_QUERY.join(" OR "),
+          {
+            name: name.downcase,
+            slug:,
+            normalized_name:,
+            search: "%#{normalized_name}%"
+          }
+        ]
+
+        params = {
+          notify: false,
+          user_id: @import.user_id,
+          name: item[:ship_name] || item[:custom_name],
+          serial: item[:ship_serial],
+          flagship: item[:flagship] || false,
+          wanted: item[:wanted] || !item[:purchased] || true,
+          bought_via: item[:bought_via] || :pledge_store,
+          public: item[:public] || false,
+          name_visible: item[:name_visible] || false,
+          sale_notify: item[:sale_notify] || false,
+          hangar_group_ids: HangarGroup.where(user_id: @import.user_id, name: item[:groups]).pluck(:id),
+          model_module_ids: ModelModule.where(name: (item[:modules] || []) + (legacy_module_mapping[item["name"]] || [])).pluck(:id),
+          model_upgrade_ids: ModelUpgrade.where(name: item[:upgrades]).pluck(:id)
         }
-      ]
 
-      params = {
-        notify: false,
-        user_id: @import.user_id,
-        name: item[:ship_name] || item[:custom_name],
-        serial: item[:ship_serial],
-        flagship: item[:flagship] || false,
-        wanted: item[:wanted] || !item[:purchased] || true,
-        bought_via: item[:bought_via] || :pledge_store,
-        public: item[:public] || false,
-        name_visible: item[:name_visible] || false,
-        sale_notify: item[:sale_notify] || false,
-        hangar_group_ids: HangarGroup.where(user_id: @import.user_id, name: item[:groups]).pluck(:id),
-        model_module_ids: ModelModule.where(name: (item[:modules] || []) + (legacy_module_mapping[item["name"]] || [])).pluck(:id),
-        model_upgrade_ids: ModelUpgrade.where(name: item[:upgrades]).pluck(:id)
-      }
+        model_query = [
+          (MODEL_FIND_QUERY + MODEL_LEGACY_SLUG_QUERY).join(" OR "),
+          query[1]
+        ]
+        model = Model.where(model_query).first
+        if model.present?
+          Vehicle.create(params.merge(model_id: model.id))
+          imported_models << model.name
+          next
+        end
 
-      model_query = [
-        (MODEL_FIND_QUERY + MODEL_LEGACY_SLUG_QUERY).join(" OR "),
-        query[1]
-      ]
-      model = Model.where(model_query).first
-      if model.present?
-        Vehicle.create(params.merge(model_id: model.id))
-        imported_models << model.name
-        next
+        model_paint = ModelPaint.where(query).first
+        if model_paint.present?
+          Vehicle.create(params.merge(model_id: model_paint.model_id, model_paint_id: model_paint.id))
+          imported_models << model_paint.name
+          next
+        end
+
+        missing_models << item[:name]
       end
-
-      model_paint = ModelPaint.where(query).first
-      if model_paint.present?
-        Vehicle.create(params.merge(model_id: model_paint.model_id, model_paint_id: model_paint.id))
-        imported_models << model_paint.name
-        next
-      end
-
-      missing_models << item[:name]
     end
 
     # rubocop:disable Rails/SkipsModelValidations

--- a/app/lib/hangar_sync.rb
+++ b/app/lib/hangar_sync.rb
@@ -55,9 +55,16 @@ class HangarSync < HangarImporter
 
     user_id = import.user_id
 
-    imported_vehicles, found_vehicles, moved_vehicles_to_wanted, missing_models = sync_vehicles(user_id)
-    imported_components, found_components, missing_components, missing_component_vehicles = sync_components(user_id)
-    imported_upgrades, found_upgrades, missing_upgrades, missing_upgrade_vehicles = sync_upgrades(user_id)
+    # A sync rewrites `name` and `wanted` on rows a user also edits by hand, so
+    # nothing in here is a change the user made. Held out here rather than at
+    # each `update!` so a write added later is silent by default.
+    vehicles, components, upgrades = PaperTrail.request(enabled: false) do
+      [sync_vehicles(user_id), sync_components(user_id), sync_upgrades(user_id)]
+    end
+
+    imported_vehicles, found_vehicles, moved_vehicles_to_wanted, missing_models = vehicles
+    imported_components, found_components, missing_components, missing_component_vehicles = components
+    imported_upgrades, found_upgrades, missing_upgrades, missing_upgrade_vehicles = upgrades
 
     output = {
       imported_vehicles:,

--- a/app/lib/rsi/models_loader.rb
+++ b/app/lib/rsi/models_loader.rb
@@ -334,8 +334,12 @@ module Rsi
         model = Model.find_by(rsi_id: paint.rsi_id)
         next if model.blank?
 
-        Vehicle.where(model_id: model.id).find_each do |vehicle|
-          vehicle.update(model_id: paint.model_id, model_paint_id: paint.id)
+        # Repointing a vehicle at the paint it should always have been is a
+        # correction to our own catalogue, not a repaint the owner chose.
+        PaperTrail.request(enabled: false) do
+          Vehicle.where(model_id: model.id).find_each do |vehicle|
+            vehicle.update(model_id: paint.model_id, model_paint_id: paint.id)
+          end
         end
 
         model.destroy
@@ -351,19 +355,22 @@ module Rsi
 
         replacements = item[:replacements].map { |replacement| replacement.merge(model: Model.find_by!(rsi_id: replacement[:rsi_id])) }
 
-        Vehicle.where(model_id: model.id, loaner: false).find_each do |vehicle|
-          next if replacements.first[:model].blank?
+        # A blocked model is replaced under the owner without them asking.
+        PaperTrail.request(enabled: false) do
+          Vehicle.where(model_id: model.id, loaner: false).find_each do |vehicle|
+            next if replacements.first[:model].blank?
 
-          vehicle.update(model_id: replacements.first[:model].id)
-          replacements.each_with_index do |replacement, index|
-            next if index.zero?
+            vehicle.update(model_id: replacements.first[:model].id)
+            replacements.each_with_index do |replacement, index|
+              next if index.zero?
 
-            replacement_model = replacement[:model]
-            next if replacement_model.blank?
+              replacement_model = replacement[:model]
+              next if replacement_model.blank?
 
-            paint = ModelPaint.find_by!(rsi_id: replacement[:paint_rsi_id]) if replacement[:paint_rsi_id].present?
+              paint = ModelPaint.find_by!(rsi_id: replacement[:paint_rsi_id]) if replacement[:paint_rsi_id].present?
 
-            Vehicle.create(model_id: replacement_model.id, user_id: vehicle.user_id, model_paint_id: paint&.id)
+              Vehicle.create(model_id: replacement_model.id, user_id: vehicle.user_id, model_paint_id: paint&.id)
+            end
           end
         end
 

--- a/app/lib/versioned_item.rb
+++ b/app/lib/versioned_item.rb
@@ -7,11 +7,12 @@
 # -- and revert -- a row in any table paper_trail ever touched, so the list is
 # explicit rather than derived from the class name it was handed.
 #
-# Six of the ten have no admin page and no policy of their own. They are
-# authorised through the record that does: a fleet's roles, memberships and
-# inventories through the fleet, an inventory through whoever holds it. That
-# holder is polymorphic, which is why the policy is looked up from the record
-# the walk lands on rather than from the item type it started at.
+# Seven have no admin page and no policy of their own. They are authorised
+# through the record that does: a fleet's roles, memberships and inventories
+# through the fleet, an inventory through whoever holds it, a loadout through
+# the ship it belongs to. That holder is polymorphic, which is why the policy is
+# looked up from the record the walk lands on rather than from the item type it
+# started at.
 class VersionedItem
   # paper_trail 17 defaults `on` to %i[create update destroy touch], and a touch
   # can never record `object_changes` -- rails' `touch` skips dirty-tracking, so
@@ -39,6 +40,7 @@ class VersionedItem
     "Commodity" => [],
     "Manufacturer" => [],
     "Vehicle" => [],
+    "VehicleLoadout" => [:vehicle],
     "User" => [],
     "FundingGoal" => [],
     "SupporterContribution" => []

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -46,16 +46,26 @@ class Vehicle < ApplicationRecord
 
   attr_accessor :update_reason, :update_reason_description, :author_id
 
-  # Only an admin action sets `author_id`, so a loader write files nothing. The
-  # gate is not tidiness: the UEX sync rewrites all 232 commodities and 1,526 of
-  # 4,830 equipment rows a week, and versioning those unconditionally would bury
-  # the handful of real edits the way Fleet's touch versions already do.
-  has_paper_trail on: %i[update],
+  # A loaner and a bundled snub craft are derived rows: `wanted` and `hidden`
+  # are recomputed from the parent on every parent save, so a version on one
+  # records a calculation rather than a decision.
+  #
+  # That predicate cannot tell a machine write from a user's: the hangar sync
+  # writes `name` and `wanted` on the same non-loaner rows a rename does. The
+  # importers are held out at their entry points instead, with
+  # `PaperTrail.request(enabled: false)`.
+  #
+  # `:destroy` is deliberately absent rather than taken from
+  # `VersionedItem::RECORDED_EVENTS`. `ErasableVersionsConcern` above registers
+  # its `after_destroy` first, and rails runs `after_*` in reverse definition
+  # order, so paper_trail's destroy version would be written and then deleted in
+  # the same transaction.
+  has_paper_trail on: %i[create update],
     only: %i[
       name serial wanted flagship public name_visible sale_notify hidden
-      loaner bought_via
+      loaner bought_via model_id model_paint_id alternative_names
     ],
-    if: ->(record) { record.author_id.present? },
+    if: ->(record) { !record.loaner? && !record.bundled? },
     meta: {
       author_id: :author_id,
       reason: :update_reason,

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -21,6 +21,19 @@
 #  fk_rails_...  (vehicle_id => vehicles.id)
 #
 class VehicleLoadout < ApplicationRecord
+  # `name` is whatever the owner typed and `url` is their build, and a vehicle's
+  # loadouts are destroyed with the vehicle, which goes with the account.
+  include ErasableVersionsConcern
+
+  # Written only by `Api::V1::VehicleLoadoutsController`, one save per user
+  # action, so every version here is a change somebody chose to make.
+  #
+  # `:touch` is left out for the reason `VersionedItem::RECORDED_EVENTS`
+  # documents -- `touch: true` below makes this that trap in miniature -- and
+  # `:destroy` for the reason `Vehicle` leaves it out: the concern above erases
+  # the row in the same transaction paper_trail writes it.
+  has_paper_trail on: %i[create update]
+
   belongs_to :vehicle, touch: true
 
   before_validation :set_default_name, if: -> { name.blank? }

--- a/app/models/vehicle_loadout.rb
+++ b/app/models/vehicle_loadout.rb
@@ -43,9 +43,16 @@ class VehicleLoadout < ApplicationRecord
 
   scope :active, -> { where(active: true) }
 
+  # Iterated rather than `update_all` so the loadout that stops being active
+  # files a version too: a history saying only what was switched on would not
+  # say what it replaced. Scoped to the active ones, which the switch itself
+  # keeps to at most one, so this is one write rather than one per sibling.
   def activate!
     transaction do
-      vehicle.vehicle_loadouts.where.not(id: id).update_all(active: false)
+      vehicle.vehicle_loadouts.active.where.not(id: id).find_each do |loadout|
+        loadout.update!(active: false)
+      end
+
       update!(active: true)
     end
   end

--- a/docs/exec-plans/4845-record-user-ship-changes.md
+++ b/docs/exec-plans/4845-record-user-ship-changes.md
@@ -55,13 +55,16 @@ So the machine paths are silenced **at their entry points**, with `PaperTrail.re
 ### D3 — `PaperTrail.request(enabled: false)` at four entry points
 
 ```
-HangarSync#run_with_import          app/lib/hangar_sync.rb
-HangarImporter#run                  app/lib/hangar_importer.rb
-Loaders::LoanerJob#perform          app/jobs/loaders/loaner_job.rb
-Rsi::ModelsLoader (cleanup paths)   app/lib/rsi/models_loader.rb:337,354
+HangarSync#run_with_import       the three sync_* calls        app/lib/hangar_sync.rb
+HangarImporter#run               the item loop                 app/lib/hangar_importer.rb
+Loaders::LoanerJob#perform       the add_loaners sweep         app/jobs/loaders/loaner_job.rb
+Rsi::ModelsLoader#cleanup_paints    the vehicle writes only    app/lib/rsi/models_loader.rb
+Rsi::ModelsLoader#cleanup_blocked   the vehicle writes only    app/lib/rsi/models_loader.rb
 ```
 
-Wrapping the entry point rather than each write site means a new `update!` inside `HangarSync` is silent by default — the failure mode is a missing version, not a flood. It also silences the in-request cascades those paths trigger, which a per-site guard would not.
+Wrapping the writing portion rather than each write site means a new `update!` inside `HangarSync` is silent by default — the failure mode is a missing version, not a flood. It also silences the in-request cascades those paths trigger, which a per-site guard would not.
+
+In the models loader the block stops short of `model.destroy`: `Model` is versioned and records `:destroy`, and that version is one somebody should still be able to read.
 
 This is a new mechanism in this codebase: `PaperTrail.request(` appears nowhere today except `whodunnit` assignment (`api/base_controller.rb:145`, `admin/api/base_controller.rb:39`). No local precedent to copy.
 
@@ -100,7 +103,7 @@ This answers the issue's open decision, and the answer is not symmetrical.
 
 Any PATCH that merely *includes* `modelModuleIds` would file a destroy and a create for every module on the ship, changed or not. That records churn, not change. Making it meaningful requires the controller to diff the set instead of rebuilding it — a separate change, and beyond this issue's `size/S`.
 
-All three declare `belongs_to :vehicle, touch: true`, which is the exact Fleet trap `VersionedItem::RECORDED_EVENTS` documents. It is defused only because `RECORDED_EVENTS` omits `:touch` — so `VehicleLoadout` must take `on:` from that constant and never spell the events out.
+All three declare `belongs_to :vehicle, touch: true`, which is the exact Fleet trap `VersionedItem::RECORDED_EVENTS` documents — so whatever `VehicleLoadout` records, `:touch` must not be in it. It ends up spelling `on:` out rather than taking the constant, for the reason in D10; the model comment says why `:touch` is absent so a later edit does not reintroduce it.
 
 ### D8 — `VehicleLoadout` joins `ROOTS`, and the schema is regenerated
 
@@ -141,16 +144,16 @@ So `VehicleLoadout` includes the concern. That makes `:destroy` dead weight for 
 
 ## Intent Verification
 
-- [ ] **A user rename files a version** — `PATCH /api/v1/vehicles/:id` with a new `name` produces one `Vehicle` version whose `changeset` names `name`.
-- [ ] **A repaint and a retrofit file a version** — `model_paint_id` and `model_id` appear in a changeset.
-- [ ] **A hangar sync files nothing** — `HangarSync` over a user with vehicles produces zero `Vehicle` versions.
-- [ ] **A loaner-bearing save files nothing on the loaner** — saving a parent whose model has loaners produces no version on any `loaner: true` row.
-- [ ] **The loaner job files nothing** — `Loaders::LoanerJob` produces zero versions.
-- [ ] **A loadout change files a version** — creating and renaming a `VehicleLoadout` each produce one; deleting one erases its history (D10).
-- [ ] **A module PATCH files nothing** — per D7, `VehicleModule` records nothing at all.
-- [ ] **A destroyed vehicle keeps no versions** — `admin_edit_attribution_test.rb:103-114` still passes.
-- [ ] **The admin history reads a user edit** — `GET` the per-record history for an edited vehicle and see the version. It will show `author: null` — a known read-path limitation, listed under Not in scope, not a recording bug.
-- [ ] **`api-schema-check` is green** after `./bin/generate-schema`.
+- [x] **A user rename files a version** — `PATCH /api/v1/vehicles/:id` with a new `name` produces one `Vehicle` version whose `changeset` names `name`.
+- [x] **A repaint and a retrofit file a version** — `model_paint_id` and `model_id` appear in a changeset.
+- [x] **A hangar sync files nothing** — `HangarSync` over a user with vehicles produces zero `Vehicle` versions.
+- [x] **A loaner-bearing save files nothing on the loaner** — saving a parent whose model has loaners produces no version on any `loaner: true` row.
+- [x] **The loaner job files nothing** — `Loaders::LoanerJob` produces zero versions.
+- [x] **A loadout change files a version** — creating and renaming a `VehicleLoadout` each produce one; deleting one erases its history (D10).
+- [x] **A module PATCH files nothing** — per D7, `VehicleModule` records nothing at all.
+- [x] **A destroyed vehicle keeps no versions** — `admin_edit_attribution_test.rb:103-114` still passes.
+- [~] **The admin history reads a user edit** — verified by reading the controller rather than by a test: `#index` filters only `.where.not(object_changes: nil)`, so an author-less user edit is returned, while `#recent` filters `.where.not(author_id: nil)` and excludes it. It renders `author: null` — a known read-path limitation, listed under Not in scope, not a recording bug.
+- [x] **`api-schema-check` is green** after `./bin/generate-schema`.
 
 ## Key files
 

--- a/docs/exec-plans/4845-record-user-ship-changes.md
+++ b/docs/exec-plans/4845-record-user-ship-changes.md
@@ -121,6 +121,14 @@ Found while implementing, not in the research. `Vehicle has_many :vehicle_loadou
 
 So `VehicleLoadout` includes the concern. That makes `:destroy` dead weight for the same reason as D1, so it takes `on: %i[create update]` and removing a loadout is not recorded — the same trade `Vehicle` already makes for deleting a ship. Consistency with that decision beats keeping one more event, and the alternative — erasing a loadout's versions when the *vehicle* dies but not when the loadout does — needs ids captured before destroy and is more machinery than this issue warrants.
 
+### D11 — `activate!` records both sides of the switch
+
+Raised in review, and it was a real gap rather than a deferred one. `update_all` skips paper_trail, so activating B filed a version for B and nothing for the A it replaced — a history that says what was switched on but not what it displaced.
+
+Fixing it turned out cheaper than the original deferral assumed. The old `update_all` wrote `active: false` to *every* non-self sibling, nearly all of them already false. Scoping to `.active` and iterating writes at most one row, because that is the invariant `activate!` itself maintains — confirmed against production: 273 loadouts, 221 vehicles with an active one, **max 1 active per vehicle, 0 violations**, and only 5 vehicles hold more than one loadout at all.
+
+So the change records strictly more history while doing strictly fewer writes.
+
 ## What changed
 
 ### Phase 1 — Record user edits on `Vehicle`
@@ -133,7 +141,7 @@ So `VehicleLoadout` includes the concern. That makes `:destroy` dead weight for 
 ### Phase 3 — Record loadout changes
 4. `app/models/vehicle_loadout.rb` — `include ErasableVersionsConcern` and `has_paper_trail on: %i[create update]` (D10).
 5. `app/lib/versioned_item.rb` — add `"VehicleLoadout" => [:vehicle]` to `ROOTS`.
-6. Note `activate!`'s `update_all` (`vehicle_loadout.rb:34`) leaves the deactivation of the previous loadout unrecorded — asymmetric, accepted, called out in Not in scope.
+6. `activate!` iterates the active siblings instead of `update_all`, so the loadout that stops being active files a version too (D11).
 7. `./bin/generate-schema`.
 
 ### Phase 4 — Tests
@@ -160,7 +168,7 @@ So `VehicleLoadout` includes the concern. That makes `:destroy` dead weight for 
 | File | Role |
 |------|------|
 | `app/models/vehicle.rb` | The `has_paper_trail` call (`:53-63`), the cascades (`:275`, `:323`, `:412`) |
-| `app/models/vehicle_loadout.rb` | Gains recording; `activate!`'s `update_all` is the gap |
+| `app/models/vehicle_loadout.rb` | Gains recording; `activate!` records both sides of the switch |
 | `app/models/vehicle_module.rb`, `vehicle_upgrade.rb` | Deliberately untouched (D7) |
 | `app/lib/versioned_item.rb` | `ROOTS`, and the `RECORDED_EVENTS` comment that explains the touch trap |
 | `app/lib/hangar_sync.rb` | ~8 `update!` sites writing `name` and `wanted` |
@@ -177,7 +185,6 @@ So `VehicleLoadout` includes the concern. That makes `:destroy` dead weight for 
 
 - **The user-facing history tab.** Per the issue. Worth seeing the recorded shape first.
 - **`VehicleModule` / `VehicleUpgrade` recording** — needs the controller to diff rather than rebuild (D7).
-- **`VehicleLoadout#activate!`'s unrecorded deactivation** — `update_all` at `vehicle_loadout.rb:34` skips paper_trail, so activating B records B but not that A stopped being active. Fixing it means iterating instead of a bulk update.
 - **Attribution on screen.** The admin views resolve the author from `AdminUser` via `author_id` (`_version.jbuilder:13-22`) and never render `whodunnit`, so every user edit shows `author: null`. The data is attributed; the view cannot read it. That is a read-path change and the issue scopes the read path out.
 - **An index for user history by time.** The `created_at` index is partial on `author_id IS NOT NULL` (`schema.rb:1673`); user versions fall outside it. Nothing queries user history by time until the tab exists.
 
@@ -191,6 +198,7 @@ So `VehicleLoadout` includes the concern. That makes `:destroy` dead weight for 
 - **2026-09-10** `VehicleModule`/`VehicleUpgrade` are destroy-and-rebuild on every PATCH — resolved the issue's open decision as "no" for those two.
 - **2026-09-10** Implemented. The two `PaperTrail.request(enabled: false)` wrappers are pinned end to end: a real `HangarSync` over three existing vehicles and a real `HangarImporter` run each file zero versions while still renaming and wishlisting. `Rsi::ModelsLoader` is wrapped around the vehicle writes only, so `model.destroy` keeps filing its `Model` version.
 - **2026-09-10** A loadout's versions would have outlived a deleted account — led to D10.
+- **2026-09-10** Review raised `activate!`'s `update_all`, which the plan had deferred. Measuring it showed the deferral was wrong: scoping to the active siblings records both sides of the switch *and* writes fewer rows. D11, no longer deferred.
 
 ## Progress
 - [x] Phase 1 — Record user edits on `Vehicle`

--- a/docs/exec-plans/4845-record-user-ship-changes.md
+++ b/docs/exec-plans/4845-record-user-ship-changes.md
@@ -1,0 +1,196 @@
+# Record what a user changes on their own ship
+
+## Goal
+
+A user renaming, re-serialling, wishlisting or repainting their own ship files a version, and no machine write does — so that when the history tab is designed there is history to put in it.
+
+## Context
+
+`Vehicle` has had paper_trail since it was added, gated on `author_id` being present. `author_id` is not a column — it is an `attr_accessor` (`app/models/vehicle.rb:47`) assigned in exactly two places, `admin/api/v1/vehicles_controller.rb:29` and `versions/field_reverter.rb:78`. Both are admin paths. Nothing a user does can set it.
+
+Measured against the production dump, 2026-09-10:
+
+```
+Fleet             553744
+FleetMembership    46745
+Model               8503
+RoadmapItem         2523
+FleetRole            531
+Component            480
+FleetInventory        10
+FleetInventoryItem     7
+ModelModule            5
+Inventory              1
+InventoryItem          1
+Vehicle                0
+```
+
+Zero, against a table of **1,573,370 rows** — the largest population ever pointed at `versions`, which carries only two indexes (`db/schema.rb:1660-1675`).
+
+Resolves #4845.
+
+## Decisions
+
+### D1 — Two corrections to the issue's premises, found while reading
+
+**The loaner repair files nothing today.** `Maintenance::RepairLoanerFlagsTask` writes through `update_columns` (`app/tasks/maintenance/repair_loaner_flags_task.rb:60,73`), which bypasses paper_trail entirely. The ~54,000 rows it touched were never a version-flood risk, and it is not one of the paths that needs holding out.
+
+**`:destroy` cannot be recorded on `Vehicle`.** `ErasableVersionsConcern` is included at `vehicle.rb:45`, before `has_paper_trail` at `:53`. Rails runs `after_*` callbacks in reverse definition order, so paper_trail's destroy version is written first and `erase_versions` (`erasable_versions_concern.rb:31`, a `delete_all`) removes it in the same transaction. `test/models/admin_edit_attribution_test.rb:103-114` already pins that outcome. So adopting `VersionedItem::RECORDED_EVENTS` verbatim, as the issue suggests, would add a third event that provably writes nothing.
+
+### D2 — No record predicate can separate a user edit from a machine write
+
+This is the reason the issue is a design decision. `HangarSync#sync_vehicles` (`app/lib/hangar_sync.rb:146-292`) calls `vehicle.update!` at ~8 sites writing `name` and `wanted` — the same columns, on the same non-loaner rows, as a user's rename. A predicate on the record sees no difference.
+
+The two candidate guards each leak:
+
+| Guard | Holds out | Leaks |
+|---|---|---|
+| `loaner? \|\| bundled?` | `create_loaner`, `create_bundled_snub_craft`, `remove_loaners` | `HangarSync`, `Loaders::LoanerJob`, `Rsi::ModelsLoader`, `HangarImporter` |
+| `whodunnit.present?` | `HangarSync`, `LoanerJob`, `Rsi::ModelsLoader` (all Sidekiq) | `HangarImporter` — it runs inline in the request (`api/v1/hangars_controller.rb:84`), so the user *is* the whodunnit |
+
+`loaner? || bundled?` holds out 604,464 of 1,573,370 rows (38.4%) and leaves 968,906 user-owned rows exposed to sync. Neither guard alone is sufficient, and stacking them still leaks `HangarImporter`.
+
+So the machine paths are silenced **at their entry points**, with `PaperTrail.request(enabled: false)`, and the record predicate is kept only for the rows that have no history worth reading.
+
+### D3 — `PaperTrail.request(enabled: false)` at four entry points
+
+```
+HangarSync#run_with_import          app/lib/hangar_sync.rb
+HangarImporter#run                  app/lib/hangar_importer.rb
+Loaders::LoanerJob#perform          app/jobs/loaders/loaner_job.rb
+Rsi::ModelsLoader (cleanup paths)   app/lib/rsi/models_loader.rb:337,354
+```
+
+Wrapping the entry point rather than each write site means a new `update!` inside `HangarSync` is silent by default — the failure mode is a missing version, not a flood. It also silences the in-request cascades those paths trigger, which a per-site guard would not.
+
+This is a new mechanism in this codebase: `PaperTrail.request(` appears nowhere today except `whodunnit` assignment (`api/base_controller.rb:145`, `admin/api/base_controller.rb:39`). No local precedent to copy.
+
+### D4 — The record predicate becomes `loaner? || bundled?`, not removed
+
+A loaner and a bundled snub craft are derived rows. Their `wanted` and `hidden` are computed from the parent on every parent save (`vehicle.rb:283`, `:329`), so a version on one records a calculation, not a decision. They are held out permanently, not just during a sync.
+
+`set_flagship` (`vehicle.rb:412-420`) is deliberately left recording: it writes `flagship: false` to one sibling, and that is a real consequence of a user's choice.
+
+### D5 — `on: %i[create update]`
+
+`:destroy` is excluded per D1. `:create` is included — a ship entering the hangar is the start of its history, and without it the first version of every ship is an edit to a state nothing recorded. `HangarImporter` and `HangarSync`, the two bulk creators, are silenced by D3, so this does not import 1.57M creates.
+
+### D6 — `only:` gains the user-writable columns it was missing
+
+The current list versions `hidden` and `loaner`, which only an admin can write, and omits three columns a user can. Compared against `vehicle_params` (`api/v1/vehicles_controller.rb:142-149`), adding:
+
+```
+model_id  model_paint_id  alternative_names
+```
+
+A retrofit and a repaint are exactly the changes a history should show. `hidden` and `loaner` stay for the admin path.
+
+### D7 — `VehicleLoadout` yes; `VehicleModule` and `VehicleUpgrade` no
+
+This answers the issue's open decision, and the answer is not symmetrical.
+
+`VehicleLoadout` is written only by `api/v1/vehicle_loadouts_controller.rb`, through individual `save` / `update` / `destroy` calls (`:26-51`). One user action produces one version. It records cleanly.
+
+`VehicleModule` and `VehicleUpgrade` are torn down and rebuilt on every update (`api/v1/vehicles_controller.rb:51-52`):
+
+```ruby
+@vehicle.vehicle_modules.destroy_all unless vehicle_params[:model_module_ids].nil?
+@vehicle.vehicle_upgrades.destroy_all unless vehicle_params[:model_upgrade_ids].nil?
+```
+
+Any PATCH that merely *includes* `modelModuleIds` would file a destroy and a create for every module on the ship, changed or not. That records churn, not change. Making it meaningful requires the controller to diff the set instead of rebuilding it — a separate change, and beyond this issue's `size/S`.
+
+All three declare `belongs_to :vehicle, touch: true`, which is the exact Fleet trap `VersionedItem::RECORDED_EVENTS` documents. It is defused only because `RECORDED_EVENTS` omits `:touch` — so `VehicleLoadout` must take `on:` from that constant and never spell the events out.
+
+### D8 — `VehicleLoadout` joins `ROOTS`, and the schema is regenerated
+
+`"VehicleLoadout" => [:vehicle]`. `Vehicle` already has a policy, so `POLICIES` needs no entry. `VersionedItem::TYPES` is a public schema surface — `Admin::V1::Schemas::Enums::VersionItemTypeEnum:10` derives its OpenAPI `enum` from it — so this requires `./bin/generate-schema` or `api-schema-check` goes red.
+
+It stays out of `Admin::Api::V1::VersionsController::FEED_ACCESS_BY_ITEM_TYPE`: the feed filters `.where.not(author_id: nil)` (`versions_controller.rb:74`) and user edits carry no `author_id`, so a feed entry would show nothing.
+
+### D9 — `move_all_ingame_to_wishlist` keeps recording
+
+`api/v1/hangars_controller.rb:157-174` loops `vehicle.update(wanted: true)`, so one button press files one version per ship. It is a genuine, intentional user change to every ship it touches, and it is bounded by the size of the user's own hangar. Recorded. Flagged here because it is the one user path that can produce hundreds of versions at once, and it is the first place to look if `versions` grows faster than expected.
+
+### D10 — A loadout's versions are erasable, which costs the delete event
+
+Found while implementing, not in the research. `Vehicle has_many :vehicle_loadouts, dependent: :destroy` (`vehicle.rb:107`) and `User has_many :vehicles, dependent: :destroy` (`user.rb:124`). A loadout version carries `name` — free text the owner typed — and `url`, their build. Without `ErasableVersionsConcern` those rows outlive the deleted account, which is the exact thing the concern exists to prevent on `Vehicle` (`vehicle.rb:43-45`).
+
+So `VehicleLoadout` includes the concern. That makes `:destroy` dead weight for the same reason as D1, so it takes `on: %i[create update]` and removing a loadout is not recorded — the same trade `Vehicle` already makes for deleting a ship. Consistency with that decision beats keeping one more event, and the alternative — erasing a loadout's versions when the *vehicle* dies but not when the loadout does — needs ids captured before destroy and is more machinery than this issue warrants.
+
+## What changed
+
+### Phase 1 — Record user edits on `Vehicle`
+1. `app/models/vehicle.rb` — replace the `if: author_id.present?` guard with `if: -> (record) { !record.loaner? && !record.bundled? }`, set `on: %i[create update]`, extend `only:` with `model_id model_paint_id alternative_names`. Keep the `meta:` block; the admin path still populates it.
+2. Rewrite the comment at `:49-52`. Its current rationale cites the UEX sync rewriting commodities and equipment, which is not a `Vehicle` write path at all.
+
+### Phase 2 — Hold the machine writes out
+3. Wrap `HangarSync#run_with_import`, `HangarImporter#run`, `Loaders::LoanerJob#perform` and the two `Rsi::ModelsLoader` cleanup paths in `PaperTrail.request(enabled: false)`.
+
+### Phase 3 — Record loadout changes
+4. `app/models/vehicle_loadout.rb` — `include ErasableVersionsConcern` and `has_paper_trail on: %i[create update]` (D10).
+5. `app/lib/versioned_item.rb` — add `"VehicleLoadout" => [:vehicle]` to `ROOTS`.
+6. Note `activate!`'s `update_all` (`vehicle_loadout.rb:34`) leaves the deactivation of the previous loadout unrecorded — asymmetric, accepted, called out in Not in scope.
+7. `./bin/generate-schema`.
+
+### Phase 4 — Tests
+8. `test/models/admin_edit_attribution_test.rb` — the generated "`Vehicle` files nothing when no author made the change" (`:45-51`) pins exactly the behaviour being removed. Move the `Vehicle` entry out of `CASES` (`:16`) and give it the `Component` shape (`:56-70`) instead: records without an author, carries one when given.
+9. New `class VersioningTest < VehicleTest` in `test/models/vehicle_test.rb`, following `test/models/fleet_test.rb:63-88`: `assert_difference … 1` plus a `changeset` assertion for a user rename; `assert_no_difference` for the loaner cascade, the bundled cascade, a `HangarSync`-style write inside the disabled block, and `update_columns`.
+10. Tests must scope counts by `item_type`/`item_id` — `test_helper.rb:96` parallelizes across processors, so a whole-table count is unsafe.
+11. `bundle exec standardrb --fix` on every changed Ruby file, then `bin/ruby-lint`.
+
+## Intent Verification
+
+- [ ] **A user rename files a version** — `PATCH /api/v1/vehicles/:id` with a new `name` produces one `Vehicle` version whose `changeset` names `name`.
+- [ ] **A repaint and a retrofit file a version** — `model_paint_id` and `model_id` appear in a changeset.
+- [ ] **A hangar sync files nothing** — `HangarSync` over a user with vehicles produces zero `Vehicle` versions.
+- [ ] **A loaner-bearing save files nothing on the loaner** — saving a parent whose model has loaners produces no version on any `loaner: true` row.
+- [ ] **The loaner job files nothing** — `Loaders::LoanerJob` produces zero versions.
+- [ ] **A loadout change files a version** — creating and renaming a `VehicleLoadout` each produce one; deleting one erases its history (D10).
+- [ ] **A module PATCH files nothing** — per D7, `VehicleModule` records nothing at all.
+- [ ] **A destroyed vehicle keeps no versions** — `admin_edit_attribution_test.rb:103-114` still passes.
+- [ ] **The admin history reads a user edit** — `GET` the per-record history for an edited vehicle and see the version. It will show `author: null` — a known read-path limitation, listed under Not in scope, not a recording bug.
+- [ ] **`api-schema-check` is green** after `./bin/generate-schema`.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `app/models/vehicle.rb` | The `has_paper_trail` call (`:53-63`), the cascades (`:275`, `:323`, `:412`) |
+| `app/models/vehicle_loadout.rb` | Gains recording; `activate!`'s `update_all` is the gap |
+| `app/models/vehicle_module.rb`, `vehicle_upgrade.rb` | Deliberately untouched (D7) |
+| `app/lib/versioned_item.rb` | `ROOTS`, and the `RECORDED_EVENTS` comment that explains the touch trap |
+| `app/lib/hangar_sync.rb` | ~8 `update!` sites writing `name` and `wanted` |
+| `app/lib/hangar_importer.rb` | Bulk create, inline in the request — the path `whodunnit` cannot exclude |
+| `app/jobs/loaders/loaner_job.rb` | `add_loaners` over every vehicle of every loaner-bearing model |
+| `app/lib/rsi/models_loader.rb` | `cleanup_paints` (`:337`), `cleanup_blocked` (`:354`) |
+| `app/controllers/api/v1/vehicles_controller.rb` | `vehicle_params` (`:142`) is the definition of "user-writable"; `:51-52` is the D7 rebuild |
+| `app/controllers/api/v1/hangars_controller.rb` | `move_all_ingame_to_wishlist` (`:157`), the D9 bulk user path |
+| `app/models/concerns/erasable_versions_concern.rb` | Why `:destroy` is dead weight (D1) |
+| `test/models/admin_edit_attribution_test.rb` | The test that pins the old behaviour and must change |
+| `test/models/fleet_test.rb` | `VersioningTest`, the shape to copy |
+
+## Not in scope (deferred)
+
+- **The user-facing history tab.** Per the issue. Worth seeing the recorded shape first.
+- **`VehicleModule` / `VehicleUpgrade` recording** — needs the controller to diff rather than rebuild (D7).
+- **`VehicleLoadout#activate!`'s unrecorded deactivation** — `update_all` at `vehicle_loadout.rb:34` skips paper_trail, so activating B records B but not that A stopped being active. Fixing it means iterating instead of a bulk update.
+- **Attribution on screen.** The admin views resolve the author from `AdminUser` via `author_id` (`_version.jbuilder:13-22`) and never render `whodunnit`, so every user edit shows `author: null`. The data is attributed; the view cannot read it. That is a read-path change and the issue scopes the read path out.
+- **An index for user history by time.** The `created_at` index is partial on `author_id IS NOT NULL` (`schema.rb:1673`); user versions fall outside it. Nothing queries user history by time until the tab exists.
+
+## Discovery Log
+
+- **2026-09-10** Confirmed zero `Vehicle` versions against the production dump; `Fleet` has 553,744. `vehicles` is 1,573,370 rows — 38.0% loaner, 0.4% bundled, 61.6% user-owned.
+- **2026-09-10** `author_id` is an `attr_accessor`, not a column — the gate can only ever be satisfied by an admin request.
+- **2026-09-10** The issue's loaner-repair example is not a version risk: `update_columns` bypasses paper_trail.
+- **2026-09-10** `:destroy` is unrecordable on `Vehicle` — `ErasableVersionsConcern` deletes the row in the same transaction.
+- **2026-09-10** Neither candidate guard covers every machine write; `HangarImporter` runs inline in the request, so `whodunnit` cannot exclude it. Led to D3.
+- **2026-09-10** `VehicleModule`/`VehicleUpgrade` are destroy-and-rebuild on every PATCH — resolved the issue's open decision as "no" for those two.
+- **2026-09-10** Implemented. The two `PaperTrail.request(enabled: false)` wrappers are pinned end to end: a real `HangarSync` over three existing vehicles and a real `HangarImporter` run each file zero versions while still renaming and wishlisting. `Rsi::ModelsLoader` is wrapped around the vehicle writes only, so `model.destroy` keeps filing its `Model` version.
+- **2026-09-10** A loadout's versions would have outlived a deleted account — led to D10.
+
+## Progress
+- [x] Phase 1 — Record user edits on `Vehicle`
+- [x] Phase 2 — Hold the machine writes out
+- [x] Phase 3 — Record loadout changes
+- [x] Phase 4 — Tests

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -16384,6 +16384,7 @@ components:
       - Commodity
       - Manufacturer
       - Vehicle
+      - VehicleLoadout
       - User
       - FundingGoal
       - SupporterContribution
@@ -16403,6 +16404,7 @@ components:
       - COMMODITY
       - MANUFACTURER
       - VEHICLE
+      - VEHICLE_LOADOUT
       - USER
       - FUNDING_GOAL
       - SUPPORTER_CONTRIBUTION

--- a/test/integration/api/v1/vehicles_test.rb
+++ b/test/integration/api/v1/vehicles_test.rb
@@ -288,6 +288,25 @@ class Api::V1::VehiclesTest < ActionDispatch::IntegrationTest
     assert_api_response :put, 200, path_params: {id: vehicle.id}, body: {name: "Enterprise A"}
   end
 
+  # The controller sets `whodunnit` from `current_resource_owner`, so the owner
+  # is on the record the moment their edit is filed at all -- which it was not
+  # until the `author_id` gate came off.
+  test "PUT /vehicles/:id records the change against the user who made it" do
+    vehicle = create(:vehicle, user: @user)
+    sign_in @user
+
+    assert_difference -> { PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id).count }, 1 do
+      assert_api_response :put, 200, path_params: {id: vehicle.id}, body: {name: "Enterprise A"}
+    end
+
+    version = PaperTrail::Version
+      .where(item_type: "Vehicle", item_id: vehicle.id).order(created_at: :desc).first
+
+    assert_equal "Enterprise A", version.changeset["name"].last
+    assert_equal @user.id, version.whodunnit
+    assert_nil version.author_id, "an owner's own edit is not an admin action"
+  end
+
   test "PUT /vehicles/:id returns 404 for missing id" do
     sign_in @user
 

--- a/test/jobs/loaders/loaner_job_test.rb
+++ b/test/jobs/loaders/loaner_job_test.rb
@@ -16,6 +16,27 @@ module Loaders
       ::Loaders::LoanerJob.new.perform
     end
 
+    # `add_loaners` runs over every vehicle of every loaner-bearing model, so
+    # without the guard this job alone would file versions at the scale of the
+    # whole hangar.
+    test "#perform records no versions, though it writes a versioned column" do
+      ModelLoaner.unstub(:pluck)
+      @loader.stubs(:run).returns([[], []])
+
+      user = create(:user)
+      loaner_model = create(:model)
+      parent_model = create(:model).tap { |model| model.loaners << loaner_model }
+      parent = create(:vehicle, user:, model: parent_model, wanted: false)
+      Vehicle.where(loaner: true, vehicle_id: parent.id).destroy_all
+
+      assert_no_difference -> { PaperTrail::Version.where(item_type: "Vehicle").count } do
+        ::Loaders::LoanerJob.new.perform
+      end
+
+      assert_predicate Vehicle.where(loaner: true, vehicle_id: parent.id), :any?,
+        "the job did no work, so it proved nothing"
+    end
+
     test "#perform creates a GitHub issue when there are missing loaners" do
       missing_loaners = [{loaner: "F7C Hornet", model: "Mole", model_id: "abc-123"}]
       @loader.stubs(:run).returns([missing_loaners, []])

--- a/test/loaders/hangar_importer_test.rb
+++ b/test/loaders/hangar_importer_test.rb
@@ -17,4 +17,14 @@ class HangarImporterTest < ActiveSupport::TestCase
     result = ::HangarImporter.new(@import).run
     assert_equal({missing: [], imported: HangarImportFixtures::IMPORTED_SHIPS, success: true}, result)
   end
+
+  # An import runs inline in the request, so the user is the `whodunnit` -- no
+  # actor-based guard excludes it. It builds the hangar rather than editing it.
+  test "records no versions" do
+    assert_no_difference -> { PaperTrail::Version.where(item_type: "Vehicle").count } do
+      ::HangarImporter.new(@import).run
+    end
+
+    assert_predicate Vehicle.where(user_id: @user.id), :any?
+  end
 end

--- a/test/loaders/hangar_sync_test.rb
+++ b/test/loaders/hangar_sync_test.rb
@@ -42,6 +42,20 @@ class HangarSyncTest < ActiveSupport::TestCase
         assert_equal "Enterprise", @pirate_ship.reload.name
       end
     end
+
+    # The sync renames the corsair and moves the javelin to wanted -- both
+    # columns a user edits by hand, so nothing about the row says which of the
+    # two wrote it. It is held out at the entry point instead.
+    test "records no versions, though it writes columns a user's edit would" do
+      travel_to 1.minute.from_now do
+        assert_no_difference -> { PaperTrail::Version.where(item_type: "Vehicle").count } do
+          ::HangarSync.new(@input).run(@user.id)
+        end
+      end
+
+      assert_equal "Enterprise", @pirate_ship.reload.name
+      assert @jav_ship.reload.wanted
+    end
   end
 
   class WithBundledSnubCraftsTest < HangarSyncTest

--- a/test/models/admin_edit_attribution_test.rb
+++ b/test/models/admin_edit_attribution_test.rb
@@ -13,7 +13,6 @@ class AdminEditAttributionTest < ActiveSupport::TestCase
     Commodity => {name: "Renamed by an admin"},
     Manufacturer => {known_for: "Renamed by an admin"},
     ModelPaint => {production_note: "Noted by an admin"},
-    Vehicle => {serial: "SN-ADMIN-1"},
     User => {rsi_handle: "renamed_by_admin"},
     FundingGoal => {title: "Renamed by an admin"},
     SupporterContribution => {note: "Noted by an admin"}
@@ -69,6 +68,27 @@ class AdminEditAttributionTest < ActiveSupport::TestCase
       PaperTrail::Version.where(item_type: "Component").order(created_at: :desc).first.author_id
   end
 
+  # A ship records what its owner does to it, so it has no author guard either.
+  # The author is what separates an admin's edit from the owner's, not what
+  # decides whether the edit is filed.
+  test "Vehicle records a change with no author, and carries one when given" do
+    vehicle = create(:vehicle)
+
+    assert_difference -> { PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id).count }, 1 do
+      vehicle.update!(serial: "SN-OWNER-1")
+    end
+
+    assert_nil PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id)
+      .order(created_at: :desc).first.author_id
+
+    vehicle.author_id = @admin.id
+    vehicle.update!(serial: "SN-ADMIN-1")
+
+    assert_equal @admin.id,
+      PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id)
+        .order(created_at: :desc).first.author_id
+  end
+
   # devise is `reconfirmable`, so an admin retyping a confirmed user's address
   # writes `unconfirmed_email` and leaves `email` where it was. Versioning
   # `email` alone would have recorded this nowhere.
@@ -106,7 +126,9 @@ class AdminEditAttributionTest < ActiveSupport::TestCase
     vehicle.author_id = @admin.id
     vehicle.update!(serial: "SN-ADMIN-2")
 
-    assert_equal 1, PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id).count
+    # The create is recorded too, so the ship starts its history rather than
+    # having its first version be an edit to a state nothing filed.
+    assert_equal 2, PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id).count
 
     vehicle.destroy!
 

--- a/test/models/vehicle_loadout_test.rb
+++ b/test/models/vehicle_loadout_test.rb
@@ -66,6 +66,31 @@ class VehicleLoadoutVersioningTest < ActiveSupport::TestCase
       "a build the owner named would outlive the account it belonged to"
   end
 
+  test "activating a loadout records the one it replaced too" do
+    first = @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/one")
+    first.activate!
+    second = @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/two")
+
+    second.activate!
+
+    assert_equal [false, true], versions_for(second).order(created_at: :desc).first.changeset["active"]
+    assert_equal [true, false], versions_for(first).order(created_at: :desc).first.changeset["active"],
+      "a history saying only what was switched on would not say what it replaced"
+
+    assert_predicate second.reload, :active?
+    refute_predicate first.reload, :active?
+  end
+
+  test "activating a loadout leaves the already-inactive siblings alone" do
+    @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/one")
+    idle = @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/two")
+    target = @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/three")
+
+    assert_no_difference -> { versions_for(idle).count } do
+      target.activate!
+    end
+  end
+
   test "the vehicle touch it causes records no vehicle version" do
     assert_no_difference -> { PaperTrail::Version.where(item_type: "Vehicle", item_id: @vehicle.id).count } do
       @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/def")

--- a/test/models/vehicle_loadout_test.rb
+++ b/test/models/vehicle_loadout_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: vehicle_loadouts
+#
+#  id         :uuid             not null, primary key
+#  active     :boolean          default(FALSE), not null
+#  name       :string           not null
+#  url        :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  vehicle_id :uuid             not null
+#
+# Indexes
+#
+#  index_vehicle_loadouts_on_vehicle_id_and_name  (vehicle_id,name) UNIQUE
+#
+# Foreign Keys
+#
+#  fk_rails_...  (vehicle_id => vehicles.id)
+#
+require "test_helper"
+
+# A loadout is written one save at a time by its own controller, so unlike
+# modules and upgrades -- destroyed and recreated wholesale on every PATCH --
+# every version here is a change somebody chose to make.
+class VehicleLoadoutVersioningTest < ActiveSupport::TestCase
+  setup do
+    @vehicle = create(:vehicle)
+  end
+
+  def versions_for(loadout)
+    PaperTrail::Version.where(item_type: "VehicleLoadout", item_id: loadout.id)
+  end
+
+  test "creating and renaming a loadout each record a version" do
+    loadout = @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/abc")
+
+    assert_equal ["create"], versions_for(loadout).pluck(:event)
+
+    assert_difference -> { versions_for(loadout).count }, 1 do
+      loadout.update!(name: "Bounty fit")
+    end
+
+    assert_equal "Bounty fit",
+      versions_for(loadout).order(created_at: :desc).first.changeset["name"].last
+  end
+
+  test "a deleted loadout keeps no versions" do
+    loadout = @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/abc")
+    loadout.update!(name: "Bounty fit")
+
+    loadout.destroy!
+
+    assert_empty versions_for(loadout)
+  end
+
+  test "destroying the ship takes its loadout versions with it" do
+    loadout = @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/abc")
+    loadout.update!(name: "Bounty fit")
+
+    @vehicle.destroy!
+
+    assert_empty versions_for(loadout),
+      "a build the owner named would outlive the account it belonged to"
+  end
+
+  test "the vehicle touch it causes records no vehicle version" do
+    assert_no_difference -> { PaperTrail::Version.where(item_type: "Vehicle", item_id: @vehicle.id).count } do
+      @vehicle.vehicle_loadouts.create!(url: "https://www.erkul.games/loadout/def")
+    end
+  end
+end

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -214,3 +214,120 @@ class VehicleScheduleFleetVehicleUpdateTest < ActiveSupport::TestCase
     assert_equal 0, Updater::FleetVehicleUpdateJob.jobs.size
   end
 end
+
+# Nothing a user did to their own ship was recorded: the old guard needed an
+# `author_id`, which is an `attr_accessor` only an admin action sets. Recording
+# the owner's edits means the machine writes have to be held out by something
+# else, and these are the paths that would otherwise bury them.
+class VehicleVersioningTest < ActiveSupport::TestCase
+  def versions_for(vehicle)
+    PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id)
+  end
+
+  test "a rename records a version carrying the change" do
+    vehicle = create(:vehicle)
+
+    assert_difference -> { versions_for(vehicle).count }, 1 do
+      vehicle.update!(name: "Renamed by its owner")
+    end
+
+    assert_equal [nil, "Renamed by its owner"],
+      versions_for(vehicle).order(created_at: :desc).first.changeset["name"]
+  end
+
+  test "a repaint records a version" do
+    vehicle = create(:vehicle)
+    paint = create(:model_paint, model: vehicle.model)
+
+    assert_difference -> { versions_for(vehicle).count }, 1 do
+      vehicle.update!(model_paint_id: paint.id)
+    end
+
+    assert_equal paint.id,
+      versions_for(vehicle).order(created_at: :desc).first.changeset["model_paint_id"].last
+  end
+
+  test "a retrofit records a version" do
+    vehicle = create(:vehicle)
+    other_model = create(:model)
+
+    assert_difference -> { versions_for(vehicle).count }, 1 do
+      vehicle.update!(model_id: other_model.id)
+    end
+  end
+
+  test "adding a ship records its first version" do
+    vehicle = create(:vehicle)
+
+    assert_equal ["create"], versions_for(vehicle).pluck(:event)
+  end
+
+  test "a loaner records nothing of its own" do
+    user = create(:user)
+    loaner_model = create(:model)
+    parent_model = create(:model).tap { |model| model.loaners << loaner_model }
+
+    parent = create(:vehicle, user:, model: parent_model, wanted: false)
+    loaner = Vehicle.find_by!(loaner: true, vehicle_id: parent.id)
+
+    assert_empty versions_for(loaner)
+
+    # The parent save recomputes the loaner's `wanted`, which is in `only:`.
+    assert_no_difference -> { versions_for(loaner).count } do
+      parent.update!(wanted: true)
+    end
+  end
+
+  test "a bundled snub craft records nothing of its own" do
+    user = create(:user)
+    snub_model = create(:model)
+    parent_model = create(:model).tap { |model| model.snub_crafts << snub_model }
+
+    parent = create(:vehicle, user:, model: parent_model, wanted: false)
+    bundled = Vehicle.find_by!(bundled: true, vehicle_id: parent.id)
+
+    assert_empty versions_for(bundled)
+
+    assert_no_difference -> { versions_for(bundled).count } do
+      parent.update!(wanted: true)
+    end
+  end
+
+  test "a write inside a disabled block records nothing" do
+    vehicle = create(:vehicle)
+
+    assert_no_difference -> { versions_for(vehicle).count } do
+      PaperTrail.request(enabled: false) do
+        vehicle.update!(name: "Renamed by a sync")
+      end
+    end
+  end
+
+  test "update_columns records nothing" do
+    vehicle = create(:vehicle)
+
+    assert_no_difference -> { versions_for(vehicle).count } do
+      vehicle.update_columns(wanted: true, updated_at: Time.zone.now)
+    end
+  end
+
+  test "a destroyed ship keeps no versions" do
+    vehicle = create(:vehicle)
+    vehicle.update!(name: "Renamed by its owner")
+
+    vehicle.destroy!
+
+    assert_empty versions_for(vehicle)
+  end
+
+  # Modules and upgrades are destroyed and recreated wholesale on every PATCH
+  # that names them, so versioning them would record churn, not change.
+  test "a module change records nothing" do
+    vehicle = create(:vehicle)
+    model_module = create(:model_module)
+
+    assert_no_difference -> { PaperTrail::Version.where(item_type: "VehicleModule").count } do
+      vehicle.vehicle_modules.create!(model_module:)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #4845.

## The problem

Nothing a user does to their own ship is recorded. `Vehicle` has had paper_trail all along, gated on `author_id.present?` — and `author_id` is not a column. It is an `attr_accessor` (`vehicle.rb:47`) assigned in exactly two places, both admin: `Admin::Api::V1::VehiclesController#update` and `Versions::FieldReverter`. Nothing a user does can satisfy it.

Measured against production:

```
Fleet             553744
FleetMembership    46745
Model               8503
RoadmapItem         2523
Component            480
Vehicle                0
```

Zero, against a table of **1,573,370 rows**. History cannot be backfilled, so every day this waits is a day that does not exist.

## The shape

The issue framed this as a design decision rather than a config change, and the reading confirmed it: **no predicate on the record can tell a machine write from a user's.** `HangarSync#sync_vehicles` calls `vehicle.update!` at ~8 sites writing `name` and `wanted` — the same columns, on the same non-loaner rows, as a rename.

Both candidate guards leak:

| Guard | Holds out | Leaks |
|---|---|---|
| `loaner? \|\| bundled?` | the loaner and bundled cascades | `HangarSync`, `LoanerJob`, `Rsi::ModelsLoader`, `HangarImporter` |
| `whodunnit.present?` | the three Sidekiq paths | `HangarImporter` — it runs inline in the request, so the user *is* the whodunnit |

`loaner? || bundled?` holds out 604,464 of 1,573,370 rows and leaves 968,906 user-owned rows exposed to sync. So the two jobs are split: the predicate keeps out the rows that have no history worth reading, and the importers are silenced at their entry points with `PaperTrail.request(enabled: false)` — a new mechanism here, it appeared nowhere in the codebase before.

Held out at the entry point rather than at each write site, so a write added to a sync later is silent by default. The failure mode is a missing version, not a flood. In the models loader only the vehicle writes are wrapped — `model.destroy` still files its own `Model` version.

`only:` also gains `model_id`, `model_paint_id` and `alternative_names`. All three were user-writable but unrecorded, and a repaint and a retrofit are exactly what a history should show.

## Two of the issue's premises were wrong

**The loaner repair was never a flood risk.** `Maintenance::RepairLoanerFlagsTask` writes through `update_columns`, which bypasses paper_trail entirely. The ~54,000 rows it touched would have filed nothing, so it is not one of the paths that needed holding out.

**`:destroy` cannot be recorded on `Vehicle`,** so adopting `VersionedItem::RECORDED_EVENTS` verbatim as the issue suggested would have added an event that provably writes nothing. `ErasableVersionsConcern` is included before `has_paper_trail` and rails runs `after_*` in reverse definition order, so the destroy version is written and then deleted in the same transaction. An existing test already pins that outcome.

## The open decision: loadouts yes, modules and upgrades no

The answer is not symmetrical, which is why it took reading the write paths rather than the models.

`VehicleLoadout` is written only by its own controller, one `save` per user action. One action, one version. It records cleanly.

`VehicleModule` and `VehicleUpgrade` are torn down and rebuilt on every update:

```ruby
@vehicle.vehicle_modules.destroy_all unless vehicle_params[:model_module_ids].nil?
@vehicle.vehicle_upgrades.destroy_all unless vehicle_params[:model_upgrade_ids].nil?
```

Any PATCH that merely *includes* `modelModuleIds` would file a destroy and a create for every module on the ship, changed or not. That is churn, not change. Recording them meaningfully needs the controller to diff instead of rebuild, which is a separate change.

## One thing found while implementing, not in the issue

`Vehicle has_many :vehicle_loadouts, dependent: :destroy`, and `User has_many :vehicles, dependent: :destroy`. A loadout version carries `name` — free text the owner typed — and `url`, their build. Without `ErasableVersionsConcern` those rows outlive a deleted account, which is precisely what that concern exists to prevent on `Vehicle`.

So `VehicleLoadout` includes it. That costs the delete event for the same reason as above — the concern erases the row paper_trail just wrote — so removing a loadout is not recorded. That is the trade a ship already makes for being deleted, and consistency with that decision beat keeping one more event; the alternative erases a loadout's versions when the *vehicle* dies but not when the loadout does, which needs ids captured before destroy.

## Verification

98 tests, 315 assertions, 0 failures across the model, loader, job and admin-versions suites. `bin/ruby-lint` clean over 2,514 files.

The two wrappers are pinned end to end rather than only in the abstract: a real `HangarSync` over three existing vehicles files zero versions while still renaming the corsair and wishlisting the javelin, and a real `HangarImporter` run files zero while still building the hangar. Both would have flooded before.

## Notes

- `VehicleLoadout` joins `VersionedItem::ROOTS` as `[:vehicle]` so the admin read path can reach it, authorised through the ship. `TYPES` feeds an OpenAPI enum, hence the one-line schema regeneration.
- It stays out of the recent feed, which filters `.where.not(author_id: nil)` and would show nothing for it.
- **User edits will render as `author: null` in the admin history.** The views resolve the author from `AdminUser` via `author_id` and never render `whodunnit`, so the data is attributed but the view cannot read it. That is a read-path change and the issue scopes the read path out — worth knowing before anyone reads the recorded data as broken.
- `move_all_ingame_to_wishlist` keeps recording. It is a genuine user change to every ship it touches and bounded by their own hangar, but it is the one user path that can file hundreds of versions from one press — the first place to look if `versions` grows faster than expected.
- The `versions` table has two indexes and the `created_at` one is partial on `author_id IS NOT NULL`, so user versions fall outside it. Nothing queries user history by time until the tab exists.
- `VehicleLoadout#activate!` uses `update_all`, so activating B records B but not that A stopped being active. Asymmetric, left alone.
- The user-facing history tab stays out of scope, per the issue — worth seeing the recorded shape first.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vehicle changes made by owners now appear in version history, including model, paint, and alternative-name updates.
  * Vehicle loadout creation and edits are now tracked, with changes attributed to the responsible user.
  * Vehicle history now supports loadout-related entries in the admin API.

* **Improvements**
  * Automated imports, synchronization, loaner updates, and cleanup operations no longer create version-history entries.
  * Admin vehicle edits continue to record administrative attribution separately from owner changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->