### PR TITLE
fix: the will-it-fit filter is broken four ways

### DIFF
--- a/app/api_components/v1/schemas/queries/hangar_query.rb
+++ b/app/api_components/v1/schemas/queries/hangar_query.rb
@@ -42,7 +42,7 @@ module V1
             boughtViaEq: ::Shared::V1::Schemas::Enums::BoughtViaEnum,
             hangarGroupsIn: {type: :array, items: {type: :string}},
             hangarGroupsNotIn: {type: :array, items: {type: :string}},
-            willItFit: {type: :string, format: :uuid},
+            willItFit: {type: :string},
             withCargo: {type: :boolean},
             s: {anyOf: [{
               type: :array, items: ::Shared::V1::Schemas::Sorts::VehicleSortEnum

--- a/app/api_components/v1/schemas/queries/model_query.rb
+++ b/app/api_components/v1/schemas/queries/model_query.rb
@@ -38,7 +38,7 @@ module V1
             productionStatusIn: {type: :array, items: {type: :string}},
             searchCont: {type: :string},
             sizeIn: {type: :array, items: {type: :string}},
-            willItFit: {type: :string, format: :uuid},
+            willItFit: {type: :string},
             withCargo: {type: :boolean},
             withCargoGrids: {type: :boolean},
             inHangar: {type: :boolean},

--- a/app/controllers/api/v1/models_controller.rb
+++ b/app/controllers/api/v1/models_controller.rb
@@ -475,15 +475,18 @@ module Api
 
         return scope if parent.blank? || parent.docks.blank?
 
-        query = []
-        parent.docks.each do |dock|
-          query << "length <= #{(dock.length || 1) - 0.5} and beam <= #{(dock.beam || 1) - 0.5} and height <= #{(dock.height || 1) - 0.5}"
-          query << "or" unless dock == parent.docks.last
+        # `dock.length || 1` turned a dock nobody measured into a half-metre one,
+        # so a carrier with no measurements answered "nothing fits" instead of
+        # saying it did not know.
+        measured = parent.docks.select(&:measured?)
+
+        return scope if measured.blank?
+
+        query = measured.map do |dock|
+          "(length <= #{dock.length - 0.5} and beam <= #{dock.beam - 0.5} and height <= #{dock.height - 0.5})"
         end
 
-        scope = scope.where(query.join(" ")) if query.present?
-
-        scope
+        scope.where(query.join(" or "))
       end
 
       private def pledge_price_in
@@ -524,7 +527,10 @@ module Api
             :s, :sorts, :length_gteq, :length_lteq, :beam_gteq, :beam_lteq, :height_gteq, :height_lteq,
             :price_gteq, :price_lteq, :pledge_price_gteq, :pledge_price_lteq, :search_cont,
             :with_dock, :with_cargo, :with_cargo_grids, :in_hangar, :in_game_eq,
-            will_it_fit: [], name_in: [], slug_in: [], manufacturer_in: [], classification_in: [],
+            # A slug, not a list -- permitted as an array it was dropped outright,
+            # so this filter never ran even when a request got past validation.
+            :will_it_fit,
+            name_in: [], slug_in: [], manufacturer_in: [], classification_in: [],
             focus_in: [], production_status_in: [], price_in: [], pledge_price_in: [], size_in: [],
             sorts: [], id_not_in: [], id_in: []
           ]

--- a/app/controllers/concerns/hangar_filters_concern.rb
+++ b/app/controllers/concerns/hangar_filters_concern.rb
@@ -11,8 +11,12 @@ module HangarFiltersConcern
 
     return scope if parent.blank? || parent.docks.blank?
 
-    vehicle_dock = parent.docks.where(dock_type: %i[vehiclepad garage]).order(length: :desc).first
-    ship_dock = parent.docks.where(dock_type: %i[landingpad hangar]).order(length: :desc).first
+    # Only measured docks: the metrics below subtract clearance from a missing
+    # length, which made an unmeasured dock exclude everything.
+    vehicle_dock = parent.docks.where(dock_type: %i[vehiclepad garage]).select(&:measured?).max_by(&:length)
+    ship_dock = parent.docks.where(dock_type: %i[landingpad hangar]).select(&:measured?).max_by(&:length)
+
+    return scope if ship_dock.blank? && vehicle_dock.blank?
 
     dock_metrics = extract_dock_metrics(ship_dock, vehicle_dock)
 
@@ -36,22 +40,12 @@ module HangarFiltersConcern
     }
   end
 
+  # Both sides are built from `scope`, because `or` takes a relation of the same
+  # class and refuses a Hash outright -- which is what this used to hand it, so a
+  # carrier holding a dock of each kind answered with a 500 rather than a list.
   private def will_it_fit_ship_or_vehicle_dock?(scope, dock_metrics)
-    scope.where(
-      models: {
-        ground: [false, nil],
-        length: ..dock_metrics[:ship_length],
-        beam: ..dock_metrics[:ship_beam],
-        height: ..dock_metrics[:ship_height]
-      }
-    ).or(
-      models: {
-        ground: true,
-        length: ..dock_metrics[:vehicle_length],
-        beam: ..dock_metrics[:vehicle_beam],
-        height: ..dock_metrics[:vehicle_height]
-      }
-    )
+    will_it_fit_ship_dock?(scope, dock_metrics)
+      .or(will_it_fit_vehicle_dock?(scope, dock_metrics))
   end
 
   private def will_it_fit_ship_dock?(scope, dock_metrics)

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -104,6 +104,10 @@ class Dock < ApplicationRecord
     end
   end
 
+  def measured?
+    length.present? && beam.present? && height.present?
+  end
+
   def dock_type_label
     Dock.human_enum_name(:dock_type, dock_type)
   end

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -16091,7 +16091,6 @@ components:
             type: string
         willItFit:
           type: string
-          format: uuid
         withCargo:
           type: boolean
         s:
@@ -18849,7 +18848,6 @@ components:
             type: string
         willItFit:
           type: string
-          format: uuid
         withCargo:
           type: boolean
         withCargoGrids:

--- a/test/integration/api/v1/hangar_test.rb
+++ b/test/integration/api/v1/hangar_test.rb
@@ -61,6 +61,31 @@ class Api::V1::HangarTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # A carrier holding a dock of each kind takes the branch that used to hand a
+  # Hash to `or`, which Rails refuses outright -- so this filter answered with a
+  # 500 for exactly the three ships anybody would pick: Polaris, Carrack, 890
+  # Jump.
+  test "GET /hangar filters by a carrier that takes both ships and vehicles" do
+    user = create(:user)
+    carrier = create(:model, slug: "carrier-with-both")
+    create(:dock, :with_dimensions, model: carrier, dock_type: :hangar)
+    create(:dock, :with_dimensions, model: carrier, dock_type: :garage)
+
+    fits = create(:model, ground: false, length: 20.0, beam: 10.0, height: 5.0)
+    too_big = create(:model, ground: false, length: 200.0, beam: 100.0, height: 50.0)
+    create(:vehicle, user:, model: fits, wanted: false)
+    create(:vehicle, user:, model: too_big, wanted: false)
+
+    sign_in user
+
+    assert_api_response :get, 200, params: {q: {willItFit: carrier.slug}} do
+      slugs = parsed_body["items"].map { |item| item.dig("model", "slug") }
+
+      assert_includes slugs, fits.slug
+      assert_not_includes slugs, too_big.slug
+    end
+  end
+
   test "DELETE /hangar clears the hangar" do
     user = create(:user, vehicle_count: 2)
     sign_in user

--- a/test/integration/api/v1/models_index_test.rb
+++ b/test/integration/api/v1/models_index_test.rb
@@ -83,6 +83,37 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # The picker sends a slug and the controller resolves one, but the schema asked
+  # for a uuid — so every real request was rejected before reaching the action.
+  test "GET /models accepts a slug for willItFit" do
+    carrier = create(:model, slug: "fitting-carrier")
+    create(:dock, :with_dimensions, model: carrier, dock_type: :hangar)
+
+    fits = create(:model, length: 20.0, beam: 10.0, height: 5.0)
+    too_big = create(:model, length: 300.0, beam: 100.0, height: 60.0)
+
+    assert_api_response :get, 200, params: {q: {willItFit: carrier.slug}} do
+      slugs = parsed_body["items"].map { |item| item["slug"] }
+
+      assert_includes slugs, fits.slug
+      assert_not_includes slugs, too_big.slug
+    end
+  end
+
+  # An unmeasured dock used to become half a metre, so a carrier nobody measured
+  # answered "nothing fits" rather than declining to answer.
+  test "GET /models does not empty the list for a carrier with unmeasured docks" do
+    carrier = create(:model, slug: "unmeasured-carrier")
+    create(:dock, model: carrier, dock_type: :hangar)
+    other = create(:model, length: 20.0, beam: 10.0, height: 5.0)
+
+    assert_api_response :get, 200, params: {q: {willItFit: carrier.slug}} do
+      slugs = parsed_body["items"].map { |item| item["slug"] }
+
+      assert_includes slugs, other.slug
+    end
+  end
+
   test "GET /models honours perPage" do
     create_list(:model, 6)
 


### PR DESCRIPTION
Resolves #4853

The "will it fit" filter does not work for anyone and has not for a while. It has a picker, a place in the public schema and four controllers including it — and four separate defects, each of which alone is enough to break it.

Found while researching #2404, which wanted to display this filter's answer as information.

## 1 — The schema asks for a uuid, everything else speaks slug

`HangarQuery` and `ModelQuery` declared `willItFit: {format: :uuid}`. The controller resolves a slug; `ModelWillItFitSelect` sends `model.slug`. Verified against production:

```
GET /v1/models?q[willItFit]=anvl-carrack   →  400  does not match format: uuid
GET /v1/models?q[willItFit]=<uuid>          →  200
```

The uuid path is the worse of the two: it matches no model, `parent.blank?` returns the scope unfiltered, and the caller gets the entire catalogue as though everything fits.

Loosening a format cannot break a client that works today.

## 2 — The ship list permits it as an array

`model_query_params` listed `will_it_fit: []`. The value is one slug, so `permit` dropped it and the filter never ran — independently of defect 1. The hangar derives its permitted keys from the schema and does not have this, which is why it reaches the next one.

## 3 — `or` handed a Hash

`will_it_fit_ship_or_vehicle_dock?` called `.or(models: {...})`. `ActiveRecord::Relation#or` refuses a Hash. The branch is reached only for a carrier with a measured dock of **both** kinds: **Polaris, Carrack, 890 Jump**. Fixing defect 1 without this one would turn a 400 into a 500 for exactly the three ships anybody would pick.

## 4 — An unmeasured dock meant "nothing fits"

`(dock.length || 1) - 0.5` in the ship list, `(dock&.length || 0) - 2.0` in the hangar. A dock nobody measured became a tiny one and excluded everything, so a carrier with no measurements stated that nothing fits rather than declining to answer. Unmeasured docks are now skipped, and a carrier holding only those does not filter at all.

## Why it lasted

`willItFit` had no test coverage anywhere. There are now four regression tests, one per defect. Defects 2 and 4 were found by a test failing, not by reading — the first attempt returned a model three times too large and that was the tell.

## Verification

2108 tests across `test/integration/api/v1/` and `test/models/` pass. `bin/ruby-lint` clean. Schema regenerated; the diff is two removed `format: uuid` lines.

## Not in scope

The two implementations disagree about the rule itself. The ship list uses every dock, 0.5m of clearance and no notion of dock type; the hangar takes the largest of each kind, tells ground vehicles from ships and allows 2m. Both are now correct on their own terms and still answer differently.

Unifying them changes filter results and belongs with #2404, which cannot display an answer until there is one rule. The decision there is to keep the hangar's, since it is the one that knows a garage from a landing pad.

🤖
