### PR TITLE
chore(setup): schedule bin/setup steps as a dependency graph

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -26,7 +26,7 @@ trap("INT") do
 end
 
 def format_duration(seconds) = CliHelpers.format_duration(seconds)
-def run_step(label, cmd = nil, async: false, &block) = CliHelpers.run_step(label, cmd, verbose: VERBOSE, async:, &block)
+def run_step(label, cmd = nil, async: false, after: [], &block) = CliHelpers.run_step(label, cmd, verbose: VERBOSE, async:, after:, &block)
 def run_step_wait(*steps) = CliHelpers.run_step_wait(*steps, verbose: VERBOSE)
 
 WORKTREE_MARKER = "# -- worktree-managed --"
@@ -319,7 +319,7 @@ if ARGV.include?("--help") || ARGV.include?("-h")
 end
 
 FileUtils.chdir APP_ROOT do
-  total_start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  total_start = CliHelpers.monotonic_now
 
   wt_name = detect_worktree
   port = 8270
@@ -384,31 +384,30 @@ FileUtils.chdir APP_ROOT do
     run_step "Wiping application state", "docker compose down -v"
   end
 
-  # Group A: Install dependencies and start Docker (all independent)
+  # One dependency graph instead of lock-step groups: every step starts as soon
+  # as what it actually needs is done, so Docker startup and pnpm install no
+  # longer gate the databases, and the Vite build overlaps everything else.
+  db_env = "DB_PORT=#{db_port} WORKTREE_SUFFIX=#{db_suffix}"
   ruby_deps = run_step "Installing Ruby dependencies", "bundle check || bundle install", async: true
   node_deps = run_step "Installing Node dependencies", "pnpm install", async: true
   docker = run_step "Starting Docker services", "docker compose up -d --wait --wait-timeout 30", async: true
-  run_step_wait(ruby_deps, node_deps, docker)
-
-  # Group B: Prepare databases and build Vite assets (need deps + Docker)
-  # db:prepare rewrites db/schema.rb after migrating, so the dev and test runs
-  # must be sequential: a dump from one truncates the file the other is reading.
-  db_env = "DB_PORT=#{db_port} WORKTREE_SUFFIX=#{db_suffix}"
-  databases = run_step "Preparing databases (dev + test)",
-    "#{db_env} bin/rails db:prepare && #{db_env} RAILS_ENV=test bin/rails db:prepare", async: true
-  vite_build = run_step "Building email assets (test)", "bin/build-email-assets", async: true
+  dev_db = run_step "Preparing database (dev)", "#{db_env} bin/rails db:prepare",
+    async: true, after: [ruby_deps, docker]
+  # After dev, not alongside: a fresh test database loads db/schema.rb, which
+  # the dev run may be dumping at that moment.
+  test_db = run_step "Preparing database (test)", "#{db_env} RAILS_ENV=test bin/rails db:prepare",
+    async: true, after: [dev_db]
+  email_assets = run_step "Building email assets (test)", "bin/build-email-assets", async: true
   # auto-imports.d.ts and components.d.ts are gitignored and only written by the
   # Vite plugins, so vue-tsc reports every auto-imported symbol as undefined
   # until a build has run at least once. Builds to vite-dev, so it does not race
   # the email assets build over the vite-test manifest.
-  frontend_types = run_step "Generating frontend type declarations", "bin/vite build", async: true
-  run_step_wait(databases, vite_build, frontend_types)
+  frontend_types = run_step "Generating frontend type declarations", "bin/vite build",
+    async: true, after: [ruby_deps, node_deps]
+  clean = run_step "Cleaning logs and temp files", "bin/rails log:clear tmp:clear", async: true, after: [ruby_deps]
+  run_step_wait(ruby_deps, node_deps, docker, dev_db, test_db, email_assets, frontend_types, clean)
 
-  # Group C: Clean logs/tmp (need databases)
-  clean = run_step "Cleaning logs and temp files", "bin/rails log:clear tmp:clear", async: true
-  run_step_wait(clean)
-
-  total_elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - total_start
+  total_elapsed = CliHelpers.monotonic_now - total_start
   puts "\n== Setup complete in #{format_duration(total_elapsed)} =="
 
   start_server = ARGV.include?("--dev") || ARGV.any? { |arg| arg.start_with?("--dev-") }

--- a/bin/setup
+++ b/bin/setup
@@ -305,8 +305,8 @@ if ARGV.include?("--help") || ARGV.include?("-h")
     Set up or update the development environment. Idempotent.
 
     Options:
-      --fresh         Wipe application state (Docker volumes) before setup
-                      WARNING: affects all worktrees (shared Docker services)
+      --fresh         Wipe application state (Docker volumes, tmp/) before setup
+                      WARNING: the volumes are shared by all worktrees
       --name=NAME     Override the worktree name used for the DB suffix, cookies, etc.
       --port=N        Override the Rails port (default: derived from the slot)
       --vite-port=N   Override the Vite dev server port (default: derived from the slot)
@@ -381,7 +381,10 @@ FileUtils.chdir APP_ROOT do
   end
 
   if FRESH
-    run_step "Wiping application state", "docker compose down -v"
+    run_step "Wiping Docker volumes", "docker compose down -v"
+    # Everything untracked under tmp/: caches, pids, sockets, test uploads.
+    # Nothing under tmp/ is tracked, so the clean takes the directory with it.
+    run_step "Wiping tmp/", "git clean -fdx -- tmp && mkdir -p tmp"
   end
 
   # One dependency graph instead of lock-step groups: every step starts as soon
@@ -404,8 +407,10 @@ FileUtils.chdir APP_ROOT do
   # the email assets build over the vite-test manifest.
   frontend_types = run_step "Generating frontend type declarations", "bin/vite build",
     async: true, after: [ruby_deps, node_deps]
-  clean = run_step "Cleaning logs and temp files", "bin/rails log:clear tmp:clear", async: true, after: [ruby_deps]
-  run_step_wait(ruby_deps, node_deps, docker, dev_db, test_db, email_assets, frontend_types, clean)
+  # Only the logs: tmp:clear would also wipe tmp/cache, and with it the Bootsnap
+  # cache and the vite_ruby build markers that let the next build skip.
+  logs = run_step "Clearing logs", "bin/rails log:clear", async: true, after: [ruby_deps]
+  run_step_wait(ruby_deps, node_deps, docker, dev_db, test_db, email_assets, frontend_types, logs)
 
   total_elapsed = CliHelpers.monotonic_now - total_start
   puts "\n== Setup complete in #{format_duration(total_elapsed)} =="

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,6 +28,10 @@ Rails.application.configure do
   # loading is working properly before deploying your code.
   config.eager_load = ENV["CI"].present?
 
+  # db/schema.rb is dumped from development only; a test-env db:migrate must not
+  # rewrite it (it raced the dev dump when bin/setup prepared both databases).
+  config.active_record.dump_schema_after_migration = false
+
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {"Cache-Control" => "public, max-age=#{1.hour.to_i}"}

--- a/lib/cli_helpers.rb
+++ b/lib/cli_helpers.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+require "open3"
+
 module CliHelpers
   SPINNER = %w[⠋ ⠙ ⠹ ⠸ ⠼ ⠴ ⠦ ⠧ ⠇ ⠏].freeze
+  STATUS_LABELS = {ok: "OK", failed: "FAILED", skipped: "skipped"}.freeze
 
   $stdout.sync = true
 
@@ -14,10 +17,30 @@ module CliHelpers
     end
   end
 
+  def self.monotonic_now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
+  def self.result_line(status, elapsed)
+    "#{STATUS_LABELS.fetch(status)} (#{elapsed ? format_duration(elapsed) : "-"})"
+  end
+
+  # Runs a step's block or shell command; returns [status, output].
+  def self.execute_step(cmd, block)
+    if block
+      block.call
+      [:ok, ""]
+    else
+      output, status = Open3.capture2e(cmd)
+      [status.success? ? :ok : :failed, output]
+    end
+  end
+
   def self.with_spinner(label)
-    start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    start_time = monotonic_now
 
     spinning = true
+    spin_thread = nil
     if $stdout.tty?
       frame = 0
       spin_thread = Thread.new do
@@ -32,7 +55,7 @@ module CliHelpers
     end
 
     begin
-      success, output = yield
+      status, output = yield
     rescue Interrupt
       spinning = false
       spin_thread&.join
@@ -43,38 +66,30 @@ module CliHelpers
     spinning = false
     spin_thread&.join
 
-    elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-    time_str = format_duration(elapsed)
+    line = result_line(status, monotonic_now - start_time)
+    print $stdout.tty? ? "\r  #{label}...#{line}#{" " * 20}\n" : "#{line}\n"
+    return if status == :ok
 
-    if success
-      if $stdout.tty?
-        print "\r  #{label}...OK (#{time_str})#{" " * 20}\n"
-      else
-        puts "OK (#{time_str})"
-      end
-    else
-      if $stdout.tty?
-        print "\r  #{label}...FAILED (#{time_str})#{" " * 20}\n\n"
-      else
-        puts "FAILED (#{time_str})\n"
-      end
-      warn output
-      abort
-    end
+    print "\n"
+    warn output
+    abort
   end
 
-  def self.run_step(label, cmd = nil, verbose: false, async: false, &block)
+  # `async: true` returns a step handle whose thread runs once every step in
+  # `after:` finished :ok; otherwise the step is :skipped, so one failure
+  # surfaces once instead of cascading. The thread returns
+  # [status, output, elapsed]; collect the handles with run_step_wait.
+  def self.run_step(label, cmd = nil, verbose: false, async: false, after: [], &block)
     if async
-      thread = Thread.new do
-        if block
-          block.call
-          [true, ""]
-        else
-          output, status = Open3.capture2e(cmd)
-          [status.success?, output]
-        end
+      step = {label: label}
+      step[:thread] = Thread.new do
+        next [:skipped, "", nil] unless after.all? { |dep| dep[:thread].value.first == :ok }
+
+        step[:start_time] = monotonic_now
+        status, output = execute_step(cmd, block)
+        [status, output, monotonic_now - step[:start_time]]
       end
-      return {label: label, thread: thread, start_time: Process.clock_gettime(Process::CLOCK_MONOTONIC)}
+      return step
     end
 
     if verbose
@@ -87,81 +102,52 @@ module CliHelpers
       abort "\n  #{label} failed!"
     end
 
-    with_spinner(label) do
-      if block
-        block.call
-        [true, ""]
-      else
-        output, status = Open3.capture2e(cmd)
-        [status.success?, output]
-      end
-    end
+    with_spinner(label) { execute_step(cmd, block) }
   end
 
   def self.run_step_wait(*steps, verbose: false)
-    if verbose
-      steps.each do |step|
-        puts "\n== #{step[:label]} =="
-        success, output = step[:thread].value
-        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - step[:start_time]
-        puts "  (#{format_duration(elapsed)})"
-        next if success
-        warn output
-        abort "\n  #{step[:label]} failed!"
-      end
-      return
-    end
+    results = Array.new(steps.size)
 
-    if $stdout.tty?
-      steps.each { |_| print "\n" }
-
-      finished = Array.new(steps.size)
+    if $stdout.tty? && !verbose
+      # Reserve one line per step
+      steps.each { print "\n" }
       frame = 0
 
       loop do
         print "\033[#{steps.size}A"
 
         steps.each_with_index do |step, i|
-          if finished[i]
-            f = finished[i]
-            status = f[:success] ? "OK" : "FAILED"
-            print "\r  #{step[:label]}...#{status} (#{f[:time_str]})#{" " * 20}\n"
-          elsif step[:thread].alive?
-            print "\r  #{step[:label]}...#{SPINNER[frame % SPINNER.size]} #{" " * 20}\n"
-          else
-            success, output = step[:thread].value
-            elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - step[:start_time]
-            time_str = format_duration(elapsed)
-            finished[i] = {success: success, output: output, time_str: time_str}
-            status = success ? "OK" : "FAILED"
-            print "\r  #{step[:label]}...#{status} (#{time_str})#{" " * 20}\n"
-          end
+          results[i] ||= step[:thread].value unless step[:thread].alive?
+          indicator =
+            if results[i]
+              result_line(results[i][0], results[i][2])
+            elsif step[:start_time]
+              SPINNER[frame % SPINNER.size]
+            else
+              "waiting"
+            end
+          print "\r  #{step[:label]}...#{indicator}#{" " * 20}\n"
         end
 
-        break if finished.all?
+        break if results.all?
         frame += 1
         sleep 0.08
       end
-
-      failed = steps.each_with_index.filter_map { |step, i| [step, finished[i]] unless finished[i][:success] }
-      unless failed.empty?
-        print "\n"
-        warn failed.map { |step, f| "== #{step[:label]} ==\n#{f[:output]}" }.join("\n")
-        abort
-      end
     else
-      results = steps.map { |s| [s, s[:thread].value] }
-      results.each do |step, (success, output)|
-        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - step[:start_time]
-        time_str = format_duration(elapsed)
-        if success
-          puts "  #{step[:label]}...OK (#{time_str})"
-        else
-          puts "  #{step[:label]}...FAILED (#{time_str})\n"
-          warn output
-          abort
-        end
+      # No spinner: report each step as it finishes, in list order
+      steps.each_with_index do |step, i|
+        puts "\n== #{step[:label]} ==" if verbose
+        results[i] = step[:thread].value
+        line = result_line(results[i][0], results[i][2])
+        puts verbose ? "  #{line}" : "  #{step[:label]}...#{line}"
       end
     end
+
+    failed = steps.zip(results).select { |_, (status, _, _)| status == :failed }
+    return if failed.empty?
+
+    print "\n"
+    warn failed.map { |step, (_, output, _)| "== #{step[:label]} ==\n#{output}" }.join("\n")
+    abort
   end
 end


### PR DESCRIPTION
`bin/setup` ran its steps in three lock-step groups, so each group waited for its slowest member, and the final `tmp:clear` threw away caches the next run needed.

- Steps are scheduled as a dependency graph: `run_step` takes `after:`, and a step starts as soon as its real prerequisites are done. The databases no longer sit behind `pnpm install`, and the Vite build overlaps everything else.
- `db:prepare` (test) is a step of its own again, running after `db:prepare` (dev) rather than chained onto it with `&&`: a fresh test database loads `db/schema.rb`, which the dev run may be dumping at that moment. The test environment additionally stops dumping the schema (`dump_schema_after_migration = false` in `test.rb`), so a test-env migrate can no longer write that file at all.
- `tmp:clear` is gone; only `log:clear` remains, as a graph node. `tmp:clear` wiped `tmp/cache` on every run: the Bootsnap cache (71 MB here, so every Rails boot after setup was cold) and vite_ruby's `last-build-*.json` markers, so every setup did a full Vite build even when nothing had changed. Both caches invalidate themselves.
- `--fresh` now also wipes everything untracked under `tmp/` (`git clean -fdx -- tmp`), so a fresh run really starts cold. Nothing under `tmp/` is tracked, so the clean takes the directory with it and it is recreated straight away. Help text updated.
- A failed step aborts the run as before; steps depending on it show `skipped` instead of failing on their own. Pending steps show `waiting`.
- Durations are measured inside the step's thread. The non-TTY path used to compute them once every step had finished, so each step in a group reported the group's total — that is why the "before" run below shows 27s for a step that takes well under a second.

### ✅ Verification

Hot runs on the same machine, back to back, piped (non-TTY):

| Run | Duration |
|---|---|
| before | 35s |
| after, cold caches | 26s |
| after, hot | 9–10s |

Before:

```
  Preparing databases (dev + test)...OK (27s)
  Building email assets (test)...OK (27s)
  Generating frontend type declarations...OK (27s)
  Cleaning logs and temp files...OK (3s)

== Setup complete in 35s ==
```

After:

```
  Installing Ruby dependencies...OK (0s)
  Installing Node dependencies...OK (6s)
  Starting Docker services...OK (1s)
  Preparing database (dev)...OK (3s)
  Preparing database (test)...OK (2s)
  Building email assets (test)...OK (0s)
  Generating frontend type declarations...OK (3s)
  Clearing logs...OK (3s)

== Setup complete in 10s ==
```

Failure path — `BUNDLE_GEMFILE=/nonexistent/Gemfile bin/setup`: bundle `FAILED` with its output, the three steps behind it `skipped`, the independent ones (pnpm, Docker, email assets) still finished, exit 1. The helper was also exercised directly for the TTY spinner path, `--verbose`, and transitive skipping (a step whose prerequisite was itself skipped).

`bin/ruby-lint bin/setup lib/cli_helpers.rb config/environments/test.rb` clean. `bin/setup --help` shows the updated `--fresh` text. `bin/scdata` is the other `CliHelpers` consumer; it only uses the synchronous block form, which is unchanged (the helper now requires `open3` itself rather than relying on the caller, which `bin/scdata` never did).

### ⚠️ Risks / Deferred

- `tmp/cache` is no longer cleared on a normal run; `bin/setup --fresh` (or `rails tmp:clear`) is the way to drop it.
- The `--fresh` tmp wipe was verified with `git clean -ndx -- tmp` (dry run) only — a real `--fresh` also drops the shared Docker volumes.

🤖
