### PR TITLE
feat(models): give ground vehicles a size ladder

### DIFF
--- a/app/api_components/admin/v1/schemas/inputs/model_create_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/model_create_input.rb
@@ -39,6 +39,7 @@ module Admin
               focus: {type: :string},
               size: {type: :string},
               dockSize: {type: :string},
+              vehicleSize: {type: [:string, :null]},
               length: {type: :number},
               beam: {type: :number},
               height: {type: :number},

--- a/app/api_components/admin/v1/schemas/inputs/model_update_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/model_update_input.rb
@@ -40,6 +40,7 @@ module Admin
               focus: {type: :string},
               size: {type: :string},
               dockSize: {type: :string},
+              vehicleSize: {type: [:string, :null]},
               length: {type: [:number, :null]},
               beam: {type: [:number, :null]},
               height: {type: [:number, :null]},

--- a/app/api_components/shared/v1/schemas/model_metrics.rb
+++ b/app/api_components/shared/v1/schemas/model_metrics.rb
@@ -47,7 +47,8 @@ module Shared
             signatureCrossSection: Shared::V1::Schemas::ModelSignatureCrossSection,
             size: {type: :string},
             sizeLabel: {type: :string},
-            dockSize: {type: :string}
+            dockSize: {type: :string},
+            vehicleSize: {type: [:string, :null]}
           },
           additionalProperties: false
 

--- a/app/controllers/admin/api/v1/models_controller.rb
+++ b/app/controllers/admin/api/v1/models_controller.rb
@@ -176,7 +176,7 @@ module Admin
             :scm_speed, :scm_speed_boosted, :max_speed, :reverse_speed_boosted, :yaw, :yaw_boosted,
             :pitch, :pitch_boosted, :roll, :roll_boosted, :erkul_identifier, :sc_key,
             :manufacturer_id, :rsi_id, :base_model_id, :production_status, :production_note,
-            :classification, :focus, :size, :dock_size, :length, :beam, :height, :on_sale, :player_ownable,
+            :classification, :focus, :size, :dock_size, :vehicle_size, :length, :beam, :height, :on_sale, :player_ownable,
             :store_url, :sales_page_url, :price, :pledge_price, :cargo, :fleetchart_offset_length,
             :fleetchart_offset_beam, :extended_length, :extended_beam, :extended_height,
             :extended_fleetchart_offset_length, :extended_fleetchart_offset_beam,

--- a/app/controllers/api/v1/filters/models_controller.rb
+++ b/app/controllers/api/v1/filters/models_controller.rb
@@ -32,6 +32,12 @@ module Api
           render "api/v1/shared/filters"
         end
 
+        def vehicle_sizes
+          @filters = Model.vehicle_size_filters
+
+          render "api/v1/shared/filters"
+        end
+
         def dock_sizes
           @filters = Model.dock_size_filters
 

--- a/app/controllers/concerns/will_it_fit_concern.rb
+++ b/app/controllers/concerns/will_it_fit_concern.rb
@@ -48,12 +48,12 @@ module WillItFitConcern
     # `size`, not `ground`: the latter means "cannot reach space", so a hover bike
     # is ground: false while still berthing as a vehicle. See Dock#fits?.
     if dock.for_vehicles?
-      return scope.where(models: {size: ::Dock::VEHICLE_SIZE}.merge(dimensions))
+      return scope.where(models: {size: ::Model::VEHICLE_SIZE}.merge(dimensions))
     end
 
     # `where.not` drops a null size along with the vehicles, which is what we
     # want: the two models without one are planetary beacons.
-    scope.where(models: dimensions).where.not(models: {size: ::Dock::VEHICLE_SIZE})
+    scope.where(models: dimensions).where.not(models: {size: ::Model::VEHICLE_SIZE})
   end
 
   private def will_it_fit_carrier(slug)

--- a/app/frontend/admin/components/base/ModelVehicleSizeSelect/index.vue
+++ b/app/frontend/admin/components/base/ModelVehicleSizeSelect/index.vue
@@ -1,0 +1,68 @@
+<script lang="ts">
+export default {
+  name: "ModelVehicleSizeSelect",
+};
+</script>
+
+<script lang="ts" setup>
+import { modelVehicleSizesFilters as fetchModelVehicleSizeFilters } from "@/services/fyApi";
+import { type FilterOption } from "@/services/fyApi";
+import { useI18n } from "@/shared/composables/useI18n";
+import BaseSelect, {
+  type BaseSelectParams,
+} from "@/shared/components/base/Select/index.vue";
+
+type Props = {
+  name: string;
+  modelValue?: string | string[] | null;
+  multiple?: boolean;
+  noLabel?: boolean;
+};
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: undefined,
+  multiple: true,
+  noLabel: true,
+});
+
+const { t } = useI18n();
+
+const internalValue = ref<string | string[] | null | undefined>(
+  props.modelValue,
+);
+
+onMounted(() => {
+  internalValue.value = props.modelValue;
+});
+
+watch(
+  () => props.modelValue,
+  () => {
+    internalValue.value = props.modelValue;
+  },
+);
+
+const emit = defineEmits(["update:modelValue"]);
+
+watch(
+  () => internalValue.value,
+  () => {
+    emit("update:modelValue", internalValue.value);
+  },
+);
+
+const fetch = async (_params: BaseSelectParams<FilterOption>) => {
+  return fetchModelVehicleSizeFilters();
+};
+</script>
+
+<template>
+  <BaseSelect
+    v-model="internalValue"
+    :label="t('labels.filters.models.vehicleSize')"
+    :query-fn="fetch"
+    :name="name"
+    :multiple="multiple"
+    :no-label="noLabel"
+  />
+</template>

--- a/app/frontend/admin/pages/models/[id]/edit/metrics.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/metrics.vue
@@ -17,6 +17,7 @@ import ModelForm from "@/admin/components/Models/Form/index.vue";
 import { InputAlignmentsEnum } from "@/shared/components/base/FormInput/types";
 import ModelSizeSelect from "@/frontend/components/base/ModelSizeSelect/index.vue";
 import ModelDockSizeSelect from "@/admin/components/base/ModelDockSizeSelect/index.vue";
+import ModelVehicleSizeSelect from "@/admin/components/base/ModelVehicleSizeSelect/index.vue";
 
 type Props = {
   model: ModelExtended;
@@ -64,6 +65,7 @@ const { defineField, handleSubmit, meta } = useForm<ModelUpdateInput>({
 });
 
 const [size, sizeProps] = defineField("size");
+const [vehicleSize, vehicleSizeProps] = defineField("vehicleSize");
 const [dockSize, dockSizeProps] = defineField("dockSize");
 const [length, lengthProps] = defineField("length");
 const [fleetchartOffsetLength, fleetchartOffsetLengthProps] = defineField(
@@ -109,6 +111,15 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
           :no-label="false"
           :multiple="false"
           name="size"
+        />
+      </div>
+      <div class="col-12 col-md-4">
+        <ModelVehicleSizeSelect
+          v-model="vehicleSize"
+          v-bind="vehicleSizeProps"
+          :no-label="false"
+          :multiple="false"
+          name="vehicleSize"
         />
       </div>
       <div class="col-12 col-md-4">

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1436,7 +1436,8 @@
           "holoBlank": "Ohne Holo?",
           "frontViewBlank": "Ohne Frontansicht-Bild?",
           "topViewColoredBlank": "Ohne farbige Draufsicht?",
-          "scIdentifierBlank": "Ohne SC-Kennung?"
+          "scIdentifierBlank": "Ohne SC-Kennung?",
+          "vehicleSize": "Fahrzeuggröße"
         },
         "modelModules": {
           "name": "Name"

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1431,7 +1431,8 @@
           "fleetchartImageBlank": "Without Fleetchart Image?",
           "holoBlank": "Without Holo?",
           "frontViewBlank": "Without Front View Image?",
-          "topViewColoredBlank": "Without Top View Colored Image?"
+          "topViewColoredBlank": "Without Top View Colored Image?",
+          "vehicleSize": "Vehicle Size"
         },
         "modelModules": {
           "name": "Name"

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1436,7 +1436,8 @@
           "holoBlank": "¿Sin Holo?",
           "frontViewBlank": "¿Sin imagen de vista frontal?",
           "topViewColoredBlank": "¿Sin imagen de vista superior a color?",
-          "scIdentifierBlank": "¿Sin identificador SC?"
+          "scIdentifierBlank": "¿Sin identificador SC?",
+          "vehicleSize": "Tamaño de vehículo"
         },
         "modelModules": {
           "name": "Nombre"

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1436,7 +1436,8 @@
           "holoBlank": "Sans Holo ?",
           "frontViewBlank": "Sans image de vue de face ?",
           "topViewColoredBlank": "Sans image de vue de dessus colorée ?",
-          "scIdentifierBlank": "Sans identifiant SC ?"
+          "scIdentifierBlank": "Sans identifiant SC ?",
+          "vehicleSize": "Taille de véhicule"
         },
         "modelModules": {
           "name": "Nom"

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1436,7 +1436,8 @@
           "holoBlank": "Senza Holo?",
           "frontViewBlank": "Senza immagine vista frontale?",
           "topViewColoredBlank": "Senza immagine vista dall'alto a colori?",
-          "scIdentifierBlank": "Senza identificatore SC?"
+          "scIdentifierBlank": "Senza identificatore SC?",
+          "vehicleSize": "Dimensione del veicolo"
         },
         "modelModules": {
           "name": "Nome"

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1436,7 +1436,8 @@
           "holoBlank": "没有 Holo?",
           "frontViewBlank": "没有前视图图片?",
           "topViewColoredBlank": "没有彩色俯视图图片?",
-          "scIdentifierBlank": "没有 SC 标识?"
+          "scIdentifierBlank": "没有 SC 标识?",
+          "vehicleSize": "载具尺寸"
         },
         "modelModules": {
           "name": "名称"

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1436,7 +1436,8 @@
           "holoBlank": "沒有 Holo?",
           "frontViewBlank": "沒有前視圖圖片?",
           "topViewColoredBlank": "沒有彩色俯視圖圖片?",
-          "scIdentifierBlank": "沒有 SC 標識?"
+          "scIdentifierBlank": "沒有 SC 標識?",
+          "vehicleSize": "載具尺寸"
         },
         "modelModules": {
           "name": "名稱"

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -112,9 +112,6 @@ class Dock < ApplicationRecord
   SHIP_DOCK_TYPES = %w[landingpad hangar].freeze
   VEHICLE_DOCK_TYPES = %w[vehiclepad garage].freeze
 
-  # What `models.size` calls a ground vehicle.
-  VEHICLE_SIZE = "vehicle"
-
   SHIP_CLEARANCE = {length: 2.0, beam: 2.0, height: 1.0}.freeze
   VEHICLE_CLEARANCE = {length: 1.0, beam: 1.0, height: 0.5}.freeze
 
@@ -169,7 +166,7 @@ class Dock < ApplicationRecord
   private def accepts?(model)
     return false unless for_ships? || for_vehicles?
 
-    (model.size == VEHICLE_SIZE) == for_vehicles?
+    (model.size == ::Model::VEHICLE_SIZE) == for_vehicles?
   end
 
   def measured?

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -104,6 +104,7 @@
 #  store_images_updated_at           :datetime
 #  store_url                         :string(255)
 #  upgrade_kits_count                :integer          default(0)
+#  vehicle_size                      :string
 #  videos_count                      :integer          default(0)
 #  weapon_pool_size                  :integer
 #  yaw                               :decimal(15, 2)
@@ -462,6 +463,14 @@ class Model < ApplicationRecord
   after_save :send_new_model_notification, if: :saved_change_to_rsi_id?
 
   validates :name, presence: true, uniqueness: {scope: :manufacturer_id}
+  VEHICLE_SIZE = "vehicle"
+
+  VEHICLE_SIZES = %w[
+    extra_extra_small extra_small small medium large extra_large extra_extra_large
+  ].freeze
+
+  validates :vehicle_size, inclusion: {in: VEHICLE_SIZES}, allow_nil: true
+  validate :vehicle_size_belongs_to_a_vehicle
 
   DEFAULT_SORTING_PARAMS = "name asc"
   ALLOWED_SORTING_PARAMS = [
@@ -565,6 +574,22 @@ class Model < ApplicationRecord
     scope.order(:focus).distinct.pluck(:focus).compact_blank.map do |item|
       Filter.new(
         category: "focus",
+        label: item.humanize,
+        value: item
+      )
+    end
+  end
+
+  # The ladder a berth is measured against, smallest first. Only meaningful
+  # where `size` is "vehicle"; a ship has none.
+  #
+  # Curated, not derived. Volume orders most of them correctly but not the
+  # Cyclone, whose recorded beam of 8.75m is wider than an Ursa and puts it a
+  # class too high.
+  def self.vehicle_size_filters
+    VEHICLE_SIZES.map do |item|
+      Filter.new(
+        category: "vehicle_size",
         label: item.humanize,
         value: item
       )
@@ -1021,6 +1046,14 @@ class Model < ApplicationRecord
     else
       sales.ongoing.update_all(ended_at: Time.current, updated_at: Time.current)
     end
+  end
+
+  # A ship has no place on this ladder, so carrying a value there is a mistake
+  # rather than extra information.
+  private def vehicle_size_belongs_to_a_vehicle
+    return if vehicle_size.blank? || size == VEHICLE_SIZE
+
+    errors.add(:vehicle_size, :not_a_vehicle)
   end
 
   private def send_on_sale_notification

--- a/app/views/admin/api/v1/models/_base.jbuilder
+++ b/app/views/admin/api/v1/models/_base.jbuilder
@@ -160,6 +160,7 @@ json.metrics do
   json.size model.size
   json.size_label model.size&.humanize
   json.dock_size model.dock_size
+  json.vehicle_size model.vehicle_size
 end
 
 json.cargo_holds model.cargo_holds

--- a/app/views/api/v1/models/_base.jbuilder
+++ b/app/views/api/v1/models/_base.jbuilder
@@ -166,6 +166,7 @@ json.metrics do
   json.size model.size
   json.size_label model.size&.humanize
   json.dock_size model.dock_size
+  json.vehicle_size model.vehicle_size
 end
 
 json.cargo_holds model.cargo_holds_with_offsets

--- a/asyncapi/cable/v1/schema.yaml
+++ b/asyncapi/cable/v1/schema.yaml
@@ -2374,6 +2374,10 @@ components:
           type: string
         dockSize:
           type: string
+        vehicleSize:
+          type:
+          - string
+          - 'null'
       additionalProperties: false
     ModelModule:
       type: object

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -228,6 +228,10 @@ en:
               must_be_in_game: is not in the game yet
             allowed_model_ids:
               must_be_in_game: name a ship that is not in the game yet
+        model:
+          attributes:
+            vehicle_size:
+              not_a_vehicle: only applies to a ground vehicle
         fleet_role:
           attributes:
             base:

--- a/config/routes/api/models_routes.rb
+++ b/config/routes/api/models_routes.rb
@@ -40,6 +40,7 @@ namespace :filters do
       get :focus
       get :sizes
       get "dock-sizes" => "models#dock_sizes"
+      get "vehicle-sizes" => "models#vehicle_sizes"
       get "cargo-options" => "models#cargo_options"
     end
   end

--- a/db/migrate/20260911133041_add_vehicle_size_to_models.rb
+++ b/db/migrate/20260911133041_add_vehicle_size_to_models.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddVehicleSizeToModels < ActiveRecord::Migration[8.1]
+  # A ladder of t-shirt sizes for ground vehicles, anchored on reference
+  # vehicles: ATLS, then the hover bikes, then PTV/UTV, Cyclone, Ursa, and
+  # Nova/Ballista at the top. "Holds an Ursa" is the answer a berth wants to
+  # give; "10 x 7 x 6" is not.
+  #
+  # Separate from `size`, which only says *that* something is a vehicle. Curated
+  # rather than derived: the Cyclone base variants are recorded 8.75m wide,
+  # wider than an Ursa, which inverts the order by volume.
+  def change
+    add_column :models, :vehicle_size, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_11_131944) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_133041) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -1347,6 +1347,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_131944) do
     t.string "store_url", limit: 255
     t.datetime "updated_at", precision: nil
     t.integer "upgrade_kits_count", default: 0
+    t.string "vehicle_size"
     t.integer "videos_count", default: 0
     t.integer "weapon_pool_size"
     t.decimal "yaw", precision: 15, scale: 2

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -13020,6 +13020,10 @@ components:
           type: string
         dockSize:
           type: string
+        vehicleSize:
+          type:
+          - string
+          - 'null'
         length:
           type: number
         beam:
@@ -13457,6 +13461,10 @@ components:
           type: string
         dockSize:
           type: string
+        vehicleSize:
+          type:
+          - string
+          - 'null'
       additionalProperties: false
       title: ModelMetrics
     ModelModule:
@@ -14643,6 +14651,10 @@ components:
           type: string
         dockSize:
           type: string
+        vehicleSize:
+          type:
+          - string
+          - 'null'
         length:
           type:
           - number

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -434,6 +434,19 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/FilterOptionsList"
+  "/filters/models/vehicle-sizes":
+    get:
+      summary: Model Vehicle Sizes Filters
+      tags:
+      - ModelsFilters
+      operationId: modelVehicleSizesFilters
+      responses:
+        '200':
+          description: successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/FilterOptionsList"
   "/filters/vehicles/bought-via":
     get:
       summary: Vehicles Bought Via Filters
@@ -18305,6 +18318,10 @@ components:
           type: string
         dockSize:
           type: string
+        vehicleSize:
+          type:
+          - string
+          - 'null'
       additionalProperties: false
       title: ModelMetrics
     ModelModule:

--- a/test/factories/models.rb
+++ b/test/factories/models.rb
@@ -102,6 +102,7 @@
 #  store_images_updated_at           :datetime
 #  store_url                         :string(255)
 #  upgrade_kits_count                :integer          default(0)
+#  vehicle_size                      :string
 #  videos_count                      :integer          default(0)
 #  weapon_pool_size                  :integer
 #  yaw                               :decimal(15, 2)

--- a/test/integration/api/v1/filters_models_vehicle_sizes_test.rb
+++ b/test/integration/api/v1/filters_models_vehicle_sizes_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "openapi_helper"
+
+class Api::V1::FiltersModelsVehicleSizesTest < ActionDispatch::IntegrationTest
+  include OpenapiRuby::Adapters::Minitest::DSL
+
+  openapi_schema :"v1/schema"
+
+  api_path "/filters/models/vehicle-sizes" do
+    get("Model Vehicle Sizes Filters") do
+      operationId "modelVehicleSizesFilters"
+      tags "ModelsFilters"
+      produces "application/json"
+
+      response(200, "successful") do
+        schema ::Shared::V1::Schemas::FilterOptionsList
+      end
+    end
+  end
+
+  test "GET /filters/models/vehicle-sizes returns the ladder smallest first" do
+    assert_api_response :get, 200 do
+      values = parsed_body.map { |filter| filter["value"] }
+
+      assert_equal Model::VEHICLE_SIZES, values
+    end
+  end
+end

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -106,6 +106,7 @@ require "test_helper"
 #  store_images_updated_at           :datetime
 #  store_url                         :string(255)
 #  upgrade_kits_count                :integer          default(0)
+#  vehicle_size                      :string
 #  videos_count                      :integer          default(0)
 #  weapon_pool_size                  :integer
 #  yaw                               :decimal(15, 2)
@@ -630,5 +631,42 @@ class ModelTest < ActiveSupport::TestCase
 
     assert_not_predicate sale, :valid?
     assert_predicate sale.errors[:ended_at], :present?
+  end
+end
+
+# The ladder a berth is measured against. Curated rather than derived — the
+# Cyclone's recorded beam is wider than an Ursa's and would place it a class too
+# high — so the only guards are that a value is on the ladder and that a ship
+# does not carry one.
+class ModelVehicleSizeTest < ActiveSupport::TestCase
+  test "a vehicle may carry a size from the ladder" do
+    model = build(:model, size: "vehicle", vehicle_size: "large")
+
+    assert_predicate model, :valid?
+  end
+
+  test "a value off the ladder is refused" do
+    model = build(:model, size: "vehicle", vehicle_size: "enormous")
+
+    assert_not model.valid?
+    assert_includes model.errors.attribute_names, :vehicle_size
+  end
+
+  test "a ship carries none" do
+    model = build(:model, size: "small", vehicle_size: "large")
+
+    assert_not model.valid?
+    assert_includes model.errors.attribute_names, :vehicle_size
+  end
+
+  test "a vehicle without one is fine" do
+    model = build(:model, size: "vehicle", vehicle_size: nil)
+
+    assert_predicate model, :valid?
+  end
+
+  test "the ladder runs smallest first" do
+    assert_equal "extra_extra_small", Model::VEHICLE_SIZES.first
+    assert_equal "extra_extra_large", Model::VEHICLE_SIZES.last
   end
 end


### PR DESCRIPTION
Tracks #4863. First piece of the berth model, and the one that does not touch `docks` — so it is independent of #4864 and of the polymorphic parent waiting behind it.

## Why a ladder rather than measurements

A berth wants to say **"holds an Ursa"**. `10 × 7 × 6` is not that answer, and measurements cannot become it, because the measurements are wrong in the place it matters:

The Cyclone base variants are recorded **6.0 × 8.75 × 3.5** — wider than they are long, and wider than an Ursa at 5.5. By volume that puts the Cyclone at 184 m³ against the Ursa's 92, a class *above* the vehicle it comfortably fits beside. `Cyclone MT` at 6.0 × 4.0 × 2.5 is sane, so the family disagrees with itself.

That is exactly the class where "does it fit the Carrack garage" is decided, so the ladder is curated and no seed is offered.

## The ladder

Seven t-shirt sizes, anchored on reference vehicles: **ATLS**, then the hover bikes, **PTV/UTV**, **Cyclone**, **Ursa**, and **Nova/Ballista** at the top.

A **proposal** for the curation pass, not a derivation. Six anchors, and the 44 vehicles fall out roughly as:

| size | anchor | vehicles |
|---|---|---|
| `extra_extra_small` | ATLS | ATLS, ATLS GEO |
| `extra_small` | hover bikes | Pulse, Pulse LX, Nox, Nox Kue, HoverQuad, X1, X1 Force, X1 Velocity, Dragonfly ×3 |
| `small` | PTV / UTV | PTV, UTV, STV, Ranger CV/RC/TR |
| `medium` | Cyclone | Cyclone ×6, Mule, ROC, CSV-SM, MDC, MTC |
| `large` | Ursa | Ursa, Ursa Fortuna, Ursa Medivac, Lynx, ROC-DS, G12 ×3 |
| `extra_large` | Storm | Storm, Storm AA |
| `extra_extra_large` | Nova / Ballista | Nova, Centurion, Spartan, Ballista |

Three placements are guesses and want a decision: the **Dragonfly** sits at 63–72 m³, Cyclone territory by volume, yet it is a bike and stows like one. The **Storm** at 284 m³ is alone between the Ursa and the Nova. And **MDC/MTC** at 77 m³ fall between the Cyclone and the Ursa with nothing to break the tie.

Volume gets the rough shape right and the boundaries wrong, which is the whole argument for curating it. Two families prove it:

**The Cyclone.** Recorded 6.0 × 8.75 × 3.5 — wider than long, wider than an Ursa — so 184 m³ against the Ursa's 92, a class above the vehicle it fits beside. `Cyclone MT` at 6.0 × 4.0 × 2.5 is sane, so the family disagrees with itself.

**The Ursa.** The turret lowers, so 2.20 and 3.20 are both real measurements of the same vehicle:

| | L × B × H | m³ |
|---|---|---:|
| Ursa | 7.60 × 5.50 × **2.20** | 92 |
| Ursa Medivac | 8.00 × 5.50 × **3.20** | 141 |
| Lynx | 7.75 × 5.70 × **3.50** | 155 |

Footprint is near-identical; only the height moves. **2.20 is the lowered figure** and the one a berth should be judged by — a vehicle that can make itself shorter to get in should be measured that way. The Medivac is the same chassis with a different interior and is to be corrected to match.

Grouped by volume this reads as two classes. It is one class, one retractable turret, and one row that measured the other configuration.

The ATLS still earns its own floor at half a PTV, and its rule of thumb — fits wherever two 1 SCU boxes stack — holds against the cargo data: 1 SCU is a 1.25 m cube, so two is 2.5 m against a recorded ATLS height of 2.8 m.

## What is in it

- `models.vehicle_size`, validated against the ladder and refused on anything that is not `size: vehicle` — a ship carrying one is a mistake, not extra information
- `GET /filters/models/vehicle-sizes`, the endpoint the admin select reads, mirroring `dock-sizes`
- `ModelVehicleSizeSelect` beside the dock size on the metrics form
- The field in the public and admin payloads and in both admin inputs
- `Dock::VEHICLE_SIZE` folded into `Model::VEHICLE_SIZE` — one definition, owned by the model that has the column

**No values are assigned.** That is a curation pass, and the two families above are the reason a volume-based seed would get it wrong.

## Verification

720 tests across `test/models/`, the new filter endpoint and the admin model endpoints pass. `bin/ruby-lint` and `pnpm lint` clean. Schemas regenerated.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vehicle-size support for ground vehicle models, including validation and API responses.
  * Added vehicle-size selection to the admin model metrics form.
  * Added a vehicle-size filter endpoint with options from extra-extra-small through extra-extra-large.
  * Added localized vehicle-size labels across supported languages.
  * Added nullable vehicle-size fields to model creation, updates, and metrics data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->