### PR TITLE
feat(fleets): let admins nickname a member

### DIFF
--- a/app/api_components/v1/schemas/fleets/fleet_member.rb
+++ b/app/api_components/v1/schemas/fleets/fleet_member.rb
@@ -12,6 +12,7 @@ module V1
             id: {type: :string, format: :uuid},
             userId: {type: :string, format: :uuid},
             username: {type: :string},
+            nickname: {type: [:string, :null]},
             fleetRole: ::V1::Schemas::Fleets::FleetRole,
             status: ::V1::Schemas::Enums::FleetMembershipStatusEnum,
             avatar: ::Shared::V1::Schemas::MediaFile,

--- a/app/api_components/v1/schemas/inputs/fleet_member_update_input.rb
+++ b/app/api_components/v1/schemas/inputs/fleet_member_update_input.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module V1
+  module Schemas
+    module Inputs
+      class FleetMemberUpdateInput
+        include OpenapiRuby::Components::Base
+
+        schema({
+          type: :object,
+          properties: {
+            nickname: {type: [:string, :null]}
+          },
+          additionalProperties: false
+        })
+      end
+    end
+  end
+end

--- a/app/api_components/v1/schemas/queries/fleet_member_query.rb
+++ b/app/api_components/v1/schemas/queries/fleet_member_query.rb
@@ -10,6 +10,7 @@ module V1
           type: :object,
           properties: {
             usernameCont: {type: :string},
+            nicknameCont: {type: :string},
             nameCont: {type: :string, deprecated: true, description: "Use usernameCont instead"},
             roleIn: {type: :array, items: {type: :string}},
             stateIn: {type: :array, items: {type: :string}},

--- a/app/controllers/api/v1/fleet_members_controller.rb
+++ b/app/controllers/api/v1/fleet_members_controller.rb
@@ -17,9 +17,9 @@ module Api
         only: %i[index show]
       before_action -> { doorkeeper_authorize! "fleet", "fleet:write" },
         unless: :user_signed_in?,
-        only: %i[create accept_request decline_request promote demote destroy]
+        only: %i[create update accept_request decline_request promote demote destroy]
 
-      before_action :set_fleet, only: %i[index show create accept_request decline_request promote demote destroy]
+      before_action :set_fleet, only: %i[index show create update accept_request decline_request promote demote destroy]
       before_action :set_member, only: %i[show accept_request decline_request promote demote destroy]
 
       def index
@@ -95,6 +95,20 @@ module Api
         render json: ValidationError.new("fleet_members.destroy", errors: @member.errors), status: :bad_request
       end
 
+      # Not covered by `set_member`: that authorizes the rule matching the
+      # action name, and `update?` is the self-service rule the membership
+      # endpoint owns. Setting a nickname acts on someone else, so it asks for
+      # `update_nickname?` instead.
+      def update
+        @member = find_member!
+
+        authorize! @member, to: :update_nickname?
+
+        return if @member.update(member_nickname_params)
+
+        render json: ValidationError.new("fleet_members.update", errors: @member.errors), status: :bad_request
+      end
+
       private def set_fleet
         @fleet = authorized_scope(Fleet.all).find_by!(slug: params[:fleet_slug])
 
@@ -102,12 +116,20 @@ module Api
       end
 
       private def set_member
-        @member = @fleet.fleet_memberships.kept
+        @member = find_member!
+
+        authorize! @member
+      end
+
+      private def find_member!
+        @fleet.fleet_memberships.kept
           .includes(:user)
           .joins(:user)
           .find_by!(users: {normalized_username: params[:username].downcase})
+      end
 
-        authorize! @member
+      private def member_nickname_params
+        authorized(params, as: :update_nickname, with: FleetMembershipPolicy, context: {fleet: @fleet})
       end
     end
   end

--- a/app/controllers/concerns/fleet_member_filters_concern.rb
+++ b/app/controllers/concerns/fleet_member_filters_concern.rb
@@ -3,7 +3,7 @@
 module FleetMemberFiltersConcern
   private def member_query_params
     @member_query_params ||= params.permit(q: [
-      :username_cont, :name_cont, :s, :sorts,
+      :username_cont, :nickname_cont, :name_cont, :s, :sorts,
       :accepted_at_gteq, :accepted_at_lteq,
       :invited_at_gteq, :invited_at_lteq,
       :requested_at_gteq, :requested_at_lteq,

--- a/app/frontend/frontend/components/Fleets/MemberActions/Items.vue
+++ b/app/frontend/frontend/components/Fleets/MemberActions/Items.vue
@@ -61,6 +61,23 @@ const canUpdateMembers = computed(() => {
   return false;
 });
 
+// Unlike promote/demote, this is not self-excluded: the server lets anyone with
+// membership-update access set a nickname, their own included.
+const canUpdateNickname = computed(
+  () => props.capabilities?.updateMembers ?? false,
+);
+
+const openNicknameModal = () => {
+  comlink.emit("open-modal", {
+    component: () =>
+      import("@/frontend/components/Fleets/MemberNicknameModal/index.vue"),
+    props: {
+      fleetSlug: String(route.params.slug),
+      member: props.member,
+    },
+  });
+};
+
 const canDeleteMembers = computed(() => {
   if (props.member && currentUser?.value) {
     return (
@@ -262,6 +279,15 @@ const declineRequest = async () => {
   >
     <i class="fa-light fa-chevron-down" />
     <span v-if="withLabels">{{ t("actions.fleet.members.demote") }}</span>
+  </Btn>
+  <Btn
+    v-if="member.status === 'accepted'"
+    v-tooltip="canUpdateNickname && t('actions.fleet.members.editNickname')"
+    :disabled="!canUpdateNickname || updating"
+    @click="openNicknameModal"
+  >
+    <i class="fa-light fa-signature" />
+    <span v-if="withLabels">{{ t("actions.fleet.members.editNickname") }}</span>
   </Btn>
   <Btn
     v-tooltip="canDeleteMembers && t('actions.fleet.members.remove')"

--- a/app/frontend/frontend/components/Fleets/MemberName/index.vue
+++ b/app/frontend/frontend/components/Fleets/MemberName/index.vue
@@ -22,6 +22,16 @@ const { t } = useI18n();
 const hasContactOptions = computed(
   () => !!props.member.rsiHandle || !!props.member.discordProfileUrl,
 );
+
+const displayName = computed(
+  () => props.member.nickname || props.member.username,
+);
+
+// The username never goes away, only moves to second place: it is what every
+// link and lookup resolves on, and a nickname the fleet chose is not identity.
+const secondaryName = computed(() =>
+  props.member.nickname ? props.member.username : undefined,
+);
 </script>
 
 <template>
@@ -29,7 +39,10 @@ const hasContactOptions = computed(
     <template v-if="hasContactOptions">
       <BtnDropdown :variant="BtnVariantsEnum.BARE">
         <template #label>
-          <span>{{ member.username }}</span>
+          <span>{{ displayName }}</span>
+          <span v-if="secondaryName" class="member-name__username">
+            {{ secondaryName }}
+          </span>
           <span
             v-if="member.citizenidProfileUrl"
             v-tooltip="t('labels.user.rsiHandleVerified')"
@@ -42,7 +55,10 @@ const hasContactOptions = computed(
       </BtnDropdown>
     </template>
     <template v-else>
-      <span>{{ member.username }}</span>
+      <span>{{ displayName }}</span>
+      <span v-if="secondaryName" class="member-name__username">
+        {{ secondaryName }}
+      </span>
     </template>
   </span>
 </template>
@@ -55,6 +71,12 @@ const hasContactOptions = computed(
   &__badge {
     font-size: 0.85em;
     line-height: 1;
+  }
+
+  &__username {
+    margin-left: 0.35em;
+    font-size: 0.85em;
+    opacity: 0.8;
   }
 }
 </style>

--- a/app/frontend/frontend/components/Fleets/MemberNicknameModal/index.vue
+++ b/app/frontend/frontend/components/Fleets/MemberNicknameModal/index.vue
@@ -1,0 +1,112 @@
+<script lang="ts">
+export default {
+  name: "MemberNicknameModal",
+};
+</script>
+
+<script lang="ts" setup>
+import { useForm } from "vee-validate";
+import Modal from "@/shared/components/AppModal/Inner/index.vue";
+import FormInput from "@/shared/components/base/FormInput/index.vue";
+import Btn from "@/shared/components/base/Btn/index.vue";
+import { validationErrorFrom } from "@/shared/utils/ApiErrors";
+import { useI18n } from "@/shared/composables/useI18n";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
+import { useComlink } from "@/shared/composables/useComlink";
+import { BtnSizesEnum } from "@/shared/components/base/Btn/types";
+import {
+  type FleetMember,
+  type FleetMemberUpdateInput,
+  useUpdateFleetMember as useUpdateFleetMemberMutation,
+} from "@/services/fyApi";
+
+const { t } = useI18n();
+
+type Props = {
+  fleetSlug: string;
+  member: FleetMember;
+};
+
+const props = defineProps<Props>();
+
+const submitting = ref(false);
+
+const validationSchema = {
+  nickname: "max:255",
+};
+
+const { displaySuccess, displayAlert } = useAppNotifications();
+
+const { defineField, handleSubmit, setErrors } =
+  useForm<FleetMemberUpdateInput>({
+    initialValues: {
+      nickname: props.member.nickname ?? undefined,
+    },
+  });
+
+const [nickname, nicknameProps] = defineField("nickname");
+
+const comlink = useComlink();
+
+const mutation = useUpdateFleetMemberMutation();
+
+// An empty field clears the nickname rather than storing "": the server
+// normalizes blank to null, and sending null says so explicitly.
+const onSubmit = handleSubmit(async (values) => {
+  submitting.value = true;
+
+  await mutation
+    .mutateAsync({
+      fleetSlug: props.fleetSlug,
+      username: props.member.username,
+      data: { nickname: values.nickname || null },
+    })
+    .then(() => {
+      comlink.emit("fleet-member-update");
+      comlink.emit("close-modal");
+
+      displaySuccess({
+        text: t("messages.fleet.members.nickname.success"),
+      });
+    })
+    .catch((error) => {
+      const { message, formErrors } = validationErrorFrom(error);
+
+      setErrors(formErrors);
+
+      displayAlert({
+        text: message || t("messages.fleet.members.nickname.failure"),
+      });
+    })
+    .finally(() => {
+      submitting.value = false;
+    });
+});
+</script>
+
+<template>
+  <Modal v-if="member" :title="t('headlines.fleets.memberNickname')">
+    <form :id="`fleet-member-nickname-${member.id}`" @submit.prevent="onSubmit">
+      <div class="row">
+        <div class="col-12">
+          <FormInput
+            v-model="nickname"
+            v-bind="nicknameProps"
+            :rules="validationSchema.nickname"
+            :placeholder="member.username"
+            name="nickname"
+            :no-label="true"
+            :autofocus="true"
+          />
+        </div>
+      </div>
+    </form>
+    <template #footer>
+      <div class="modal-actions">
+        <Btn :loading="submitting" :size="BtnSizesEnum.LG" @click="onSubmit">
+          {{ t("actions.save") }}
+        </Btn>
+      </div>
+    </template>
+  </Modal>
+</template>

--- a/app/frontend/frontend/components/base/MemberContactMenu/types.ts
+++ b/app/frontend/frontend/components/base/MemberContactMenu/types.ts
@@ -3,6 +3,7 @@
 // same handles under their own payload shapes.
 export interface MemberContact {
   username?: string;
+  nickname?: string | null;
   rsiHandle?: string;
   discordProfileUrl?: string;
   citizenidProfileUrl?: string;

--- a/app/frontend/frontend/validations/index.ts
+++ b/app/frontend/frontend/validations/index.ts
@@ -13,6 +13,7 @@ import {
   numeric,
   between,
   min,
+  max,
   min_value,
   confirmed,
   regex,
@@ -25,6 +26,7 @@ export const setupRules = () => {
   defineRule("confirmed", confirmed);
   defineRule("regex", regex);
   defineRule("min", min);
+  defineRule("max", max);
   defineRule("min_value", min_value);
   defineRule("numeric", numeric);
   defineRule("between", between);

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -201,7 +201,8 @@
           "accept": "Akzeptieren",
           "decline": "Ablehnen",
           "remove": "Entfernen",
-          "editRole": "Rolle bearbeiten"
+          "editRole": "Rolle bearbeiten",
+          "editNickname": "Spitzname bearbeiten"
         },
         "inviteUrls": {
           "create": "Neue Einladungs-URL erstellen"

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -299,7 +299,8 @@
           "addShip": "Schiff hinzufügen",
           "assignSlotFor": "Slot für %{username} zuweisen",
           "reassignSlotFor": "Slot für %{username} neu zuweisen"
-        }
+        },
+        "memberNickname": "Spitzname des Mitglieds"
       },
       "hangarGroup": {
         "create": "Create Group",

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -281,6 +281,10 @@
           "decline": {
             "success": "Mitglied abgelehnt.",
             "failure": "Mitglied konnte nicht abgelehnt werden."
+          },
+          "nickname": {
+            "success": "Spitzname gespeichert.",
+            "failure": "Spitzname konnte nicht gespeichert werden."
           }
         },
         "calendarSubscription": {

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -201,7 +201,8 @@
           "accept": "Accept",
           "decline": "Decline",
           "remove": "Remove",
-          "editRole": "Edit Role"
+          "editRole": "Edit Role",
+          "editNickname": "Edit Nickname"
         },
         "inviteUrls": {
           "create": "Create new Invite Url"

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -291,7 +291,8 @@
           "addShip": "Add ship",
           "assignSlotFor": "Assign slot for %{username}",
           "reassignSlotFor": "Reassign slot for %{username}"
-        }
+        },
+        "memberNickname": "Member Nickname"
       },
       "hangarGroup": {
         "create": "Create Group",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -280,6 +280,10 @@
           "decline": {
             "success": "Member declined.",
             "failure": "Member could not be declined."
+          },
+          "nickname": {
+            "success": "Nickname saved.",
+            "failure": "Nickname could not be saved."
           }
         },
         "calendarSubscription": {

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -201,7 +201,8 @@
           "accept": "Aceptar",
           "decline": "Rechazar",
           "remove": "Eliminar",
-          "editRole": "Editar rol"
+          "editRole": "Editar rol",
+          "editNickname": "Editar apodo"
         },
         "inviteUrls": {
           "create": "Crear nueva URL de invitación"

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -299,7 +299,8 @@
           "addShip": "Agregar nave",
           "assignSlotFor": "Asignar plaza para %{username}",
           "reassignSlotFor": "Reasignar plaza para %{username}"
-        }
+        },
+        "memberNickname": "Apodo del miembro"
       },
       "hangarGroup": {
         "create": "Create Group",

--- a/app/frontend/translations/es/messages.json
+++ b/app/frontend/translations/es/messages.json
@@ -281,6 +281,10 @@
           "decline": {
             "success": "Miembro rechazado.",
             "failure": "El miembro no pudo ser rechazado."
+          },
+          "nickname": {
+            "success": "Apodo guardado.",
+            "failure": "No se pudo guardar el apodo."
           }
         },
         "calendarSubscription": {

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -201,7 +201,8 @@
           "accept": "Accepter",
           "decline": "Décliner",
           "remove": "Retirer",
-          "editRole": "Modifier le rôle"
+          "editRole": "Modifier le rôle",
+          "editNickname": "Modifier le surnom"
         },
         "inviteUrls": {
           "create": "Créer le nouveau lien d'invitation"

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -299,7 +299,8 @@
           "addShip": "Ajouter un vaisseau",
           "assignSlotFor": "Attribuer une place à %{username}",
           "reassignSlotFor": "Réattribuer une place à %{username}"
-        }
+        },
+        "memberNickname": "Surnom du membre"
       },
       "hangarGroup": {
         "create": "Créer un groupe",

--- a/app/frontend/translations/fr/messages.json
+++ b/app/frontend/translations/fr/messages.json
@@ -281,6 +281,10 @@
           "decline": {
             "success": "Membre décliné.",
             "failure": "Le membre n'a pas pu être décliné."
+          },
+          "nickname": {
+            "success": "Surnom enregistré.",
+            "failure": "Le surnom n'a pas pu être enregistré."
           }
         },
         "calendarSubscription": {

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -201,7 +201,8 @@
           "accept": "Accetta",
           "decline": "Rifiuta",
           "remove": "Rimuovi",
-          "editRole": "Modifica ruolo"
+          "editRole": "Modifica ruolo",
+          "editNickname": "Modifica soprannome"
         },
         "inviteUrls": {
           "create": "Crea nuovo URL per invito"

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -299,7 +299,8 @@
           "addShip": "Aggiungi nave",
           "assignSlotFor": "Assegna slot a %{username}",
           "reassignSlotFor": "Riassegna slot a %{username}"
-        }
+        },
+        "memberNickname": "Soprannome del membro"
       },
       "hangarGroup": {
         "create": "Crea Gruppo",

--- a/app/frontend/translations/it/messages.json
+++ b/app/frontend/translations/it/messages.json
@@ -280,6 +280,10 @@
           "decline": {
             "success": "Membro respinto.",
             "failure": "Il membro non può essere respinto."
+          },
+          "nickname": {
+            "success": "Soprannome salvato.",
+            "failure": "Impossibile salvare il soprannome."
           }
         },
         "calendarSubscription": {

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -201,7 +201,8 @@
           "accept": "Accept",
           "decline": "Decline",
           "remove": "移除",
-          "editRole": "编辑角色"
+          "editRole": "编辑角色",
+          "editNickname": "编辑昵称"
         },
         "inviteUrls": {
           "create": "Create new Invite Url"

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -299,7 +299,8 @@
           "addShip": "添加飞船",
           "assignSlotFor": "为 %{username} 分配席位",
           "reassignSlotFor": "为 %{username} 重新分配席位"
-        }
+        },
+        "memberNickname": "成员昵称"
       },
       "hangarGroup": {
         "create": "Create Group",

--- a/app/frontend/translations/zh-CN/messages.json
+++ b/app/frontend/translations/zh-CN/messages.json
@@ -280,6 +280,10 @@
           "decline": {
             "success": "成员已拒绝。",
             "failure": "无法拒绝成员。"
+          },
+          "nickname": {
+            "success": "昵称已保存。",
+            "failure": "无法保存昵称。"
           }
         },
         "calendarSubscription": {

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -201,7 +201,8 @@
           "accept": "Accept",
           "decline": "Decline",
           "remove": "移除",
-          "editRole": "編輯角色"
+          "editRole": "編輯角色",
+          "editNickname": "編輯暱稱"
         },
         "inviteUrls": {
           "create": "Create new Invite Url"

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -299,7 +299,8 @@
           "addShip": "新增飛船",
           "assignSlotFor": "為 %{username} 分配席位",
           "reassignSlotFor": "為 %{username} 重新分配席位"
-        }
+        },
+        "memberNickname": "成員暱稱"
       },
       "hangarGroup": {
         "create": "Create Group",

--- a/app/frontend/translations/zh-TW/messages.json
+++ b/app/frontend/translations/zh-TW/messages.json
@@ -280,6 +280,10 @@
           "decline": {
             "success": "成員已拒絕。",
             "failure": "成員無法拒絕。"
+          },
+          "nickname": {
+            "success": "暱稱已儲存。",
+            "failure": "無法儲存暱稱。"
           }
         },
         "calendarSubscription": {

--- a/app/models/fleet_membership.rb
+++ b/app/models/fleet_membership.rb
@@ -12,6 +12,7 @@
 #  hide_ships        :boolean          default(FALSE)
 #  invited_at        :datetime
 #  invited_by        :uuid
+#  nickname          :string
 #  primary           :boolean          default(FALSE)
 #  requested_at      :datetime
 #  ships_filter      :integer          default(0)
@@ -73,7 +74,7 @@ class FleetMembership < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     [
       "aasm_state", "accepted_at", "created_at", "declined_at", "fleet_id", "fleet_role_id", "hangar_group_id",
-      "hide_ships", "id", "id_value", "invited_at", "invited_by", "name", "primary", "requested_at",
+      "hide_ships", "id", "id_value", "invited_at", "invited_by", "name", "nickname", "primary", "requested_at",
       "ships_filter", "updated_at", "used_invite_token", "user_id", "username", "state"
     ]
   end
@@ -85,6 +86,8 @@ class FleetMembership < ApplicationRecord
   validate_enum_attributes :ships_filter
 
   validates :user_id, uniqueness: {scope: :fleet_id, conditions: -> { where(discarded_at: nil) }}
+
+  validates :nickname, length: {maximum: 255}, allow_blank: true
 
   DEFAULT_SORTING_PARAMS = ["created_at desc", "accepted_at desc"]
   ALLOWED_SORTING_PARAMS = [
@@ -101,6 +104,7 @@ class FleetMembership < ApplicationRecord
   ransack_alias :state, :aasm_state
 
   before_validation :set_default_ships_filter
+  before_validation :normalize_nickname
   after_create :broadcast_create
   after_destroy :broadcast_destroy, :remove_fleet_vehicles
   after_save :set_primary
@@ -185,6 +189,12 @@ class FleetMembership < ApplicationRecord
     return if ships_filter.present?
 
     self.ships_filter = "all"
+  end
+
+  def normalize_nickname
+    return if nickname.nil?
+
+    self.nickname = nickname.strip.presence
   end
 
   def schedule_setup_fleet_vehicles

--- a/app/policies/fleet_membership_policy.rb
+++ b/app/policies/fleet_membership_policy.rb
@@ -30,6 +30,13 @@ class FleetMembershipPolicy < FleetBasePolicy
     accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:memberships:manage", "fleet:memberships:update"])
   end
 
+  # Distinct from `update?`, which is the self-service rule the membership
+  # endpoint uses. A nickname is set on someone else, so it is gated on the
+  # same privilege as promote/demote rather than on owning the record.
+  def update_nickname?
+    accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:memberships:manage", "fleet:memberships:update"])
+  end
+
   def update?
     record.try(:user_id) && record.user_id == user.id
   end
@@ -37,6 +44,10 @@ class FleetMembershipPolicy < FleetBasePolicy
   def destroy?
     (accepted_fleet_membership&.has_access?(["fleet:manage", "fleet:memberships:manage", "fleet:memberships:destroy"]) && record.id != fleet_membership&.id) ||
       (record.id == fleet_membership&.id && !fleet_membership&.fleet_role&.permanent?)
+  end
+
+  params_filter(:update_nickname) do |params|
+    params.permit(:nickname)
   end
 
   params_filter do |params|

--- a/app/views/api/v1/fleet_members/_base.jbuilder
+++ b/app/views/api/v1/fleet_members/_base.jbuilder
@@ -1,6 +1,7 @@
 json.id member.id
 json.user_id member.user_id
 json.username member.user.username
+json.nickname member.nickname
 if member.fleet_role.present?
   json.fleet_role do
     json.partial! "api/v1/fleet_roles/base", fleet_role: member.fleet_role

--- a/app/views/api/v1/fleet_members/_fleet_member.jbuilder
+++ b/app/views/api/v1/fleet_members/_fleet_member.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.cache! ["v1", member] do
+json.cache! ["v2", member] do
   json.partial! "api/v1/fleet_members/base", member: member
 end
 

--- a/app/views/api/v1/fleet_members/update.jbuilder
+++ b/app/views/api/v1/fleet_members/update.jbuilder
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+json.partial! "api/v1/fleet_members/fleet_member", member: @member

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -1266,6 +1266,10 @@ components:
           format: uuid
         username:
           type: string
+        nickname:
+          type:
+          - string
+          - 'null'
         fleetRole:
           "$ref": "#/components/schemas/FleetRole"
         status:

--- a/config/locales/de/activerecord.yml
+++ b/config/locales/de/activerecord.yml
@@ -138,6 +138,7 @@ de:
           admin: Admin
           member: Mitglied
           officer: Offizier
+        nickname: Spitzname
         user_id: Mitglied
       habitation:
         habitation_types:

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -138,6 +138,7 @@ en:
           admin: Admin
           member: Member
           officer: Officer
+        nickname: Nickname
         user_id: Member
       habitation:
         habitation_types:

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -138,6 +138,7 @@ es:
           admin: Admin
           member: Miembro
           officer: Oficial
+        nickname: Apodo
         user_id: Miembro
       habitation:
         habitation_types:

--- a/config/locales/fr/activerecord.yml
+++ b/config/locales/fr/activerecord.yml
@@ -138,6 +138,7 @@ fr:
           admin: Admin
           member: Membre
           officer: Officier
+        nickname: Surnom
         user_id: Membre
       habitation:
         habitation_types:

--- a/config/locales/it/activerecord.yml
+++ b/config/locales/it/activerecord.yml
@@ -138,6 +138,7 @@ it:
           admin: Admin
           member: Membro
           officer: Ufficiale
+        nickname: Soprannome
         user_id: Membro
       habitation:
         habitation_types:

--- a/config/locales/zh-CN/activerecord.yml
+++ b/config/locales/zh-CN/activerecord.yml
@@ -138,6 +138,7 @@ zh-CN:
           admin: 管理员
           member: 成员
           officer: 军官
+        nickname: 昵称
         user_id: 成员
       habitation:
         habitation_types:

--- a/config/locales/zh-TW/activerecord.yml
+++ b/config/locales/zh-TW/activerecord.yml
@@ -138,6 +138,7 @@ zh-TW:
           admin: 管理員
           member: 成員
           officer: 軍官
+        nickname: 暱稱
         user_id: 成員
       habitation:
         habitation_types:

--- a/config/routes/api/fleets_routes.rb
+++ b/config/routes/api/fleets_routes.rb
@@ -15,7 +15,7 @@ resources :fleets, param: :slug, only: %i[show create update destroy] do
     end
   end
 
-  resources :fleet_members, path: "members", param: :username, only: %i[index show create destroy] do
+  resources :fleet_members, path: "members", param: :username, only: %i[index show create update destroy] do
     member do
       put :demote
       put :promote

--- a/db/migrate/20260911131944_add_nickname_to_fleet_memberships.rb
+++ b/db/migrate/20260911131944_add_nickname_to_fleet_memberships.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNicknameToFleetMemberships < ActiveRecord::Migration[8.1]
+  def change
+    add_column :fleet_memberships, :nickname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_10_230000) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_131944) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -647,6 +647,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_10_230000) do
     t.boolean "hide_ships", default: false
     t.datetime "invited_at", precision: nil
     t.uuid "invited_by"
+    t.string "nickname"
     t.boolean "primary", default: false
     t.datetime "requested_at", precision: nil
     t.integer "ships_filter", default: 0

--- a/docs/exec-plans/2586-nicknames-for-fleet-members.md
+++ b/docs/exec-plans/2586-nicknames-for-fleet-members.md
@@ -1,0 +1,145 @@
+# Nicknames for fleet members
+
+## Goal
+A fleet admin can set, change, and clear a per-fleet nickname on any member, and that nickname is what the fleet sees throughout the members UI while the real username remains the identifier everywhere it links or resolves.
+
+## Context
+Fleet admins want to label members with the name the fleet actually knows them by — an in-game handle, a callsign, a shortened form — instead of the Fleetyards username. Today `fleet_memberships` carries no free-text field at all, and the public API has no member-update endpoint, so both the storage and the write path are new.
+
+Resolves #2586
+
+GitHub issue: https://github.com/fleetyards/fleetyards/issues/2586
+
+> **Label correction needed.** The issue carries `size/S` ("One PR, no migration"). A migration is unavoidable — see D1. Still one PR, but the label should move to a size that permits a migration.
+
+## Decisions
+
+### D1 — Store the nickname on `fleet_memberships`, not `users`
+The issue scopes nicknames to a fleet ("Admins could add nicknames for members"). A user belongs to many fleets, so a nickname on `users` would leak one fleet's label into every other fleet and would be writable by the wrong admins. The nickname is a property of the *membership*.
+
+There is no existing free-text column on `fleet_memberships` to reuse (`db/schema.rb:638-660` — the only string columns are `aasm_state`, `invited_by`, `used_invite_token`), so a migration adding `nickname:string` is required. Rejected: overloading `used_invite_token`; a separate `fleet_member_nicknames` table (a 1:1 side table buys nothing and costs a join on the hot members list).
+
+### D2 — New `PUT /fleets/{fleetSlug}/members/{username}`, not the self-service membership endpoint
+`Api::V1::FleetMembersController` has no `update` action. The only existing `update` is `Api::V1::FleetMembershipsController#update`, which is deliberately self-service — it acts on `current_user`'s own membership and cannot address another member. Reusing it would require inventing a "which member" parameter on an endpoint whose whole contract is "mine".
+
+The new action lives beside `promote`/`demote` on `FleetMembersController`, which already resolves `:username` to a member via `set_member` (`app/controllers/api/v1/fleet_members_controller.rb:104-111`).
+
+### D3 — Authorize with the existing `fleet:memberships:update` privilege
+`promote?`, `demote?`, `accept_request?`, and `decline_request?` are all gated on `["fleet:manage", "fleet:memberships:manage", "fleet:memberships:update"]`, and `CAPABILITY_PRIVILEGES[:update_members]` (`app/models/fleet_membership.rb:129`) already exposes exactly that set to the frontend as `capabilities.updateMembers`. Setting a nickname is the same class of act.
+
+Consequence: **no new capability**, so `test/models/fleet_membership_capabilities_test.rb` needs no change, and the frontend gates on a boolean it already receives.
+
+The new rule must be named `update_nickname?`, not `update?` — `FleetMembershipPolicy#update?` is the self-service rule (`app/policies/fleet_membership_policy.rb:33-35`, `record.user_id == user.id`) and widening it would let any member edit their own membership through a path that is meant to stay narrow. The controller authorizes explicitly against the new rule.
+
+### D4 — A rule-scoped `params_filter`, leaving the shared one untouched
+`params_filter` (`app/policies/fleet_membership_policy.rb`) is shared by every action on the policy and permits `[:primary, :ships_filter, :hangar_group_id]` to anyone with a membership. Widening it would have let a fleet admin flip another member's `primary` flag and ships filter through the new endpoint.
+
+Action Policy supports rule-scoped filters — `params_filter(:create)` in `app/policies/fleet_policy.rb:48` is the precedent, selected at the call site with `authorized(params, as: :create)`. So `params_filter(:update_nickname)` permits `:nickname` and nothing else, and the shared filter is not touched at all. It needs no privilege check of its own because the action authorizes `update_nickname?` before reading params, exactly as `params_filter(:create)` relies on `create?`.
+
+### D5 — Nickname is optional, not unique, length-capped; username stays the identifier
+A nickname is a label, not a handle. Two members may plausibly share one, and enforcing per-fleet uniqueness would make the admin UI fail in a way the issue never asked for. Blank input clears it (normalize `""` → `nil`).
+
+The username remains what every link, lookup, and route resolves on — `MemberLinks/index.vue:26` (`/hangar/${member.username}`) and `set_member`'s `normalized_username` lookup are untouched.
+
+### D6 — Display nickname primary, username secondary, at one choke point
+`components/Fleets/MemberName/index.vue` is the single component rendering `member.username` for the list, the invites list, and the mobile detail modal. Rendering the nickname there (with the username kept visible beneath/beside it, never replaced) covers every surface at once and keeps the real identity discoverable. When no nickname is set, the component renders exactly as it does today.
+
+## What changed
+
+### Phase 1 — Backend: storage, write path, payload
+1. Migration `add_nickname_to_fleet_memberships` — `add_column :fleet_memberships, :nickname, :string`. Run `bin/rails db:migrate` and let the annotation update `app/models/fleet_membership.rb`'s schema block.
+2. `app/models/fleet_membership.rb` — length validation (max 255, `allow_blank`), a `before_validation` normalizing blank to `nil`, and add `nickname` to `ransackable_attributes` (`:75-78`) so admins can search by it.
+3. `app/policies/fleet_membership_policy.rb` — add `update_nickname?` gated on `["fleet:manage", "fleet:memberships:manage", "fleet:memberships:update"]`; add `params_filter(:update_nickname)` permitting only `:nickname` (D4).
+4. `app/controllers/api/v1/fleet_members_controller.rb` — `update` action plus a new `update.jbuilder`. The lookup is extracted from `set_member` into `find_member!` so `update` can authorize `update_nickname?` instead of the `update?` that a `set_member` before_action would infer from the action name.
+5. `config/routes/api/fleets_routes.rb:18` — add `:update` to the `fleet_members` `only:` list.
+6. `app/controllers/concerns/fleet_member_filters_concern.rb:4-13` — permit `:nickname_cont` in `member_query_params`.
+7. `app/views/api/v1/fleet_members/_base.jbuilder` — `json.nickname member.nickname` beside `json.username` (line 5).
+8. Bump the cache key `"v1"` → `"v2"` in `app/views/api/v1/fleet_members/_fleet_member.jbuilder` — a new rendered field does not bust a key derived from an unchanged record. The admin partial is **not** bumped: its payload is a separate `_base.jbuilder` that does not render the nickname, so a bump there would flush a cache for nothing.
+
+### Phase 2 — API schema and generated clients
+1. `app/api_components/v1/schemas/fleets/fleet_member.rb` — add `nickname` (nullable string) to the properties. The component sets `additionalProperties: false` (`:51`), so the jbuilder field breaks schema validation until this lands. Leave it out of `required`.
+2. New `app/api_components/v1/schemas/inputs/fleet_member_update_input.rb` — `nickname` only. Per AGENTS.md:244-330, the request body must `$ref` a component, never an inline type.
+3. `app/api_components/v1/schemas/queries/fleet_member_query.rb` — add `nicknameCont` (also `additionalProperties: false`, `:31`).
+4. New `test/integration/api/v1/fleets_members_update_test.rb` — modelled on the PUT spec in `test/integration/api/v1/fleets_membership_test.rb:64-80`. Declare actions in alphabetical order (see that file's comment at `:11-12`) so the generated YAML ordering stays stable.
+5. Run `bin/generate-schema`, then `bin/generate-asyncapi` and `bin/generate-cable-client` — `FleetMember` is broadcast over `FleetMembersChannel` (`test/asyncapi/fleet_members_channel_test.rb:15`), so the cable schema and `app/frontend/services/fyCable/models/FleetMember.ts` go stale otherwise. Never hand-edit `swagger/`, `asyncapi/`, or `app/frontend/services/fy*Api/`.
+
+### Phase 3 — Frontend
+1. `components/Fleets/MemberName/index.vue` — render nickname primary with username secondary when `member.nickname` is present; unchanged output when it is not (D6).
+2. New nickname edit modal, modelled on `components/Fleets/MemberModal/index.vue` (vee-validate `useForm` + orval mutation + `comlink.emit`).
+3. `components/Fleets/MemberActions/Items.vue` — an "Edit nickname" entry gated on the existing `canUpdateMembers` (`:53-62`), opening the modal.
+4. `components/Fleets/MembersList/index.vue` — verify the `col-username` slot (`:101-114`) and column widths (`:49-88`) still read well with a two-line name cell.
+5. `components/Fleets/MembersFilterForm/index.vue` — left alone; see "Not in scope".
+
+### Phase 4 — i18n and tests
+1. Frontend strings in `app/frontend/translations/<locale>/{labels,actions,messages,validationError}.json` — `labels.fleet.members.nickname`, `actions.fleet.members.editNickname`, success/failure messages. **All 7 locales by hand** (`de en es fr it zh-CN zh-TW`); Crowdin is not in use and `enableFallback` hides every gap, so en-only keys silently never reach the others.
+2. Backend strings — `config/locales/<locale>/activerecord.yml` (attribute name under `fleet_membership:`, `:136-141`) and `validation_error.yml` (`fleet_members:`, `:22`), all 7 locales.
+3. `test/models/fleet_membership_test.rb` — validation and blank-normalization coverage.
+4. `test/factories/fleet_memberships.rb` — a `:with_nickname` trait.
+5. `bin/ruby-lint` (standardrb — `bin/rubocop` passes on code CI rejects) and `bin/rails test` on the touched paths.
+
+## Intent Verification
+
+- [ ] **An admin can set a nickname** — a member with `fleet:memberships:update` can PUT a nickname onto another member and see it persisted.
+- [ ] **A non-admin cannot** — a plain accepted member PUTs a nickname onto another member and is rejected; they also cannot set one on themselves via the self-service membership endpoint.
+- [ ] **Clearing works** — submitting an empty nickname stores `nil`, and the UI falls back to the username.
+- [ ] **The fleet sees it** — the nickname appears in the members list, the invites list, and the mobile detail modal for every member of the fleet.
+- [ ] **Username still resolves** — the hangar link and the `:username` route param are unaffected by a nickname being set.
+- [ ] **Live update** — a nickname change propagates over `FleetMembersChannel` without a reload (the existing `after_commit :broadcast_update` covers this; confirm the badge/list actually repaints).
+- [ ] **Schema is green** — `bin/generate-schema` produces no unstaged drift and `api-schema-check` passes.
+- [ ] **No stale cache** — a member rendered before the change shows their nickname immediately after it (the `"v2"` bump).
+
+## Key files
+
+| File | Role |
+|------|------|
+| `db/migrate/*_add_nickname_to_fleet_memberships.rb` | New column |
+| `app/models/fleet_membership.rb` | Validation, normalization, ransack whitelist |
+| `app/policies/fleet_membership_policy.rb` | `update_nickname?` rule + `params_filter` branch |
+| `app/controllers/api/v1/fleet_members_controller.rb` | New `update` action |
+| `config/routes/api/fleets_routes.rb` | Route for the new action |
+| `app/controllers/concerns/fleet_member_filters_concern.rb` | `nickname_cont` query param |
+| `app/views/api/v1/fleet_members/_base.jbuilder` | Renders the field |
+| `app/views/api/v1/fleet_members/_fleet_member.jbuilder` | Cache key bump |
+| `app/views/admin/api/v1/fleet_members/_fleet_member.jbuilder` | Cache key bump |
+| `app/api_components/v1/schemas/fleets/fleet_member.rb` | Response component (`additionalProperties: false`) |
+| `app/api_components/v1/schemas/inputs/fleet_member_update_input.rb` | New request component |
+| `app/api_components/v1/schemas/queries/fleet_member_query.rb` | Filter component |
+| `test/integration/api/v1/fleets_members_update_test.rb` | Generates the OpenAPI path |
+| `app/frontend/frontend/components/Fleets/MemberName/index.vue` | Display choke point |
+| `app/frontend/frontend/components/Fleets/MemberActions/Items.vue` | Admin entry point |
+| `app/frontend/frontend/components/Fleets/MemberModal/index.vue` | Template for the edit modal |
+| `app/frontend/translations/*/` | 7 locales, by hand |
+
+## Not in scope (deferred)
+- **Nicknames in the Discord `/fleet members` command** (`lib/discord/commands/fleet_members.rb`) — a separate surface with its own rendering and tests; worth a follow-up once the core lands.
+- **Nicknames in the admin panel** (`app/frontend/admin/pages/fleets/[id]/members*`) — the admin panel's member payload is a separate thinner component; the issue asks for fleet admins, not site admins.
+- **Member-editable nicknames** — the issue explicitly says admins. Letting members set their own is a product decision, not an oversight.
+- **Per-fleet uniqueness** — see D5.
+- **E2E coverage of the members page** — `test/playwright/e2e/Fleet.spec.ts` has no member references today; adding the first one is its own piece of work.
+- **Searching the members list by nickname** — `nicknameCont` is permitted and in the schema, so an API consumer can filter on it, but the UI search box still only sends `usernameCont`. A single box matching either needs a new query param: ransack does **not** resolve `ransack_alias` inside an `_or_` chain, so `username_or_nickname_cont` builds `fleet_memberships.username` and blows up on a column that does not exist. The working form is `user_username_or_nickname_cont`, verified against the dev database. Changing what `usernameCont` means would be a silent break for existing API callers, so a combined search wants its own parameter.
+
+## Open questions
+- Should a member be able to *see* that they have a nickname, and who set it? The plan shows it to everyone in the fleet, with no attribution.
+- Should the nickname or the username be the sort key when the list is sorted by name? The plan leaves sorting on `user_username` as-is.
+
+## Discovery Log
+
+- **2026-09-11** Initial research and plan creation. Confirmed: no `nickname`/`alias`/`display_name` exists in any member/user context; the public API has no member-update action; `update_members` / `fleet:memberships:update` already exists as a capability so no capability test changes are needed; `FleetMember` is broadcast over cable, so three generators must run, not one.
+- **2026-09-11** Phases 1 and 2 landed. Three findings changed the shape:
+  - **`params_filter` is rule-scoped.** D4 originally widened the shared filter behind a privilege check. `params_filter(:update_nickname)` is strictly better — the shared filter is untouched, so there is no path by which this endpoint can write `primary`, `ships_filter`, or `hangar_group_id`.
+  - **A widened body is rejected, not ignored.** `additionalProperties: false` on the input component is enforced by request validation, so a body carrying extra attributes returns 400 rather than silently dropping them. The test asserts the 400 and that nothing was written.
+  - **The cable schema fails the suite before the REST schema does.** Adding the jbuilder field made six tests raise `AsyncapiCable::Error: object property at /nickname is a disallowed additional property` from `broadcast_update`, well before any OpenAPI check. `bin/generate-asyncapi` is not optional here, and it has to run before the tests can go green.
+  - Backend i18n needed only `activerecord.attributes.fleet_membership.nickname` — `validation_error.fleet_members.update` already existed in all 7 locales.
+  - Generated schema diff is purely additive: 70 lines, no deletions.
+- **2026-09-11** Phases 3 and 4 landed.
+  - `MemberContact` (`components/base/MemberContactMenu/types.ts`) gained an optional `nickname`. It is deliberately structural rather than tied to `FleetMember`, and the other surfaces that use it (vehicle owner, inventory manager) simply never pass one.
+  - The action button gates on a new `canUpdateNickname` rather than the existing `canUpdateMembers`, which excludes the current user. The server applies no such self-exclusion to `update_nickname?`, so reusing `canUpdateMembers` would have hidden the button from an admin editing their own nickname.
+  - The modal takes `fleetSlug`, not a whole `Fleet`: `MemberActions` never has the fleet object, only `route.params.slug`.
+  - Frontend i18n needed four new keys across 7 locales, all hand-translated. `actions.save` already existed; `messages.fleet.members.update` exists but reads "Settings saved." and belongs to the self-service settings page, so the nickname got its own messages.
+  - Verified green: 117 fleet-member integration tests, 32 model/asyncapi tests, 559 vitest tests, `bin/ruby-lint`, eslint, prettier, and `lint:ts` (exit 0).
+
+## Progress
+- [x] Phase 1 — Backend: storage, write path, payload
+- [x] Phase 2 — API schema and generated clients
+- [x] Phase 3 — Frontend
+- [x] Phase 4 — i18n and tests

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -3552,6 +3552,57 @@ paths:
                 "$ref": "#/components/schemas/StandardError"
         '400':
           "$ref": "#/components/responses/SchemaValidationError"
+    put:
+      summary: Update Member
+      tags:
+      - FleetMembers
+      operationId: updateFleetMember
+      description: Set the nickname a fleet knows a member by
+      security:
+      - SessionCookie: []
+      - Oauth2:
+        - fleet
+        - fleet:write
+      - OpenId:
+        - fleet
+        - fleet:write
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/FleetMemberUpdateInput"
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FleetMember"
+        '400':
+          description: bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ValidationError"
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '403':
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
+        '404':
+          description: not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/StandardError"
   "/fleets/{fleetSlug}/members/{username}/accept":
     parameters:
     - name: fleetSlug
@@ -14482,6 +14533,10 @@ components:
           format: uuid
         username:
           type: string
+        nickname:
+          type:
+          - string
+          - 'null'
         fleetRole:
           "$ref": "#/components/schemas/FleetRole"
         status:
@@ -14585,6 +14640,8 @@ components:
       properties:
         usernameCont:
           type: string
+        nicknameCont:
+          type: string
         nameCont:
           type: string
           deprecated: true
@@ -14636,6 +14693,15 @@ components:
       additionalProperties: false
       example: {}
       title: FleetMemberQuery
+    FleetMemberUpdateInput:
+      type: object
+      properties:
+        nickname:
+          type:
+          - string
+          - 'null'
+      additionalProperties: false
+      title: FleetMemberUpdateInput
     FleetMembersList:
       type: object
       properties:

--- a/test/factories/fleet_memberships.rb
+++ b/test/factories/fleet_memberships.rb
@@ -10,6 +10,7 @@
 #  hide_ships        :boolean          default(FALSE)
 #  invited_at        :datetime
 #  invited_by        :uuid
+#  nickname          :string
 #  primary           :boolean          default(FALSE)
 #  requested_at      :datetime
 #  ships_filter      :integer          default(0)
@@ -65,6 +66,10 @@ FactoryBot.define do
     trait :hide_ships do
       hide_ships { true }
       ships_filter { :hide }
+    end
+
+    trait :with_nickname do
+      nickname { "Wingman" }
     end
 
     trait :as_admin do

--- a/test/integration/api/v1/fleets_members_update_test.rb
+++ b/test/integration/api/v1/fleets_members_update_test.rb
@@ -1,0 +1,193 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FleetsMembersUpdateTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/fleets/{fleetSlug}/members/{username}" do
+    parameter name: "fleetSlug", in: :path, schema: {type: :string}, description: "Fleet slug"
+    parameter name: "username", in: :path, schema: {type: :string}, description: "Username"
+
+    put("Update Member") do
+      operationId "updateFleetMember"
+      description "Set the nickname a fleet knows a member by"
+      tags "FleetMembers"
+      consumes "application/json"
+      produces "application/json"
+
+      request_body required: true, schema: ::V1::Schemas::Inputs::FleetMemberUpdateInput
+
+      security [
+        {SessionCookie: []},
+        {Oauth2: ["fleet", "fleet:write"]},
+        {OpenId: ["fleet", "fleet:write"]}
+      ]
+
+      response(200, "successful") do
+        schema ::V1::Schemas::Fleets::FleetMember
+      end
+
+      response(400, "bad request") do
+        schema ::Shared::V1::Schemas::ValidationError
+      end
+
+      response(401, "unauthorized") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(403, "forbidden") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+
+      response(404, "not found") do
+        schema ::Shared::V1::Schemas::StandardError
+      end
+    end
+  end
+
+  setup do
+    @admin = create(:user)
+    @member = create(:user)
+    @outsider = create(:user)
+    @fleet = create(:fleet, admins: [@admin], members: [@member])
+    @membership = @fleet.fleet_memberships.find_by(user: @member)
+  end
+
+  test "PUT /fleets/:slug/members/:username sets the nickname" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      body: {nickname: "Wingman"} do
+      assert_equal "Wingman", parsed_body["nickname"]
+      assert_equal @member.username, parsed_body["username"]
+    end
+
+    assert_equal "Wingman", @membership.reload.nickname
+  end
+
+  test "PUT /fleets/:slug/members/:username clears the nickname with null" do
+    @membership.update!(nickname: "Wingman")
+
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      body: {nickname: nil} do
+      assert_nil parsed_body["nickname"]
+    end
+
+    assert_nil @membership.reload.nickname
+  end
+
+  test "PUT /fleets/:slug/members/:username treats a blank nickname as cleared" do
+    @membership.update!(nickname: "Wingman")
+
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      body: {nickname: "   "} do
+      assert_nil parsed_body["nickname"]
+    end
+
+    assert_nil @membership.reload.nickname
+  end
+
+  test "PUT /fleets/:slug/members/:username trims surrounding whitespace" do
+    sign_in @admin
+
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      body: {nickname: "  Wingman  "} do
+      assert_equal "Wingman", parsed_body["nickname"]
+    end
+  end
+
+  test "PUT /fleets/:slug/members/:username returns 400 for a nickname that is too long" do
+    sign_in @admin
+
+    assert_api_response :put, 400,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      body: {nickname: "a" * 256}
+
+    assert_nil @membership.reload.nickname
+  end
+
+  # The nickname is the only thing this endpoint may write. Everything else on a
+  # membership is either self-service or has its own action, so a fleet admin
+  # must not be able to reach it by widening the body. `additionalProperties:
+  # false` on the input rejects the request outright; the rule-scoped params
+  # filter would drop the extras anyway.
+  test "PUT /fleets/:slug/members/:username rejects attributes other than the nickname" do
+    hangar_group = create(:hangar_group, user: @member)
+
+    sign_in @admin
+
+    put "/api/v1/fleets/#{@fleet.slug}/members/#{@member.username}",
+      params: {nickname: "Wingman", primary: true, shipsFilter: "hide", hangarGroupId: hangar_group.id},
+      as: :json
+
+    assert_response :bad_request
+
+    @membership.reload
+    assert_nil @membership.nickname
+    assert_not @membership.primary
+    assert_equal "all", @membership.ships_filter
+    assert_nil @membership.hangar_group_id
+  end
+
+  test "PUT /fleets/:slug/members/:username returns 403 without membership update access" do
+    @fleet.default_member_role.update!(resource_access: ["fleet:memberships:read"])
+
+    sign_in @member
+
+    assert_api_response :put, 403,
+      path_params: {fleetSlug: @fleet.slug, username: @admin.username},
+      body: {nickname: "Wingman"}
+  end
+
+  test "PUT /fleets/:slug/members/:username does not let a member nickname themselves" do
+    @fleet.default_member_role.update!(resource_access: ["fleet:memberships:read"])
+
+    sign_in @member
+
+    assert_api_response :put, 403,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      body: {nickname: "Wingman"}
+
+    assert_nil @membership.reload.nickname
+  end
+
+  test "PUT /fleets/:slug/members/:username returns 404 for an unknown member" do
+    sign_in @admin
+
+    assert_api_response :put, 404,
+      path_params: {fleetSlug: @fleet.slug, username: "unknown"},
+      body: {nickname: "Wingman"}
+  end
+
+  test "PUT /fleets/:slug/members/:username returns 404 for an outsider" do
+    sign_in @outsider
+
+    assert_api_response :put, 404,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      body: {nickname: "Wingman"}
+  end
+
+  test "PUT /fleets/:slug/members/:username returns 401 when not signed in" do
+    assert_api_response :put, 401,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      body: {nickname: "Wingman"}
+  end
+
+  test "PUT /fleets/:slug/members/:username with OAuth bearer token" do
+    assert_api_response :put, 200,
+      path_params: {fleetSlug: @fleet.slug, username: @member.username},
+      headers: oauth_headers_for(@admin, scopes: ["fleet", "fleet:write"]),
+      body: {nickname: "Wingman"}
+  end
+end

--- a/test/models/fleet_membership_test.rb
+++ b/test/models/fleet_membership_test.rb
@@ -12,6 +12,7 @@
 #  hide_ships        :boolean          default(FALSE)
 #  invited_at        :datetime
 #  invited_by        :uuid
+#  nickname          :string
 #  primary           :boolean          default(FALSE)
 #  requested_at      :datetime
 #  ships_filter      :integer          default(0)
@@ -46,6 +47,39 @@ class FleetMembershipTest < ActiveSupport::TestCase
     @fleet = create(:fleet, admins: [@admin_user], members: [@member_user])
     @admin_membership = @fleet.fleet_memberships.find_by(user: @admin_user)
     @member_membership = @fleet.fleet_memberships.find_by(user: @member_user)
+  end
+
+  test "nickname is trimmed of surrounding whitespace" do
+    @member_membership.update!(nickname: "  Wingman  ")
+
+    assert_equal "Wingman", @member_membership.reload.nickname
+  end
+
+  test "a blank nickname is stored as nil" do
+    @member_membership.update!(nickname: "Wingman")
+    @member_membership.update!(nickname: "   ")
+
+    assert_nil @member_membership.reload.nickname
+  end
+
+  test "nickname is rejected beyond 255 characters" do
+    @member_membership.nickname = "a" * 256
+
+    refute @member_membership.valid?
+    assert_includes @member_membership.errors.attribute_names, :nickname
+  end
+
+  test "nickname accepts 255 characters" do
+    @member_membership.nickname = "a" * 255
+
+    assert @member_membership.valid?
+  end
+
+  test "two members of one fleet may share a nickname" do
+    @admin_membership.update!(nickname: "Wingman")
+    @member_membership.update!(nickname: "Wingman")
+
+    assert_equal "Wingman", @member_membership.reload.nickname
   end
 
   test "#has_access? delegates to fleet_role when present" do


### PR DESCRIPTION
Fleets know their members by a name that often is not the Fleetyards username. This lets anyone with membership-update access set one, and shows it wherever a member is named.

Resolves #2586

## How it works

The nickname lives on `fleet_memberships`, not on `users` — a user belongs to many fleets, and one fleet's label has no business leaking into another. There was no free-text column to reuse, so this adds one. (The issue carries `size/S`, "one PR, no migration"; still one PR, but the migration was unavoidable.)

Setting one is a new `PUT /fleets/{fleetSlug}/members/{username}`, gated by a new `update_nickname?` rule on the same `fleet:memberships:update` privilege that promote and demote already use — so no new capability, and `FleetMembershipCapabilitiesTest` is untouched.

Two things worth a reviewer's attention:

- **The rule is deliberately not `update?`.** That one is the self-service rule the membership endpoint owns (`record.user_id == user.id`). Widening it would have let a fleet admin reach attributes they have no business writing on someone else.
- **The params filter is rule-scoped.** `params_filter(:update_nickname)` permits the nickname and nothing else, leaving the shared filter alone, so `primary`, `shipsFilter`, and `hangarGroupId` are unreachable from this endpoint. A body carrying them is rejected outright with a 400 by request validation, not silently trimmed — there's a test for exactly that.

## Display

The username never disappears. `MemberName` is the single component naming a member for the list, the invites list, and the mobile detail modal, so it shows the nickname with the username kept beside it at the same weight the list already uses for secondary text. Every link and lookup still resolves on the username.

## Also here

`fix(validations): register the max rule` is a separate commit. Every locale already shipped a `validations.max` message, but the rule was never passed to `defineRule`, so any field using it threw `No such validator 'max' exists`. Found it the moment the nickname field tried to use it.

## Not in scope

Deferred, with reasoning in the exec-plan: the Discord `/fleet members` command, the admin panel, e2e coverage of the members page, and per-fleet uniqueness (a nickname is a label, not a handle).

Searching the members list by nickname is also deferred. `nicknameCont` is permitted and in the schema for API callers, but the UI box still sends only `usernameCont`, and repointing it would silently change an existing filter's meaning. Worth knowing for whoever picks it up: ransack does **not** resolve a `ransack_alias` inside an `_or_` chain, so `username_or_nickname_cont` builds SQL against `fleet_memberships.username`, a column that does not exist, and only blows up when the query runs. The working form is `user_username_or_nickname_cont`.

Two open questions are noted in the plan — whether sorting by name should use the nickname, and whether a member should be able to see that they have one.

## Verification

- 134 Ruby tests (fleet member integration, membership, admin, model, asyncapi) — green
- 559 vitest — green
- `bin/ruby-lint`, eslint, prettier, `lint:ts` — all clean
- Generated schema diff is purely additive: 70 lines, no deletions

Adding the field to the payload broke six tests via the cable broadcast before any OpenAPI check ran, so `bin/generate-asyncapi` and `bin/generate-cable-client` are both part of this alongside `bin/generate-schema`.

🤖
