### PR TITLE
fix(docks): remove the 391 docks that belong to nothing

### DIFF
--- a/db/data/20260911131018_remove_orphaned_docks.rb
+++ b/db/data/20260911131018_remove_orphaned_docks.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# 391 of the 419 rows in `docks` belong to nothing.
+#
+# They were station docks. A script created 384 of them in six minutes on
+# 2021-09-04 and seven more in 2022 -- numbered pads per station, "01" through
+# "04", "Vehiclepad 01", and "Ladingpad 01" with the N missing in all 34 of
+# them, so the names came from a hand-kept source.
+#
+# They became unreachable in March 2025, when `20250304083059_cleanup_stations`
+# dropped a dozen tables and with them `docks.station_id` -- the column, not the
+# rows. That is what `belongs_to :model, optional: true` was for: a dock belonged
+# either to a model or to a station.
+#
+# Nothing references them. `Model#docks` is the only association to this table
+# and there is no foreign key into it. None of the 391 carries dimensions, so
+# nothing measurable is lost; 28 remain, all on player-ownable models, and all
+# 23 models with docks keep theirs.
+#
+# `model_id` deliberately stays nullable. `cargo_holds` is already polymorphic
+# and six of its rows hang off a `ModelModule` -- the Galaxy's medic module
+# carries a vehicle lift for an Ursa -- so a dock wants the same parent. See
+# #4863.
+class RemoveOrphanedDocks < ActiveRecord::Migration[8.1]
+  def up
+    Dock.where(model_id: nil).delete_all
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_09_11_000000)
+DataMigrate::Data.define(version: 2026_09_11_131018)


### PR DESCRIPTION
Resolves #4852

391 of the 419 rows in `docks` belong to nothing.

## Where they came from

They were **station** docks. A script created 384 of them in six minutes on 2021-09-04, between 18:52 and 18:58, and seven more in May 2022. Each row has its own timestamp, so they were inserted one at a time — but nobody types 384 rows in six minutes.

The names say what they were: `01` (79×), `02` (73×), `03` and `04` (34× each), `Vehiclepad 01/02`, and `Ladingpad 01/02` — numbered pads per station, with the N missing from "Landingpad" in all 34 of them. The names came from a hand-kept source that the script multiplied.

No commit that day touches docks, so it was a one-off run outside a deploy.

## How they became orphans

`20250304083059_cleanup_stations` dropped a dozen tables in March 2025 — `stations`, `shops`, `starsystems`, `trade_routes` and the rest — and among them:

```ruby
remove_column :docks, :station_id, :uuid
```

The column went, the rows stayed. `belongs_to :model, optional: true` existed precisely because a dock belonged either to a model or to a station, so with stations gone those rows lost their only association.

They were never junk. They were curated station data that the cleanup missed.

## Why it is worth doing

They are not merely idle. Measuring dock coverage for #2404 gave "25 of 419 docks have dimensions", which reads like a feature blocked on missing data, and that conclusion was drawn before the denominator was checked. Against the rows that actually belong to a ship it is **25 of 28**, and 21 of the 23 models with docks are fully measured.

## What the migration does

Verified against a read-only query on production data:

| | |
|---|---|
| deleted | 391 |
| kept | 28 |
| of those, on player-ownable models | 28 |
| models with docks afterwards | 23 |
| **orphans carrying dimensions** | **0** |

Nothing measurable is lost, and nothing references them: `Model#docks` is the only association to this table and there is no foreign key into it.

## What it deliberately does not do

`model_id` stays nullable. `cargo_holds` is already polymorphic and six of its rows hang off a `ModelModule` — the Galaxy's medic module carries a vehicle lift for an Ursa, and the Caterpillar may get one. A dock wants the same parent, so requiring a model now would fix a shape that is already visibly too narrow. That belongs with #4863.

An earlier version of this branch added the `NOT NULL` constraint, dropped `optional` from `belongs_to :model`, refused a null `modelId` in the admin input and tested the rule. All of it is removed; the deletion stands on its own.

## Verification

728 tests across `test/models/`, the admin dock endpoints and the model list pass. `bin/ruby-lint` clean. Admin schema regenerated.

🤖
