### PR TITLE
fix(errors): tell an offline client the connection is gone, not the server

### DIFF
--- a/app/frontend/frontend/pages/visual-tests/states.vue
+++ b/app/frontend/frontend/pages/visual-tests/states.vue
@@ -25,6 +25,7 @@ import PanelBody from "@/shared/components/base/Panel/Body/index.vue";
 import ProgressBar from "@/shared/components/ProgressBar/index.vue";
 import UploadProgress from "@/shared/components/UploadProgress/index.vue";
 import ServerError from "@/shared/components/ServerError/index.vue";
+import Offline from "@/shared/components/Offline/index.vue";
 import SmallLoader from "@/shared/components/SmallLoader/index.vue";
 import { EmptyVariantsEnum } from "@/shared/components/Empty/types";
 import { HeadingLevelEnum } from "@/shared/components/base/Heading/types";
@@ -375,17 +376,21 @@ const updatePerPage = (value: number | string) => {
 
   <Heading :level="HeadingLevelEnum.H2">Error Pages</Heading>
   <p>
-    The five full-page error blocks. They are normally rendered as a whole
-    route, so they bring their own heading. <code>Forbidden</code> is the one
-    for a resource that exists and is not yours, as against
+    The six full-page error blocks. They are normally rendered as a whole route,
+    so they bring their own heading. <code>Forbidden</code> is the one for a
+    resource that exists and is not yours, as against
     <code>NotAuthorized</code> for not being signed in at all.
-    <code>InviteInvalid</code> names the token it was given, which is opaque and
-    long enough to run out of the box if it does not break.
+    <code>Offline</code> is for a request that never got an answer, as against
+    <code>ServerError</code> for one the server failed; it only shows its retry
+    button where the caller hands it one. <code>InviteInvalid</code> names the
+    token it was given, which is opaque and long enough to run out of the box if
+    it does not break.
   </p>
   <NotFound />
   <NotAuthorized />
   <Forbidden />
   <ServerError />
+  <Offline :retry="() => {}" />
   <InviteInvalid token="8f14e45fceea167a5a36dedd4bea2543" />
 
   <Heading :level="HeadingLevelEnum.H2">FetchProgressBar</Heading>

--- a/app/frontend/shared/components/AsyncData.spec.ts
+++ b/app/frontend/shared/components/AsyncData.spec.ts
@@ -23,6 +23,14 @@ const statusOf = (error: AsyncStatus["error"]["value"]) =>
     error: ref(error),
   }) as unknown as AsyncStatus;
 
+// A request that never got an answer: no response, which is what axios reports
+// for a device that is offline or a host it could not reach.
+const unanswered = () =>
+  ({
+    isAxiosError: true,
+    code: "ERR_NETWORK",
+  }) as unknown as AsyncStatus["error"]["value"];
+
 const mount = (status: number) =>
   mountWithDefaults<typeof Component>(Component, {
     props: { asyncStatus: statusOf(failedWith(status)) },
@@ -47,5 +55,14 @@ describe("AsyncData", () => {
 
     expect(wrapper.findComponent({ name: "ServerError" }).exists()).toBe(true);
     expect(wrapper.findComponent({ name: "Forbidden" }).exists()).toBe(false);
+  });
+
+  it("blames the connection, not the server, when nothing answered", async () => {
+    const wrapper = await mountWithDefaults<typeof Component>(Component, {
+      props: { asyncStatus: statusOf(unanswered()) },
+    });
+
+    expect(wrapper.findComponent({ name: "Offline" }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: "ServerError" }).exists()).toBe(false);
   });
 });

--- a/app/frontend/shared/components/AsyncData.spec.ts
+++ b/app/frontend/shared/components/AsyncData.spec.ts
@@ -25,11 +25,12 @@ const statusOf = (error: AsyncStatus["error"]["value"]) =>
 
 // A request that never got an answer: no response, which is what axios reports
 // for a device that is offline or a host it could not reach.
-const unanswered = () =>
-  ({
+function unanswered() {
+  return {
     isAxiosError: true,
     code: "ERR_NETWORK",
-  }) as unknown as AsyncStatus["error"]["value"];
+  } as unknown as AsyncStatus["error"]["value"];
+}
 
 const mount = (status: number) =>
   mountWithDefaults<typeof Component>(Component, {

--- a/app/frontend/shared/components/AsyncData.types.ts
+++ b/app/frontend/shared/components/AsyncData.types.ts
@@ -13,6 +13,7 @@ export type AsyncStatus = {
 };
 
 export enum ErrorTypesEnum {
+  OFFLINE = "OFFLINE",
   NOT_FOUND = "NOT_FOUND",
   FORBIDDEN = "FORBIDDEN",
   ERROR = "ERROR",

--- a/app/frontend/shared/components/AsyncData.vue
+++ b/app/frontend/shared/components/AsyncData.vue
@@ -8,6 +8,7 @@ export default {
 import NotFound from "@/shared/components/NotFound/index.vue";
 import Forbidden from "@/shared/components/Forbidden/index.vue";
 import ServerError from "@/shared/components/ServerError/index.vue";
+import Offline from "@/shared/components/Offline/index.vue";
 import Loader from "@/shared/components/Loader/index.vue";
 import {
   type AsyncStatus,
@@ -46,6 +47,10 @@ const loading = computed(() => {
   <slot v-if="error && !hideError" name="error">
     <NotFound v-if="errorType === ErrorTypesEnum.NOT_FOUND" />
     <Forbidden v-else-if="errorType === ErrorTypesEnum.FORBIDDEN" />
+    <Offline
+      v-else-if="errorType === ErrorTypesEnum.OFFLINE"
+      :retry="asyncStatus.refetch"
+    />
     <ServerError v-else />
   </slot>
   <slot v-else-if="loading" name="loading">

--- a/app/frontend/shared/components/FilteredList/index.spec.ts
+++ b/app/frontend/shared/components/FilteredList/index.spec.ts
@@ -85,8 +85,8 @@ const mountOnRoute = async (
 
 // A request that never got an answer: no response, which is what axios reports
 // for a device that is offline or a host it could not reach.
-const unanswered = () =>
-  ({
+function unanswered() {
+  return {
     fetchStatus: ref("idle"),
     isError: ref(true),
     isPending: ref(false),
@@ -94,7 +94,8 @@ const unanswered = () =>
     isFetching: ref(false),
     isRefetching: ref(false),
     error: ref({ isAxiosError: true, code: "ERR_NETWORK" }),
-  }) as unknown as AsyncStatus;
+  } as unknown as AsyncStatus;
+}
 
 const mount = (status: number) =>
   mountWithDefaults<typeof ListComponent>(ListComponent, {

--- a/app/frontend/shared/components/FilteredList/index.spec.ts
+++ b/app/frontend/shared/components/FilteredList/index.spec.ts
@@ -83,6 +83,19 @@ const mountOnRoute = async (
   });
 };
 
+// A request that never got an answer: no response, which is what axios reports
+// for a device that is offline or a host it could not reach.
+const unanswered = () =>
+  ({
+    fetchStatus: ref("idle"),
+    isError: ref(true),
+    isPending: ref(false),
+    isLoading: ref(false),
+    isFetching: ref(false),
+    isRefetching: ref(false),
+    error: ref({ isAxiosError: true, code: "ERR_NETWORK" }),
+  }) as unknown as AsyncStatus;
+
 const mount = (status: number) =>
   mountWithDefaults<typeof ListComponent>(ListComponent, {
     props: { name: "test-list", records: [], asyncStatus: failedWith(status) },
@@ -113,6 +126,18 @@ describe("FilteredList", () => {
 
     expect(wrapper.findComponent({ name: "ServerError" }).exists()).toBe(true);
     expect(wrapper.findComponent({ name: "Forbidden" }).exists()).toBe(false);
+  });
+
+  it("blames the connection, not the server, when nothing answered", async () => {
+    const wrapper = await mountWithDefaults<typeof ListComponent>(
+      ListComponent,
+      {
+        props: { name: "test-list", records: [], asyncStatus: unanswered() },
+      },
+    );
+
+    expect(wrapper.findComponent({ name: "Offline" }).exists()).toBe(true);
+    expect(wrapper.findComponent({ name: "ServerError" }).exists()).toBe(false);
   });
 
   // A flex line breaks on a child's unwrapped width, so the paginator only

--- a/app/frontend/shared/components/FilteredList/index.vue
+++ b/app/frontend/shared/components/FilteredList/index.vue
@@ -10,6 +10,7 @@ import Loader from "@/shared/components/Loader/index.vue";
 import Empty from "@/shared/components/Empty/index.vue";
 import ServerError from "@/shared/components/ServerError/index.vue";
 import Forbidden from "@/shared/components/Forbidden/index.vue";
+import Offline from "@/shared/components/Offline/index.vue";
 import { useFiltersStore } from "@/shared/stores/filters";
 import { usePaginationStore } from "@/shared/stores/pagination";
 import { provideListGeometry } from "@/shared/composables/useListGeometry";
@@ -186,12 +187,14 @@ const error = computed(() => {
   return props.asyncStatus.isError.value;
 });
 
+const errorType = computed(() => errorTypeFrom(props.asyncStatus.error?.value));
+
 // A list behind a flag that is not on yet, or a record belonging to somebody
 // else, comes back 403 — which is an answer, not an outage.
-const forbidden = computed(
-  () =>
-    errorTypeFrom(props.asyncStatus.error?.value) === ErrorTypesEnum.FORBIDDEN,
-);
+const forbidden = computed(() => errorType.value === ErrorTypesEnum.FORBIDDEN);
+
+// A request that never reached the server is not an outage either.
+const offline = computed(() => errorType.value === ErrorTypesEnum.OFFLINE);
 
 const emptyVisible = computed(() => {
   return !!(
@@ -331,6 +334,7 @@ const toggleFilter = () => {
           <slot v-if="error" name="error">
             <transition name="fade">
               <Forbidden v-if="forbidden" />
+              <Offline v-else-if="offline" :retry="asyncStatus.refetch" />
               <ServerError v-else />
             </transition>
           </slot>

--- a/app/frontend/shared/components/Offline/index.vue
+++ b/app/frontend/shared/components/Offline/index.vue
@@ -1,0 +1,59 @@
+<script lang="ts">
+export default {
+  name: "Offline",
+};
+</script>
+
+<script lang="ts" setup>
+import Btn from "@/shared/components/base/Btn/index.vue";
+import Box from "@/shared/components/Box/index.vue";
+import Text from "@/shared/components/base/Text/index.vue";
+import { useI18n } from "@/shared/composables/useI18n";
+import { PanelTonesEnum } from "@/shared/components/base/Panel/types";
+import { HeadingSizeEnum } from "@/shared/components/base/Heading/types";
+
+type Props = {
+  retry?: () => void;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  retry: undefined,
+});
+
+const { t } = useI18n();
+
+const retry = () => props.retry?.();
+
+// This screen is rendered from an error that has already settled, so the
+// connection coming back moves nothing on its own — the same retry the button
+// offers runs as soon as the device is back, rather than waiting to be pressed.
+onMounted(() => {
+  window.addEventListener("online", retry);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("online", retry);
+});
+</script>
+
+<template>
+  <Box
+    :tone="PanelTonesEnum.ERROR"
+    :heading-size="HeadingSizeEnum.HERO"
+    animated
+    large
+  >
+    <template #heading>
+      {{ t("headlines.offline") }}
+    </template>
+    <template #default>
+      <Text>{{ t("texts.offline") }}</Text>
+    </template>
+    <template v-if="props.retry" #footer>
+      <Btn @click="retry">
+        <i class="fa-duotone fa-rotate" />
+        {{ t("actions.retry").toUpperCase() }}
+      </Btn>
+    </template>
+  </Box>
+</template>

--- a/app/frontend/shared/components/Offline/index.vue
+++ b/app/frontend/shared/components/Offline/index.vue
@@ -12,9 +12,9 @@ import { useI18n } from "@/shared/composables/useI18n";
 import { PanelTonesEnum } from "@/shared/components/base/Panel/types";
 import { HeadingSizeEnum } from "@/shared/components/base/Heading/types";
 
-type Props = {
+interface Props {
   retry?: () => void;
-};
+}
 
 const props = withDefaults(defineProps<Props>(), {
   retry: undefined,

--- a/app/frontend/shared/utils/ErrorTypes.spec.ts
+++ b/app/frontend/shared/utils/ErrorTypes.spec.ts
@@ -21,7 +21,19 @@ describe("errorTypeFrom", () => {
     expect(errorTypeFrom(failedWith(422))).toBe(ErrorTypesEnum.ERROR);
   });
 
-  it("has no verdict without a response", () => {
+  it("reads a request that got no answer as a lost connection", () => {
+    expect(errorTypeFrom({ isAxiosError: true, code: "ERR_NETWORK" })).toBe(
+      ErrorTypesEnum.OFFLINE,
+    );
+  });
+
+  it("keeps a cancelled request off the error screens", () => {
+    expect(
+      errorTypeFrom({ isAxiosError: true, code: "ERR_CANCELED" }),
+    ).toBeUndefined();
+  });
+
+  it("has no verdict on something that is not a failed request", () => {
     expect(errorTypeFrom(new Error("boom"))).toBeUndefined();
     expect(errorTypeFrom(undefined)).toBeUndefined();
   });

--- a/app/frontend/shared/utils/ErrorTypes.ts
+++ b/app/frontend/shared/utils/ErrorTypes.ts
@@ -4,6 +4,14 @@ import { ErrorTypesEnum } from "@/shared/components/AsyncData.types";
 const statusOf = (error: unknown) =>
   isAxiosError(error) ? error.response?.status : undefined;
 
+// A request that never got an answer: the device is offline, the connection
+// dropped, or the host is unreachable. Axios reports all of them without a
+// response, which is the only thing that separates them from a server that
+// answered with a failure. A cancelled request is not one of them - nothing
+// went wrong, the caller walked away.
+const unanswered = (error: unknown) =>
+  isAxiosError(error) && !error.response && error.code !== "ERR_CANCELED";
+
 /**
  * Which screen a failed request deserves. Shared so every surface answers the
  * same way: a refused request is not a broken server, wherever it surfaces.
@@ -11,7 +19,7 @@ const statusOf = (error: unknown) =>
 export const errorTypeFrom = (error: unknown): ErrorTypesEnum | undefined => {
   const status = statusOf(error);
 
-  if (!status) return undefined;
+  if (!status) return unanswered(error) ? ErrorTypesEnum.OFFLINE : undefined;
 
   if (status === 404) return ErrorTypesEnum.NOT_FOUND;
 

--- a/app/frontend/shared/utils/ErrorTypes.ts
+++ b/app/frontend/shared/utils/ErrorTypes.ts
@@ -9,8 +9,11 @@ const statusOf = (error: unknown) =>
 // response, which is the only thing that separates them from a server that
 // answered with a failure. A cancelled request is not one of them - nothing
 // went wrong, the caller walked away.
-const unanswered = (error: unknown) =>
-  isAxiosError(error) && !error.response && error.code !== "ERR_CANCELED";
+function unanswered(error: unknown) {
+  return (
+    isAxiosError(error) && !error.response && error.code !== "ERR_CANCELED"
+  );
+}
 
 /**
  * Which screen a failed request deserves. Shared so every surface answers the

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -43,6 +43,7 @@
       "ok": "Ok",
       "reset": "Reset",
       "reload": "Neu Laden",
+      "retry": "Erneut versuchen",
       "confirm": "Bestätigen",
       "showDetailPage": "Detailseite",
       "showDetails": "Details anzeigen",

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -193,6 +193,7 @@
       "inviteInvalid": "Ungültiger Einladungslink",
       "accessDenied": "Zugriff verweigert",
       "serverError": "Serverfehler",
+      "offline": "Verbindung verloren",
       "comments": "Kommentare",
       "login": "Anmelden",
       "hangar": {

--- a/app/frontend/translations/de/texts.json
+++ b/app/frontend/translations/de/texts.json
@@ -24,6 +24,7 @@
       "inviteInvalid": "Dieser Einladungslink ist nicht gültig. Möglicherweise wurde er falsch übertragen, er ist abgelaufen oder er hat sein Nutzungslimit erreicht. Bitte lass dir von der Person, die dich eingeladen hat, einen neuen Link geben.",
       "accessDenied": "Sie sind nicht berechtigt, diese Seite anzuzeigen.",
       "serverError": "Der Server hat derzeit technische Probleme. Bitte versuchen Sie es später erneut.",
+      "offline": "Die Anfrage hat den Server nicht erreicht. Dein Gerät scheint offline zu sein oder der Server war nicht erreichbar. Prüfe deine Verbindung und versuche es erneut.",
       "compare": {
         "ships": {
           "info": "To start select at least two and not more than eight Ships you want to compare."

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -43,6 +43,7 @@
       "ok": "Ok",
       "reset": "Reset",
       "reload": "Reload",
+      "retry": "Try Again",
       "confirm": "Confirm",
       "showDetailPage": "Detail Page",
       "showDetails": "Show Details",

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -185,6 +185,7 @@
       "inviteInvalid": "Invalid Invite Link",
       "accessDenied": "Access Denied",
       "serverError": "Server Error",
+      "offline": "Connection Lost",
       "comments": "Comments",
       "login": "Login",
       "hangar": {

--- a/app/frontend/translations/en/texts.json
+++ b/app/frontend/translations/en/texts.json
@@ -24,6 +24,7 @@
       "inviteInvalid": "This invite link is not valid. It may have been mistyped, it may have expired, or it may have already reached its limit of uses. Ask whoever invited you for a new link.",
       "accessDenied": "You are not authorized to view this page.",
       "serverError": "The server is currently experiencing technical difficulties. Please try again later.",
+      "offline": "The request never reached the server. Your device appears to be offline, or the server could not be reached. Check your connection and try again.",
       "compare": {
         "ships": {
           "info": "To start select at least two and not more than eight Ships you want to compare."

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -43,6 +43,7 @@
       "ok": "Aceptar",
       "reset": "Restablecer",
       "reload": "Recargar",
+      "retry": "Reintentar",
       "confirm": "Confirmar",
       "showDetailPage": "Página de detalles",
       "showDetails": "Mostrar detalles",

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -193,6 +193,7 @@
       "inviteInvalid": "Enlace de invitación no válido",
       "accessDenied": "Acceso denegado",
       "serverError": "Error del servidor",
+      "offline": "Conexión perdida",
       "comments": "Comentarios",
       "login": "Iniciar sesión",
       "hangar": {

--- a/app/frontend/translations/es/texts.json
+++ b/app/frontend/translations/es/texts.json
@@ -24,6 +24,7 @@
       "inviteInvalid": "Este enlace de invitación no es válido. Puede que se haya copiado mal, que haya caducado o que ya haya alcanzado su límite de usos. Pide un enlace nuevo a quien te invitó.",
       "accessDenied": "No está autorizado para ver esta página.",
       "serverError": "El servidor está experimentando dificultades técnicas. Inténtelo más tarde.",
+      "offline": "La solicitud no ha llegado al servidor. Tu dispositivo parece estar sin conexión o no se ha podido contactar con el servidor. Comprueba tu conexión e inténtalo de nuevo.",
       "compare": {
         "ships": {
           "info": "To start select at least two and not more than eight Ships you want to compare."

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -43,6 +43,7 @@
       "ok": "Ok",
       "reset": "Réinitialiser",
       "reload": "Recharger",
+      "retry": "Réessayer",
       "confirm": "Valider",
       "showDetailPage": "Détails",
       "showDetails": "Afficher les détails",

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -193,6 +193,7 @@
       "inviteInvalid": "Lien d'invitation invalide",
       "accessDenied": "Accès refusé",
       "serverError": "Erreur du serveur",
+      "offline": "Connexion perdue",
       "comments": "Commentaires",
       "login": "Se connecter",
       "hangar": {

--- a/app/frontend/translations/fr/texts.json
+++ b/app/frontend/translations/fr/texts.json
@@ -24,6 +24,7 @@
       "inviteInvalid": "Ce lien d'invitation n'est pas valide. Il a peut-être été mal recopié, il a peut-être expiré, ou il a peut-être déjà atteint sa limite d'utilisations. Demandez un nouveau lien à la personne qui vous a invité.",
       "accessDenied": "Vous n'êtes pas autorisé à consulter cette page.",
       "serverError": "Le serveur rencontre actuellement des difficultés techniques. Veuillez réessayer plus tard.",
+      "offline": "La requête n'a pas atteint le serveur. Votre appareil semble hors ligne ou le serveur est injoignable. Vérifiez votre connexion et réessayez.",
       "compare": {
         "ships": {
           "info": "To start select at least two and not more than eight Ships you want to compare."

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -43,6 +43,7 @@
       "ok": "Ok",
       "reset": "Reset",
       "reload": "Ricarica",
+      "retry": "Riprova",
       "confirm": "Conferma",
       "showDetailPage": "Pagina dei dettagli",
       "showDetails": "Mostra i dettagli",

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -193,6 +193,7 @@
       "inviteInvalid": "Link di invito non valido",
       "accessDenied": "Accesso negato",
       "serverError": "Errore del server",
+      "offline": "Connessione persa",
       "comments": "Commenti",
       "login": "Accedi",
       "hangar": {

--- a/app/frontend/translations/it/texts.json
+++ b/app/frontend/translations/it/texts.json
@@ -24,6 +24,7 @@
       "inviteInvalid": "Questo link di invito non è valido. Potrebbe essere stato copiato male, potrebbe essere scaduto oppure potrebbe aver già raggiunto il limite di utilizzi. Chiedi un nuovo link a chi ti ha invitato.",
       "accessDenied": "Non sei autorizzato a visualizzare questa pagina.",
       "serverError": "Il server sta riscontrando difficoltà tecniche. Riprova più tardi.",
+      "offline": "La richiesta non ha raggiunto il server. Il tuo dispositivo sembra essere offline oppure il server non è raggiungibile. Controlla la connessione e riprova.",
       "compare": {
         "ships": {
           "info": "Per iniziare a selezionare almeno due e non più di otto Navi che si desiderano confrontare."

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -43,6 +43,7 @@
       "ok": "确定",
       "reset": "重置",
       "reload": "重新加载",
+      "retry": "重试",
       "confirm": "确认",
       "showDetailPage": "详情页面",
       "showDetails": "显示详情",

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -193,6 +193,7 @@
       "inviteInvalid": "邀请链接无效",
       "accessDenied": "拒绝访问",
       "serverError": "服务器错误",
+      "offline": "连接已断开",
       "comments": "评论",
       "login": "登录",
       "hangar": {

--- a/app/frontend/translations/zh-CN/texts.json
+++ b/app/frontend/translations/zh-CN/texts.json
@@ -24,6 +24,7 @@
       "inviteInvalid": "此邀请链接无效。可能是输入有误、已过期，或已达到使用次数上限。请向邀请你的人索取新的链接。",
       "accessDenied": "您无权查看此页面。",
       "serverError": "服务器当前遇到技术问题。请稍后再试。",
+      "offline": "请求未能到达服务器。你的设备似乎已离线，或者无法连接到服务器。请检查网络连接后重试。",
       "compare": {
         "ships": {
           "info": "To start select at least two and not more than eight Ships you want to compare."

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -43,6 +43,7 @@
       "ok": "確定",
       "reset": "重置",
       "reload": "重新載入",
+      "retry": "重試",
       "confirm": "確認",
       "showDetailPage": "詳情頁面",
       "showDetails": "顯示詳情",

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -193,6 +193,7 @@
       "inviteInvalid": "邀請連結無效",
       "accessDenied": "拒絕存取",
       "serverError": "伺服器錯誤",
+      "offline": "連線已中斷",
       "comments": "評論",
       "login": "登入",
       "hangar": {

--- a/app/frontend/translations/zh-TW/texts.json
+++ b/app/frontend/translations/zh-TW/texts.json
@@ -24,6 +24,7 @@
       "inviteInvalid": "此邀請連結無效。可能是輸入有誤、已過期，或已達到使用次數上限。請向邀請你的人索取新的連結。",
       "accessDenied": "您無權檢視此頁面。",
       "serverError": "伺服器目前遇到技術問題。請稍後再試。",
+      "offline": "請求未能送達伺服器。你的裝置似乎已離線，或者無法連線到伺服器。請檢查網路連線後再試一次。",
       "compare": {
         "ships": {
           "info": "To start select at least two and not more than eight Ships you want to compare."


### PR DESCRIPTION
## The bug

With the client offline, a failed request showed the **Server Error** screen — the app blamed the server for something that never left the device.

`errorTypeFrom` classified a failure by HTTP status alone. A request that never got an answer has no `response`, so it returned no verdict, and both render sites fell through to their `v-else`, which is `ServerError`.

## The fix

A failed axios request with no response is now `ErrorTypesEnum.OFFLINE` and gets its own screen. `ERR_CANCELED` is excluded — nothing went wrong there, so it keeps getting no verdict at all.

The wording covers both a device that is offline and a host that could not be reached, because the client cannot tell those apart.

- `shared/utils/ErrorTypes.ts` — the new classification, shared by every surface as before.
- `shared/components/Offline/index.vue` — new screen. It takes an optional `retry` and shows a Try Again button when it gets one. It also runs that retry on the browser's `online` event: the screen is drawn from an error that has already settled, so the connection coming back moves nothing on its own and it would otherwise just sit there.
- `AsyncData.vue` and `FilteredList/index.vue` — a new branch ahead of the `ServerError` fallback, handing `asyncStatus.refetch` down as the retry. `FilteredList` now derives `forbidden` and `offline` from one `errorType` computed instead of calling `errorTypeFrom` per branch.
- Translations for `headlines.offline`, `texts.offline` and `actions.retry` in all seven locales.
- `visual-tests/states.vue` shows the new block (five error pages → six).

## Verification

24 tests pass across the three affected specs, including new cases in each: an unanswered request routes to `Offline` and not `ServerError` in both `AsyncData` and `FilteredList`, and a cancelled request stays off the error screens entirely. eslint and prettier clean.

`pnpm lint:ts` is clean. (It was red on my first run against a stale local `services/fyApi` — that directory is gitignored and generated, so `pnpm generate-api-client` fixes it. Nothing on `main` is affected.)

🤖
