### PR TITLE
feat(docks): let a dock belong to a module as well as a ship

### DIFF
--- a/app/api_components/admin/v1/schemas/dock.rb
+++ b/app/api_components/admin/v1/schemas/dock.rb
@@ -21,12 +21,16 @@ module Admin
             height: {type: :number},
             minShipSize: {type: :integer},
             maxShipSize: {type: :integer},
-            modelId: {type: :string, format: :uuid},
+            parentId: {type: :string, format: :uuid},
+            parentType: {type: :string},
             createdAt: {type: :string, format: "date-time"},
             updatedAt: {type: :string, format: "date-time"}
           },
           additionalProperties: false,
-          required: %w[id dockType dockTypeLabel shipSize shipSizeLabel createdAt updatedAt]
+          required: %w[
+            id dockType dockTypeLabel shipSize shipSizeLabel parentId parentType
+            createdAt updatedAt
+          ]
         })
       end
     end

--- a/app/api_components/admin/v1/schemas/inputs/dock_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/dock_input.rb
@@ -20,7 +20,7 @@ module Admin
               minShipSize: {type: [:integer, :null]},
               maxShipSize: {type: [:integer, :null]},
               parentId: {type: :string, format: :uuid},
-              parentType: {type: :string}
+              parentType: {type: :string, enum: ::Dock::PARENT_TYPES}
             },
             additionalProperties: false
           })

--- a/app/api_components/admin/v1/schemas/inputs/dock_input.rb
+++ b/app/api_components/admin/v1/schemas/inputs/dock_input.rb
@@ -19,7 +19,8 @@ module Admin
               height: {type: [:number, :null]},
               minShipSize: {type: [:integer, :null]},
               maxShipSize: {type: [:integer, :null]},
-              modelId: {type: [:string, :null], format: :uuid}
+              parentId: {type: :string, format: :uuid},
+              parentType: {type: :string}
             },
             additionalProperties: false
           })

--- a/app/api_components/admin/v1/schemas/queries/dock_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/dock_query.rb
@@ -10,7 +10,8 @@ module Admin
           schema({
             type: :object,
             properties: {
-              modelIdEq: {type: :string, format: :uuid},
+              parentIdEq: {type: :string, format: :uuid},
+              parentTypeEq: {type: :string},
               dockTypeEq: {type: :string},
               shipSizeEq: {type: :string},
               nameCont: {type: :string}

--- a/app/api_components/v1/schemas/models/model_extended.rb
+++ b/app/api_components/v1/schemas/models/model_extended.rb
@@ -24,6 +24,10 @@ module V1
                   slug: {type: :string},
                   name: {type: :string},
                   dockType: {type: :string},
+                  # Set when the berth arrives with a module rather than being
+                  # built into the hull, so the carrier is conditional on
+                  # actually mounting it.
+                  moduleName: {type: :string},
                   storeImage: ::Shared::V1::Schemas::MediaFile
                 },
                 additionalProperties: false,

--- a/app/controllers/admin/api/v1/docks_controller.rb
+++ b/app/controllers/admin/api/v1/docks_controller.rb
@@ -56,13 +56,13 @@ module Admin
         private def dock_params
           @dock_params ||= params.permit(
             :name, :dock_type, :ship_size, :group,
-            :length, :beam, :height, :min_ship_size, :max_ship_size, :model_id
+            :length, :beam, :height, :min_ship_size, :max_ship_size, :parent_id, :parent_type
           )
         end
 
         private def dock_query_params
           @dock_query_params ||= params.permit(q: [
-            :model_id_eq, :dock_type_eq, :ship_size_eq, :name_cont, :sorts
+            :parent_id_eq, :parent_type_eq, :dock_type_eq, :ship_size_eq, :name_cont, :sorts
           ]).fetch(:q, {})
         end
       end

--- a/app/controllers/concerns/will_it_fit_concern.rb
+++ b/app/controllers/concerns/will_it_fit_concern.rb
@@ -20,7 +20,7 @@ module WillItFitConcern
     # dominate, so a 90x40 dock takes what a 100x20 cannot and picking by length
     # made the filter disagree with `Model#carried_by_with_docks`, which walks
     # them all.
-    docks = carrier.docks.select { |dock| dock.berth? && dock.measured? }
+    docks = carrier.berths.select { |dock| dock.berth? && dock.measured? }
 
     # A carrier nobody measured cannot answer, and filtering everything away
     # would state that nothing fits.

--- a/app/frontend/admin/components/Docks/Editor/index.vue
+++ b/app/frontend/admin/components/Docks/Editor/index.vue
@@ -34,11 +34,11 @@ import {
 
 // A dock hangs off whatever carries it -- a ship, or a module such as the
 // Galaxy's medic bay with its vehicle lift. Both admin pages render this.
-type Props = {
+interface Props {
   parentId: string;
   parentType: DockInputParentType;
   headline: string;
-};
+}
 
 const props = defineProps<Props>();
 

--- a/app/frontend/admin/components/Docks/Editor/index.vue
+++ b/app/frontend/admin/components/Docks/Editor/index.vue
@@ -140,7 +140,11 @@ const destroyMutation = useDestroyDockMutation({
 });
 
 const onDestroy = async (record: Dock) => {
-  await destroyMutation.mutateAsync({ id: record.id });
+  try {
+    await destroyMutation.mutateAsync({ id: record.id });
+  } catch {
+    displayAlert({ text: t("messages.dock.destroy.failure") });
+  }
 };
 
 // Create

--- a/app/frontend/admin/components/Docks/Editor/index.vue
+++ b/app/frontend/admin/components/Docks/Editor/index.vue
@@ -1,0 +1,238 @@
+<script lang="ts">
+export default {
+  name: "AdminDocksEditor",
+};
+</script>
+
+<script lang="ts" setup>
+import { useI18n } from "@/shared/composables/useI18n";
+import Heading from "@/shared/components/base/Heading/index.vue";
+import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
+import {
+  type Dock,
+  type DockInput,
+  type FilterOption,
+  useDocks as useDocksQuery,
+  useCreateDock as useCreateDockMutation,
+  useUpdateDock as useUpdateDockMutation,
+  useDestroyDock as useDestroyDockMutation,
+  getDocksQueryKey,
+} from "@/services/fyAdminApi";
+import { useQueryClient } from "@tanstack/vue-query";
+import { usePagination } from "@/shared/composables/usePagination";
+import Paginator from "@/shared/components/Paginator/index.vue";
+import BasePill from "@/shared/components/base/Pill/index.vue";
+
+// A dock hangs off whatever carries it -- a ship, or a module such as the
+// Galaxy's medic bay with its vehicle lift. Both admin pages render this.
+type Props = {
+  parentId: string;
+  parentType: string;
+  headline: string;
+};
+
+const props = defineProps<Props>();
+
+const { t } = useI18n();
+const queryClient = useQueryClient();
+
+const editableList = ref<{
+  editingId: string | null;
+  creating: boolean;
+  startCreate: () => void;
+  finishEdit: () => void;
+  finishCreate: () => void;
+} | null>(null);
+
+const docksQueryParams = computed(() => ({
+  page: page.value,
+  perPage: perPage.value,
+  q: {
+    parentIdEq: props.parentId,
+    parentTypeEq: props.parentType,
+  },
+}));
+
+const docksQueryKey = computed(() => getDocksQueryKey(docksQueryParams.value));
+
+const { perPage, page, updatePerPage } = usePagination(docksQueryKey);
+
+const { data, isLoading } = useDocksQuery(docksQueryParams);
+
+const invalidateDocks = () =>
+  queryClient.invalidateQueries({
+    queryKey: getDocksQueryKey(),
+  });
+
+// Dropdown options
+const dockTypeOptions: FilterOption[] = [
+  { label: "Vehicle Pad", value: "vehiclepad" },
+  { label: "Garage", value: "garage" },
+  { label: "Landing Pad", value: "landingpad" },
+  { label: "Docking Port", value: "dockingport" },
+  { label: "Hangar", value: "hangar" },
+];
+
+const shipSizeOptions: FilterOption[] = [
+  { label: "Extra Extra Small", value: "extra_extra_small" },
+  { label: "Extra Small", value: "extra_small" },
+  { label: "Small", value: "small" },
+  { label: "Medium", value: "medium" },
+  { label: "Large", value: "large" },
+  { label: "Extra Large", value: "extra_large" },
+  { label: "Capital", value: "capital" },
+];
+
+// Edit
+const editForm = ref<DockInput>({});
+
+const onStartEdit = (record: Dock) => {
+  editForm.value = {
+    name: record.name,
+    dockType: record.dockType,
+    shipSize: record.shipSize,
+  };
+};
+
+const updateMutation = useUpdateDockMutation({
+  mutation: {
+    onSettled: invalidateDocks,
+  },
+});
+
+const onSaveEdit = async () => {
+  const id = editableList.value?.editingId;
+  if (!id) return;
+
+  await updateMutation.mutateAsync({
+    id,
+    data: editForm.value,
+  });
+
+  editableList.value?.finishEdit();
+};
+
+// Delete
+const destroyMutation = useDestroyDockMutation({
+  mutation: {
+    onSettled: invalidateDocks,
+  },
+});
+
+const onDestroy = async (record: Dock) => {
+  await destroyMutation.mutateAsync({ id: record.id });
+};
+
+// Create
+const createForm = ref<DockInput>({
+  parentId: props.parentId,
+  parentType: props.parentType,
+  dockType: "landingpad",
+  shipSize: "medium",
+});
+
+const onStartCreate = () => {
+  createForm.value = {
+    parentId: props.parentId,
+    parentType: props.parentType,
+    dockType: "landingpad",
+    shipSize: "medium",
+  };
+};
+
+const createMutation = useCreateDockMutation({
+  mutation: {
+    onSettled: invalidateDocks,
+  },
+});
+
+const onSaveCreate = async () => {
+  await createMutation.mutateAsync({
+    data: createForm.value,
+  });
+
+  editableList.value?.finishCreate();
+};
+</script>
+
+<template>
+  <div class="flex items-center justify-between mb-4">
+    <Heading hero>{{ headline }}</Heading>
+    <Btn
+      :disabled="editableList?.creating"
+      @click="editableList?.startCreate()"
+    >
+      <i class="fa-duotone fa-plus" />
+      {{ t("actions.add") }}
+    </Btn>
+  </div>
+
+  <InlineEditableList
+    empty-name="Docks"
+    :loading="isLoading"
+    ref="editableList"
+    :items="(data?.items as Dock[]) || []"
+    :confirm-destroy-text="t('messages.confirm.dock.destroy')"
+    @start-edit="onStartEdit"
+    @save-edit="onSaveEdit"
+    @start-create="onStartCreate"
+    @save-create="onSaveCreate"
+    @destroy="onDestroy"
+  >
+    <template #display="{ item }">
+      <BasePill uppercase margin-right>{{ item.dockTypeLabel }}</BasePill>
+      <BasePill margin-right>{{ item.shipSizeLabel }}</BasePill>
+      <span v-if="item.name">{{ item.name }}</span>
+    </template>
+
+    <template #edit>
+      <BaseSelect
+        v-model="editForm.dockType"
+        name="edit-dock-type"
+        :options="dockTypeOptions"
+        :nullable="false"
+        label="Dock Type"
+      />
+      <BaseSelect
+        v-model="editForm.shipSize"
+        name="edit-ship-size"
+        :options="shipSizeOptions"
+        :nullable="false"
+        label="Ship Size"
+      />
+      <FormInput
+        v-model="editForm.name"
+        name="edit-name"
+        translation-key="dock.name"
+      />
+    </template>
+
+    <template #create>
+      <BaseSelect
+        v-model="createForm.dockType"
+        name="create-dock-type"
+        :options="dockTypeOptions"
+        :nullable="false"
+        label="Dock Type"
+      />
+      <BaseSelect
+        v-model="createForm.shipSize"
+        name="create-ship-size"
+        :options="shipSizeOptions"
+        :nullable="false"
+        label="Ship Size"
+      />
+      <FormInput
+        v-model="createForm.name"
+        name="create-name"
+        translation-key="dock.name"
+      />
+    </template>
+  </InlineEditableList>
+
+  <Paginator
+    :query-result-ref="data"
+    :per-page="perPage"
+    :update-per-page="updatePerPage"
+  />
+</template>

--- a/app/frontend/admin/components/Docks/Editor/index.vue
+++ b/app/frontend/admin/components/Docks/Editor/index.vue
@@ -24,6 +24,9 @@ import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { usePagination } from "@/shared/composables/usePagination";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import BasePill from "@/shared/components/base/Pill/index.vue";
+// Registered globally as `Select`, so `<BaseSelect>` resolves to nothing
+// without this and the two dropdowns render as empty comments.
+import BaseSelect from "@/shared/components/base/Select/index.vue";
 import {
   InputAlignmentsEnum,
   InputTypesEnum,
@@ -211,13 +214,13 @@ const onSaveCreate = async () => {
         v-model="editForm.dockType"
         name="edit-dock-type"
         :options="dockTypeOptions"
-        label="Dock Type"
+        :label="t('labels.dock.dockType')"
       />
       <BaseSelect
         v-model="editForm.shipSize"
         name="edit-ship-size"
         :options="shipSizeOptions"
-        label="Ship Size"
+        :label="t('labels.dock.shipSize')"
       />
       <FormInput
         v-model="editForm.name"
@@ -255,13 +258,13 @@ const onSaveCreate = async () => {
         v-model="createForm.dockType"
         name="create-dock-type"
         :options="dockTypeOptions"
-        label="Dock Type"
+        :label="t('labels.dock.dockType')"
       />
       <BaseSelect
         v-model="createForm.shipSize"
         name="create-ship-size"
         :options="shipSizeOptions"
-        label="Ship Size"
+        :label="t('labels.dock.shipSize')"
       />
       <FormInput
         v-model="createForm.name"

--- a/app/frontend/admin/components/Docks/Editor/index.vue
+++ b/app/frontend/admin/components/Docks/Editor/index.vue
@@ -11,6 +11,7 @@ import InlineEditableList from "@/shared/components/InlineEditableList/index.vue
 import {
   type Dock,
   type DockInput,
+  type DockInputParentType,
   type FilterOption,
   useDocks as useDocksQuery,
   useCreateDock as useCreateDockMutation,
@@ -19,15 +20,20 @@ import {
   getDocksQueryKey,
 } from "@/services/fyAdminApi";
 import { useQueryClient } from "@tanstack/vue-query";
+import { useAppNotifications } from "@/shared/composables/useAppNotifications";
 import { usePagination } from "@/shared/composables/usePagination";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import BasePill from "@/shared/components/base/Pill/index.vue";
+import {
+  InputAlignmentsEnum,
+  InputTypesEnum,
+} from "@/shared/components/base/FormInput/types";
 
 // A dock hangs off whatever carries it -- a ship, or a module such as the
 // Galaxy's medic bay with its vehicle lift. Both admin pages render this.
 type Props = {
   parentId: string;
-  parentType: string;
+  parentType: DockInputParentType;
   headline: string;
 };
 
@@ -35,6 +41,7 @@ const props = defineProps<Props>();
 
 const { t } = useI18n();
 const queryClient = useQueryClient();
+const { displayAlert } = useAppNotifications();
 
 const editableList = ref<{
   editingId: string | null;
@@ -91,6 +98,9 @@ const onStartEdit = (record: Dock) => {
     name: record.name,
     dockType: record.dockType,
     shipSize: record.shipSize,
+    length: record.length,
+    beam: record.beam,
+    height: record.height,
   };
 };
 
@@ -104,10 +114,12 @@ const onSaveEdit = async () => {
   const id = editableList.value?.editingId;
   if (!id) return;
 
-  await updateMutation.mutateAsync({
-    id,
-    data: editForm.value,
-  });
+  try {
+    await updateMutation.mutateAsync({ id, data: editForm.value });
+  } catch {
+    displayAlert({ text: t("messages.dock.update.failure") });
+    return;
+  }
 
   editableList.value?.finishEdit();
 };
@@ -127,16 +139,12 @@ const onDestroy = async (record: Dock) => {
 const createForm = ref<DockInput>({
   parentId: props.parentId,
   parentType: props.parentType,
-  dockType: "landingpad",
-  shipSize: "medium",
 });
 
 const onStartCreate = () => {
   createForm.value = {
     parentId: props.parentId,
     parentType: props.parentType,
-    dockType: "landingpad",
-    shipSize: "medium",
   };
 };
 
@@ -147,9 +155,12 @@ const createMutation = useCreateDockMutation({
 });
 
 const onSaveCreate = async () => {
-  await createMutation.mutateAsync({
-    data: createForm.value,
-  });
+  try {
+    await createMutation.mutateAsync({ data: createForm.value });
+  } catch {
+    displayAlert({ text: t("messages.dock.create.failure") });
+    return;
+  }
 
   editableList.value?.finishCreate();
 };
@@ -183,6 +194,16 @@ const onSaveCreate = async () => {
       <BasePill uppercase margin-right>{{ item.dockTypeLabel }}</BasePill>
       <BasePill margin-right>{{ item.shipSizeLabel }}</BasePill>
       <span v-if="item.name">{{ item.name }}</span>
+      <!-- An unmeasured berth answers nothing, so say so rather than leaving
+           the row looking complete. -->
+      <span class="docks-editor__dimensions">
+        <template v-if="item.length && item.beam && item.height">
+          {{ item.length }} × {{ item.beam }} × {{ item.height }} m
+        </template>
+        <template v-else>
+          {{ t("labels.dock.unmeasured") }}
+        </template>
+      </span>
     </template>
 
     <template #edit>
@@ -190,20 +211,42 @@ const onSaveCreate = async () => {
         v-model="editForm.dockType"
         name="edit-dock-type"
         :options="dockTypeOptions"
-        :nullable="false"
         label="Dock Type"
       />
       <BaseSelect
         v-model="editForm.shipSize"
         name="edit-ship-size"
         :options="shipSizeOptions"
-        :nullable="false"
         label="Ship Size"
       />
       <FormInput
         v-model="editForm.name"
         name="edit-name"
         translation-key="dock.name"
+      />
+      <FormInput
+        v-model="editForm.length"
+        :type="InputTypesEnum.NUMBER"
+        :alignment="InputAlignmentsEnum.RIGHT"
+        name="edit-length"
+        translation-key="dock.length"
+        :step="0.1"
+      />
+      <FormInput
+        v-model="editForm.beam"
+        :type="InputTypesEnum.NUMBER"
+        :alignment="InputAlignmentsEnum.RIGHT"
+        name="edit-beam"
+        translation-key="dock.beam"
+        :step="0.1"
+      />
+      <FormInput
+        v-model="editForm.height"
+        :type="InputTypesEnum.NUMBER"
+        :alignment="InputAlignmentsEnum.RIGHT"
+        name="edit-height"
+        translation-key="dock.height"
+        :step="0.1"
       />
     </template>
 
@@ -212,20 +255,42 @@ const onSaveCreate = async () => {
         v-model="createForm.dockType"
         name="create-dock-type"
         :options="dockTypeOptions"
-        :nullable="false"
         label="Dock Type"
       />
       <BaseSelect
         v-model="createForm.shipSize"
         name="create-ship-size"
         :options="shipSizeOptions"
-        :nullable="false"
         label="Ship Size"
       />
       <FormInput
         v-model="createForm.name"
         name="create-name"
         translation-key="dock.name"
+      />
+      <FormInput
+        v-model="createForm.length"
+        :type="InputTypesEnum.NUMBER"
+        :alignment="InputAlignmentsEnum.RIGHT"
+        name="create-length"
+        translation-key="dock.length"
+        :step="0.1"
+      />
+      <FormInput
+        v-model="createForm.beam"
+        :type="InputTypesEnum.NUMBER"
+        :alignment="InputAlignmentsEnum.RIGHT"
+        name="create-beam"
+        translation-key="dock.beam"
+        :step="0.1"
+      />
+      <FormInput
+        v-model="createForm.height"
+        :type="InputTypesEnum.NUMBER"
+        :alignment="InputAlignmentsEnum.RIGHT"
+        name="create-height"
+        translation-key="dock.height"
+        :step="0.1"
       />
     </template>
   </InlineEditableList>
@@ -236,3 +301,11 @@ const onSaveCreate = async () => {
     :update-per-page="updatePerPage"
   />
 </template>
+
+<style lang="scss" scoped>
+.docks-editor__dimensions {
+  margin-left: 0.5rem;
+  opacity: 0.6;
+  font-size: 0.875rem;
+}
+</style>

--- a/app/frontend/admin/components/Docks/Editor/index.vue
+++ b/app/frontend/admin/components/Docks/Editor/index.vue
@@ -75,22 +75,27 @@ const invalidateDocks = () =>
   });
 
 // Dropdown options
+// Labels match `activerecord.dock.dock_types`, which is what the payload's
+// dockTypeLabel renders. `vehiclepad` is deliberately absent: every row that
+// had it moved to the cargo grid, and nothing new should become one.
 const dockTypeOptions: FilterOption[] = [
-  { label: "Vehicle Pad", value: "vehiclepad" },
-  { label: "Garage", value: "garage" },
-  { label: "Landing Pad", value: "landingpad" },
-  { label: "Docking Port", value: "dockingport" },
   { label: "Hangar", value: "hangar" },
+  { label: "Landingpad", value: "landingpad" },
+  { label: "Cargo Grid", value: "cargogrid" },
+  { label: "Garage", value: "garage" },
+  { label: "Dockingport", value: "dockingport" },
 ];
 
+// A ladder, so the order is the point -- alphabetical put Capital first and
+// Extra Large between the two smallest. Hence `unsorted` on the select.
 const shipSizeOptions: FilterOption[] = [
-  { label: "Extra Extra Small", value: "extra_extra_small" },
-  { label: "Extra Small", value: "extra_small" },
-  { label: "Small", value: "small" },
-  { label: "Medium", value: "medium" },
-  { label: "Large", value: "large" },
-  { label: "Extra Large", value: "extra_large" },
-  { label: "Capital", value: "capital" },
+  { label: "Snubcraft (XXS)", value: "extra_extra_small" },
+  { label: "Extra Small (XS)", value: "extra_small" },
+  { label: "Small (S)", value: "small" },
+  { label: "Medium (M)", value: "medium" },
+  { label: "Large (L)", value: "large" },
+  { label: "Extra Large (XL)", value: "extra_large" },
+  { label: "Capital (C)", value: "capital" },
 ];
 
 // Edit
@@ -220,6 +225,7 @@ const onSaveCreate = async () => {
         v-model="editForm.shipSize"
         name="edit-ship-size"
         :options="shipSizeOptions"
+        unsorted
         :label="t('labels.dock.shipSize')"
       />
       <FormInput
@@ -264,6 +270,7 @@ const onSaveCreate = async () => {
         v-model="createForm.shipSize"
         name="create-ship-size"
         :options="shipSizeOptions"
+        unsorted
         :label="t('labels.dock.shipSize')"
       />
       <FormInput

--- a/app/frontend/admin/components/Docks/Editor/index.vue
+++ b/app/frontend/admin/components/Docks/Editor/index.vue
@@ -75,28 +75,27 @@ const invalidateDocks = () =>
   });
 
 // Dropdown options
-// Labels match `activerecord.dock.dock_types`, which is what the payload's
-// dockTypeLabel renders. `vehiclepad` is deliberately absent: every row that
-// had it moved to the cargo grid, and nothing new should become one.
-const dockTypeOptions: FilterOption[] = [
-  { label: "Hangar", value: "hangar" },
-  { label: "Landingpad", value: "landingpad" },
-  { label: "Cargo Grid", value: "cargogrid" },
-  { label: "Garage", value: "garage" },
-  { label: "Dockingport", value: "dockingport" },
-];
+// `vehiclepad` is deliberately absent: every row that had it moved to the cargo
+// grid, and nothing new should become one.
+const dockTypeOptions = computed<FilterOption[]>(() =>
+  ["hangar", "landingpad", "cargogrid", "garage", "dockingport"].map(
+    (value) => ({ label: t(`labels.dockTypes.${value}`), value }),
+  ),
+);
 
 // A ladder, so the order is the point -- alphabetical put Capital first and
 // Extra Large between the two smallest. Hence `unsorted` on the select.
-const shipSizeOptions: FilterOption[] = [
-  { label: "Snubcraft (XXS)", value: "extra_extra_small" },
-  { label: "Extra Small (XS)", value: "extra_small" },
-  { label: "Small (S)", value: "small" },
-  { label: "Medium (M)", value: "medium" },
-  { label: "Large (L)", value: "large" },
-  { label: "Extra Large (XL)", value: "extra_large" },
-  { label: "Capital (C)", value: "capital" },
-];
+const shipSizeOptions = computed<FilterOption[]>(() =>
+  [
+    "extra_extra_small",
+    "extra_small",
+    "small",
+    "medium",
+    "large",
+    "extra_large",
+    "capital",
+  ].map((value) => ({ label: t(`labels.shipSizes.${value}`), value })),
+);
 
 // Edit
 const editForm = ref<DockInput>({});
@@ -191,7 +190,7 @@ const onSaveCreate = async () => {
   </div>
 
   <InlineEditableList
-    empty-name="Docks"
+    :empty-name="t('headlines.admin.models.edit.docks')"
     :loading="isLoading"
     ref="editableList"
     :items="(data?.items as Dock[]) || []"

--- a/app/frontend/admin/pages/models/[id]/edit/docks.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/docks.vue
@@ -9,9 +9,9 @@ import DocksEditor from "@/admin/components/Docks/Editor/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { type ModelExtended } from "@/services/fyAdminApi";
 
-type Props = {
+interface Props {
   model: ModelExtended;
-};
+}
 
 defineProps<Props>();
 

--- a/app/frontend/admin/pages/models/modules/[id]/edit/docks.vue
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/docks.vue
@@ -9,9 +9,9 @@ import DocksEditor from "@/admin/components/Docks/Editor/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
 import { type ModelModule } from "@/services/fyAdminApi";
 
-type Props = {
+interface Props {
   modelModule: ModelModule;
-};
+}
 
 defineProps<Props>();
 

--- a/app/frontend/admin/pages/models/modules/[id]/edit/docks.vue
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/docks.vue
@@ -1,16 +1,16 @@
 <script lang="ts">
 export default {
-  name: "AdminModelEditDocksPage",
+  name: "AdminModelModuleEditDocksPage",
 };
 </script>
 
 <script lang="ts" setup>
 import DocksEditor from "@/admin/components/Docks/Editor/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
-import { type ModelExtended } from "@/services/fyAdminApi";
+import { type ModelModule } from "@/services/fyAdminApi";
 
 type Props = {
-  model: ModelExtended;
+  modelModule: ModelModule;
 };
 
 defineProps<Props>();
@@ -20,8 +20,8 @@ const { t } = useI18n();
 
 <template>
   <DocksEditor
-    :parent-id="model.id"
-    parent-type="Model"
-    :headline="t('headlines.admin.models.edit.docks')"
+    :parent-id="modelModule.id"
+    parent-type="ModelModule"
+    :headline="t('headlines.admin.modelModules.docks')"
   />
 </template>

--- a/app/frontend/admin/pages/models/modules/[id]/edit/routes.ts
+++ b/app/frontend/admin/pages/models/modules/[id]/edit/routes.ts
@@ -66,6 +66,18 @@ export const routes: RouteRecordRaw[] = [
     },
   },
   {
+    path: "docks/",
+    name: "admin-model-module-edit-docks",
+    component: () => import("@/admin/pages/models/modules/[id]/edit/docks.vue"),
+    meta: {
+      title: "admin.modelModules.edit.docks",
+      customTitle: true,
+      needsAuthentication: true,
+      nav: "editTabs",
+      activeRoute: "admin-model-modules",
+    },
+  },
+  {
     path: "history/",
     name: "admin-model-module-edit-history",
     component: () =>

--- a/app/frontend/frontend/components/Models/CarriedByList/index.vue
+++ b/app/frontend/frontend/components/Models/CarriedByList/index.vue
@@ -74,7 +74,10 @@ const storeImage = (item: ModelExtendedCarriedByItem) => {
 
                   <template #actions>
                     <Pill :variant="PillVariantsEnum.NEUTRAL" uppercase>
-                      {{ t(`labels.dockTypes.${item.dockType}`) }}
+                      {{
+                        item.moduleName ||
+                        t(`labels.dockTypes.${item.dockType}`)
+                      }}
                     </Pill>
                   </template>
                 </PanelHeading>

--- a/app/frontend/shared/components/base/Select/index.vue
+++ b/app/frontend/shared/components/base/Select/index.vue
@@ -65,6 +65,9 @@ type Props = {
   nullable?: boolean;
   paginated?: boolean;
   noLabel?: boolean;
+  // Options that carry their own order -- a size ladder, a ranking -- where
+  // alphabetical says nothing. Off by default: every existing caller sorts.
+  unsorted?: boolean;
   bigIcon?: boolean;
   hideSelected?: boolean;
   inline?: boolean;
@@ -89,6 +92,7 @@ const props = withDefaults(defineProps<Props>(), {
   nullable: true,
   paginated: false,
   noLabel: false,
+  unsorted: false,
   bigIcon: false,
   hideSelected: false,
   inline: false,
@@ -306,6 +310,10 @@ const searchLabelFallback = computed(() => {
  * "Cannot access 'sort' before initialization" and nothing mounted.
  */
 const sort = (options: FilterOption[]) => {
+  if (props.unsorted) {
+    return options;
+  }
+
   const sortedOptions = JSON.parse(JSON.stringify(options));
   return sortedOptions.sort((a: FilterOption, b: FilterOption) => {
     if (a.label < b.label) {

--- a/app/frontend/translations/de/headlines.json
+++ b/app/frontend/translations/de/headlines.json
@@ -72,6 +72,7 @@
           "models": "Verknüpfte Modelle",
           "prices": "Preise",
           "hardpoints": "Aufhängungspunkte",
+          "docks": "Andockplätze",
           "cargoHolds": "Frachträume",
           "history": "Verlauf"
         },

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -2260,7 +2260,8 @@
         "garage": "Garage",
         "landingpad": "Landeplatz",
         "dockingport": "Andockstutzen",
-        "hangar": "Hangar"
+        "hangar": "Hangar",
+        "cargogrid": "Frachtgitter"
       }
     }
   }

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -971,7 +971,11 @@
       "dock": {
         "name": "Name",
         "dockType": "Dock-Typ",
-        "shipSize": "Schiffsgröße"
+        "shipSize": "Schiffsgröße",
+        "length": "Länge",
+        "beam": "Breite",
+        "height": "Höhe",
+        "unmeasured": "nicht vermessen"
       },
       "modelPosition": {
         "name": "Name",

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -2262,6 +2262,15 @@
         "dockingport": "Andockstutzen",
         "hangar": "Hangar",
         "cargogrid": "Frachtgitter"
+      },
+      "shipSizes": {
+        "extra_extra_small": "Snubcraft (XXS)",
+        "extra_small": "Extra klein (XS)",
+        "small": "Klein (S)",
+        "medium": "Mittel (M)",
+        "large": "Groß (L)",
+        "extra_large": "Extra groß (XL)",
+        "capital": "Kapital (C)"
       }
     }
   }

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -871,6 +871,14 @@
           "success": "Import abgebrochen",
           "error": "Import konnte nicht abgebrochen werden"
         }
+      },
+      "dock": {
+        "create": {
+          "failure": "Andockplatz konnte nicht angelegt werden."
+        },
+        "update": {
+          "failure": "Andockplatz konnte nicht gespeichert werden."
+        }
       }
     }
   }

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -878,6 +878,9 @@
         },
         "update": {
           "failure": "Andockplatz konnte nicht gespeichert werden."
+        },
+        "destroy": {
+          "failure": "Andockplatz konnte nicht gelöscht werden."
         }
       }
     }

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -174,6 +174,7 @@
             "models": "Modelle",
             "prices": "Preise",
             "hardpoints": "Aufhängungspunkte",
+            "docks": "Andockplätze",
             "cargoHolds": "Frachträume",
             "history": "Verlauf"
           }

--- a/app/frontend/translations/de/placeholders.json
+++ b/app/frontend/translations/de/placeholders.json
@@ -194,7 +194,10 @@
         "description": "Beschreibung"
       },
       "dock": {
-        "name": "Dock-Name"
+        "name": "Dock-Name",
+        "length": "Länge in m",
+        "beam": "Breite in m",
+        "height": "Höhe in m"
       },
       "modelPosition": {
         "name": "Positionsname",

--- a/app/frontend/translations/de/title.json
+++ b/app/frontend/translations/de/title.json
@@ -265,6 +265,7 @@
             "models": "%{name} Modelle bearbeiten",
             "prices": "%{name} Preise bearbeiten",
             "hardpoints": "%{name} Hardpoints bearbeiten",
+            "docks": "%{name} Andockplätze bearbeiten",
             "cargoHolds": "%{name} Frachträume bearbeiten",
             "history": "Modul-Verlauf"
           }

--- a/app/frontend/translations/en/headlines.json
+++ b/app/frontend/translations/en/headlines.json
@@ -64,6 +64,7 @@
           "models": "Linked Models",
           "prices": "Prices",
           "hardpoints": "Hardpoints",
+          "docks": "Docks",
           "cargoHolds": "Cargo Holds",
           "history": "History"
         },

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -2259,6 +2259,15 @@
         "dockingport": "Docking port",
         "hangar": "Hangar",
         "cargogrid": "Cargo grid"
+      },
+      "shipSizes": {
+        "extra_extra_small": "Snubcraft (XXS)",
+        "extra_small": "Extra Small (XS)",
+        "small": "Small (S)",
+        "medium": "Medium (M)",
+        "large": "Large (L)",
+        "extra_large": "Extra Large (XL)",
+        "capital": "Capital (C)"
       }
     }
   }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -2257,7 +2257,8 @@
         "garage": "Garage",
         "landingpad": "Landing pad",
         "dockingport": "Docking port",
-        "hangar": "Hangar"
+        "hangar": "Hangar",
+        "cargogrid": "Cargo grid"
       }
     }
   }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -967,7 +967,11 @@
       "dock": {
         "name": "Name",
         "dockType": "Dock Type",
-        "shipSize": "Ship Size"
+        "shipSize": "Ship Size",
+        "length": "Length",
+        "beam": "Beam",
+        "height": "Height",
+        "unmeasured": "not measured"
       },
       "modelPosition": {
         "name": "Name",

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -877,6 +877,9 @@
         },
         "update": {
           "failure": "Could not save the dock."
+        },
+        "destroy": {
+          "failure": "Could not delete the dock."
         }
       }
     }

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -870,6 +870,14 @@
           "success": "Import cancelled",
           "error": "Could not cancel this import"
         }
+      },
+      "dock": {
+        "create": {
+          "failure": "Could not create the dock."
+        },
+        "update": {
+          "failure": "Could not save the dock."
+        }
       }
     }
   }

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -174,6 +174,7 @@
             "models": "Models",
             "prices": "Prices",
             "hardpoints": "Hardpoints",
+            "docks": "Docks",
             "cargoHolds": "Cargo Holds",
             "history": "History"
           }

--- a/app/frontend/translations/en/placeholders.json
+++ b/app/frontend/translations/en/placeholders.json
@@ -194,7 +194,10 @@
         "description": "Description"
       },
       "dock": {
-        "name": "Dock Name"
+        "name": "Dock Name",
+        "length": "Length in m",
+        "beam": "Beam in m",
+        "height": "Height in m"
       },
       "modelPosition": {
         "name": "Position Name",

--- a/app/frontend/translations/en/title.json
+++ b/app/frontend/translations/en/title.json
@@ -265,6 +265,7 @@
             "models": "Edit %{name} Models",
             "prices": "Edit %{name} Prices",
             "hardpoints": "Edit %{name} Hardpoints",
+            "docks": "Edit %{name} Docks",
             "cargoHolds": "Edit %{name} Cargo Holds",
             "history": "Edit Module History"
           }

--- a/app/frontend/translations/es/headlines.json
+++ b/app/frontend/translations/es/headlines.json
@@ -72,6 +72,7 @@
           "models": "Modelos vinculados",
           "prices": "Precios",
           "hardpoints": "Puntos de montaje",
+          "docks": "Muelles",
           "cargoHolds": "Bodegas de carga",
           "history": "Historial de cambios"
         },

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -2262,6 +2262,15 @@
         "dockingport": "Puerto de atraque",
         "hangar": "Hangar",
         "cargogrid": "Rejilla de carga"
+      },
+      "shipSizes": {
+        "extra_extra_small": "Snubcraft (XXS)",
+        "extra_small": "Extra pequeño (XS)",
+        "small": "Pequeño (S)",
+        "medium": "Mediano (M)",
+        "large": "Grande (L)",
+        "extra_large": "Extra grande (XL)",
+        "capital": "Capital (C)"
       }
     }
   }

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -971,7 +971,11 @@
       "dock": {
         "name": "Nombre",
         "dockType": "Tipo de muelle",
-        "shipSize": "Tamaño de nave"
+        "shipSize": "Tamaño de nave",
+        "length": "Longitud",
+        "beam": "Manga",
+        "height": "Altura",
+        "unmeasured": "sin medir"
       },
       "modelPosition": {
         "name": "Nombre",

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -2260,7 +2260,8 @@
         "garage": "Garaje",
         "landingpad": "Plataforma de aterrizaje",
         "dockingport": "Puerto de atraque",
-        "hangar": "Hangar"
+        "hangar": "Hangar",
+        "cargogrid": "Rejilla de carga"
       }
     }
   }

--- a/app/frontend/translations/es/messages.json
+++ b/app/frontend/translations/es/messages.json
@@ -871,6 +871,14 @@
           "success": "Importación cancelada",
           "error": "No se pudo cancelar esta importación"
         }
+      },
+      "dock": {
+        "create": {
+          "failure": "No se pudo crear el muelle."
+        },
+        "update": {
+          "failure": "No se pudo guardar el muelle."
+        }
       }
     }
   }

--- a/app/frontend/translations/es/messages.json
+++ b/app/frontend/translations/es/messages.json
@@ -878,6 +878,9 @@
         },
         "update": {
           "failure": "No se pudo guardar el muelle."
+        },
+        "destroy": {
+          "failure": "No se pudo eliminar el muelle."
         }
       }
     }

--- a/app/frontend/translations/es/nav.json
+++ b/app/frontend/translations/es/nav.json
@@ -174,6 +174,7 @@
             "models": "Modelos",
             "prices": "Precios",
             "hardpoints": "Puntos de Conexión",
+            "docks": "Muelles",
             "cargoHolds": "Bodegas de carga",
             "history": "Historial"
           }

--- a/app/frontend/translations/es/placeholders.json
+++ b/app/frontend/translations/es/placeholders.json
@@ -195,7 +195,10 @@
         "description": "Descripción"
       },
       "dock": {
-        "name": "Nombre del muelle"
+        "name": "Nombre del muelle",
+        "length": "Longitud en m",
+        "beam": "Manga en m",
+        "height": "Altura en m"
       },
       "modelPosition": {
         "name": "Nombre de la posición",

--- a/app/frontend/translations/es/title.json
+++ b/app/frontend/translations/es/title.json
@@ -265,6 +265,7 @@
             "models": "Editar %{name} Modelos",
             "prices": "Editar %{name} Precios",
             "hardpoints": "Editar puntos de montaje de %{name}",
+            "docks": "Editar muelles de %{name}",
             "cargoHolds": "Editar bodegas de carga de %{name}",
             "history": "Editar historial del módulo"
           }

--- a/app/frontend/translations/fr/headlines.json
+++ b/app/frontend/translations/fr/headlines.json
@@ -72,6 +72,7 @@
           "models": "Modèles liés",
           "prices": "Prix",
           "hardpoints": "Points d'attache",
+          "docks": "Quais",
           "cargoHolds": "Soutes à cargaison",
           "history": "Historique"
         },

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -2264,7 +2264,8 @@
         "garage": "Garage",
         "landingpad": "Aire d'atterrissage",
         "dockingport": "Port d'amarrage",
-        "hangar": "Hangar"
+        "hangar": "Hangar",
+        "cargogrid": "Grille de fret"
       }
     }
   }

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -2266,6 +2266,15 @@
         "dockingport": "Port d'amarrage",
         "hangar": "Hangar",
         "cargogrid": "Grille de fret"
+      },
+      "shipSizes": {
+        "extra_extra_small": "Snubcraft (XXS)",
+        "extra_small": "Très petit (XS)",
+        "small": "Petit (S)",
+        "medium": "Moyen (M)",
+        "large": "Grand (L)",
+        "extra_large": "Très grand (XL)",
+        "capital": "Capital (C)"
       }
     }
   }

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -971,7 +971,11 @@
       "dock": {
         "name": "Nom",
         "dockType": "Type de quai",
-        "shipSize": "Taille du vaisseau"
+        "shipSize": "Taille du vaisseau",
+        "length": "Longueur",
+        "beam": "Largeur",
+        "height": "Hauteur",
+        "unmeasured": "non mesuré"
       },
       "modelPosition": {
         "name": "Nom",

--- a/app/frontend/translations/fr/messages.json
+++ b/app/frontend/translations/fr/messages.json
@@ -871,6 +871,14 @@
           "success": "Import annulé",
           "error": "Impossible d'annuler cet import"
         }
+      },
+      "dock": {
+        "create": {
+          "failure": "Impossible de créer le quai."
+        },
+        "update": {
+          "failure": "Impossible d'enregistrer le quai."
+        }
       }
     }
   }

--- a/app/frontend/translations/fr/messages.json
+++ b/app/frontend/translations/fr/messages.json
@@ -878,6 +878,9 @@
         },
         "update": {
           "failure": "Impossible d'enregistrer le quai."
+        },
+        "destroy": {
+          "failure": "Impossible de supprimer le quai."
         }
       }
     }

--- a/app/frontend/translations/fr/nav.json
+++ b/app/frontend/translations/fr/nav.json
@@ -174,6 +174,7 @@
             "models": "Modèles",
             "prices": "Prix",
             "hardpoints": "Points de Fixation",
+            "docks": "Quais",
             "cargoHolds": "Soutes à cargaison",
             "history": "Historique"
           }

--- a/app/frontend/translations/fr/placeholders.json
+++ b/app/frontend/translations/fr/placeholders.json
@@ -195,7 +195,10 @@
         "description": "Description"
       },
       "dock": {
-        "name": "Nom du quai"
+        "name": "Nom du quai",
+        "length": "Longueur en m",
+        "beam": "Largeur en m",
+        "height": "Hauteur en m"
       },
       "modelPosition": {
         "name": "Nom du poste",

--- a/app/frontend/translations/fr/title.json
+++ b/app/frontend/translations/fr/title.json
@@ -265,6 +265,7 @@
             "models": "Éditer %{name} Modèles",
             "prices": "Éditer %{name} Prix",
             "hardpoints": "Modifier les Points de Montage de %{name}",
+            "docks": "Modifier les quais de %{name}",
             "cargoHolds": "Modifier les soutes de %{name}",
             "history": "Modifier l'historique du module"
           }

--- a/app/frontend/translations/it/headlines.json
+++ b/app/frontend/translations/it/headlines.json
@@ -72,6 +72,7 @@
           "models": "Modelli collegati",
           "prices": "Prezzi",
           "hardpoints": "Punti di montaggio",
+          "docks": "Dock",
           "cargoHolds": "Stive di carico",
           "history": "Cronologia"
         },

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -971,7 +971,11 @@
       "dock": {
         "name": "Nome",
         "dockType": "Tipo di dock",
-        "shipSize": "Dimensione nave"
+        "shipSize": "Dimensione nave",
+        "length": "Lunghezza",
+        "beam": "Larghezza",
+        "height": "Altezza",
+        "unmeasured": "non misurato"
       },
       "modelPosition": {
         "name": "Nome",

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -2262,6 +2262,15 @@
         "dockingport": "Porta di attracco",
         "hangar": "Hangar",
         "cargogrid": "Griglia di carico"
+      },
+      "shipSizes": {
+        "extra_extra_small": "Snubcraft (XXS)",
+        "extra_small": "Extra piccolo (XS)",
+        "small": "Piccolo (S)",
+        "medium": "Medio (M)",
+        "large": "Grande (L)",
+        "extra_large": "Extra grande (XL)",
+        "capital": "Capitale (C)"
       }
     }
   }

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -2260,7 +2260,8 @@
         "garage": "Garage",
         "landingpad": "Piazzola di atterraggio",
         "dockingport": "Porta di attracco",
-        "hangar": "Hangar"
+        "hangar": "Hangar",
+        "cargogrid": "Griglia di carico"
       }
     }
   }

--- a/app/frontend/translations/it/messages.json
+++ b/app/frontend/translations/it/messages.json
@@ -877,6 +877,9 @@
         },
         "update": {
           "failure": "Impossibile salvare il dock."
+        },
+        "destroy": {
+          "failure": "Impossibile eliminare il dock."
         }
       }
     }

--- a/app/frontend/translations/it/messages.json
+++ b/app/frontend/translations/it/messages.json
@@ -870,6 +870,14 @@
           "success": "Importazione annullata",
           "error": "Impossibile annullare questa importazione"
         }
+      },
+      "dock": {
+        "create": {
+          "failure": "Impossibile creare il dock."
+        },
+        "update": {
+          "failure": "Impossibile salvare il dock."
+        }
       }
     }
   }

--- a/app/frontend/translations/it/nav.json
+++ b/app/frontend/translations/it/nav.json
@@ -174,6 +174,7 @@
             "models": "Modelli",
             "prices": "Prezzi",
             "hardpoints": "Punti di Attacco",
+            "docks": "Dock",
             "cargoHolds": "Stive di carico",
             "history": "Cronologia"
           }

--- a/app/frontend/translations/it/placeholders.json
+++ b/app/frontend/translations/it/placeholders.json
@@ -195,7 +195,10 @@
         "description": "Descrizione"
       },
       "dock": {
-        "name": "Nome dock"
+        "name": "Nome dock",
+        "length": "Lunghezza in m",
+        "beam": "Larghezza in m",
+        "height": "Altezza in m"
       },
       "modelPosition": {
         "name": "Nome posizione",

--- a/app/frontend/translations/it/title.json
+++ b/app/frontend/translations/it/title.json
@@ -265,6 +265,7 @@
             "models": "Modifica %{name} Modelli",
             "prices": "Modifica %{name} Prezzi",
             "hardpoints": "Modifica Hardpoint di %{name}",
+            "docks": "Modifica dock di %{name}",
             "cargoHolds": "Modifica stive di carico di %{name}",
             "history": "Modifica cronologia del modulo"
           }

--- a/app/frontend/translations/zh-CN/headlines.json
+++ b/app/frontend/translations/zh-CN/headlines.json
@@ -72,6 +72,7 @@
           "models": "关联型号",
           "prices": "价格",
           "hardpoints": "挂载点",
+          "docks": "停靠点",
           "cargoHolds": "货舱",
           "history": "修改历史"
         },

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -971,7 +971,11 @@
       "dock": {
         "name": "名称",
         "dockType": "停靠类型",
-        "shipSize": "飞船尺寸"
+        "shipSize": "飞船尺寸",
+        "length": "长度",
+        "beam": "宽度",
+        "height": "高度",
+        "unmeasured": "未测量"
       },
       "modelPosition": {
         "name": "名称",

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -2258,6 +2258,15 @@
         "dockingport": "对接口",
         "hangar": "机库",
         "cargogrid": "货运格栅"
+      },
+      "shipSizes": {
+        "extra_extra_small": "斯努布克拉夫特 (XXS)",
+        "extra_small": "特小号 (XS)",
+        "small": "小型(S)",
+        "medium": "中号 (M)",
+        "large": "大号（L）",
+        "extra_large": "特大号 (XL)",
+        "capital": "资本（C）"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -2256,7 +2256,8 @@
         "garage": "车库",
         "landingpad": "停机坪",
         "dockingport": "对接口",
-        "hangar": "机库"
+        "hangar": "机库",
+        "cargogrid": "货运格栅"
       }
     }
   }

--- a/app/frontend/translations/zh-CN/messages.json
+++ b/app/frontend/translations/zh-CN/messages.json
@@ -877,6 +877,9 @@
         },
         "update": {
           "failure": "无法保存停靠点。"
+        },
+        "destroy": {
+          "failure": "无法删除停靠点。"
         }
       }
     }

--- a/app/frontend/translations/zh-CN/messages.json
+++ b/app/frontend/translations/zh-CN/messages.json
@@ -870,6 +870,14 @@
           "success": "导入已取消",
           "error": "无法取消此次导入"
         }
+      },
+      "dock": {
+        "create": {
+          "failure": "无法创建停靠点。"
+        },
+        "update": {
+          "failure": "无法保存停靠点。"
+        }
       }
     }
   }

--- a/app/frontend/translations/zh-CN/nav.json
+++ b/app/frontend/translations/zh-CN/nav.json
@@ -174,6 +174,7 @@
             "models": "模型",
             "prices": "价格",
             "hardpoints": "武器挂点",
+            "docks": "停靠点",
             "cargoHolds": "货舱",
             "history": "历史"
           }

--- a/app/frontend/translations/zh-CN/placeholders.json
+++ b/app/frontend/translations/zh-CN/placeholders.json
@@ -195,7 +195,10 @@
         "description": "描述"
       },
       "dock": {
-        "name": "停靠口名称"
+        "name": "停靠口名称",
+        "length": "长度（米）",
+        "beam": "宽度（米）",
+        "height": "高度（米）"
       },
       "modelPosition": {
         "name": "岗位名称",

--- a/app/frontend/translations/zh-CN/title.json
+++ b/app/frontend/translations/zh-CN/title.json
@@ -265,6 +265,7 @@
             "models": "编辑 %{name} 模型",
             "prices": "编辑 %{name} 价格",
             "hardpoints": "编辑 %{name} 挂载点",
+            "docks": "编辑 %{name} 停靠点",
             "cargoHolds": "编辑 %{name} 货舱",
             "history": "编辑模块修改历史"
           }

--- a/app/frontend/translations/zh-TW/headlines.json
+++ b/app/frontend/translations/zh-TW/headlines.json
@@ -72,6 +72,7 @@
           "models": "關聯型號",
           "prices": "價格",
           "hardpoints": "掛載點",
+          "docks": "停靠點",
           "cargoHolds": "貨艙",
           "history": "歷史記錄"
         },

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -971,7 +971,11 @@
       "dock": {
         "name": "名稱",
         "dockType": "停靠類型",
-        "shipSize": "飛船尺寸"
+        "shipSize": "飛船尺寸",
+        "length": "長度",
+        "beam": "寬度",
+        "height": "高度",
+        "unmeasured": "未測量"
       },
       "modelPosition": {
         "name": "名稱",

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -2256,7 +2256,8 @@
         "garage": "車庫",
         "landingpad": "停機坪",
         "dockingport": "對接口",
-        "hangar": "機庫"
+        "hangar": "機庫",
+        "cargogrid": "貨運格柵"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -2258,6 +2258,15 @@
         "dockingport": "對接口",
         "hangar": "機庫",
         "cargogrid": "貨運格柵"
+      },
+      "shipSizes": {
+        "extra_extra_small": "小型飛船 (XXS)",
+        "extra_small": "超小型 (XS)",
+        "small": "小型 (S)",
+        "medium": "中型 (M)",
+        "large": "大型 (L)",
+        "extra_large": "超大型 (XL)",
+        "capital": "主力艦 (C)"
       }
     }
   }

--- a/app/frontend/translations/zh-TW/messages.json
+++ b/app/frontend/translations/zh-TW/messages.json
@@ -870,6 +870,14 @@
           "success": "匯入已取消",
           "error": "無法取消這次匯入"
         }
+      },
+      "dock": {
+        "create": {
+          "failure": "無法建立停靠點。"
+        },
+        "update": {
+          "failure": "無法儲存停靠點。"
+        }
       }
     }
   }

--- a/app/frontend/translations/zh-TW/messages.json
+++ b/app/frontend/translations/zh-TW/messages.json
@@ -877,6 +877,9 @@
         },
         "update": {
           "failure": "無法儲存停靠點。"
+        },
+        "destroy": {
+          "failure": "無法刪除停靠點。"
         }
       }
     }

--- a/app/frontend/translations/zh-TW/nav.json
+++ b/app/frontend/translations/zh-TW/nav.json
@@ -174,6 +174,7 @@
             "models": "模型",
             "prices": "價格",
             "hardpoints": "武器掛點",
+            "docks": "停靠點",
             "cargoHolds": "貨艙",
             "history": "歷史"
           }

--- a/app/frontend/translations/zh-TW/placeholders.json
+++ b/app/frontend/translations/zh-TW/placeholders.json
@@ -195,7 +195,10 @@
         "description": "描述"
       },
       "dock": {
-        "name": "停靠口名稱"
+        "name": "停靠口名稱",
+        "length": "長度（公尺）",
+        "beam": "寬度（公尺）",
+        "height": "高度（公尺）"
       },
       "modelPosition": {
         "name": "職位名稱",

--- a/app/frontend/translations/zh-TW/title.json
+++ b/app/frontend/translations/zh-TW/title.json
@@ -265,6 +265,7 @@
             "models": "編輯 %{name} 模型",
             "prices": "編輯 %{name} 價格",
             "hardpoints": "編輯 %{name} 掛載點",
+            "docks": "編輯 %{name} 停靠點",
             "cargoHolds": "編輯 %{name} 貨艙",
             "history": "編輯模組歷史記錄"
           }

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -42,6 +42,13 @@ class Dock < ApplicationRecord
     parent.table[:ship_size]
   end
 
+  # The module this berth arrives with, and nil when it is built into the hull.
+  # A module berth is conditional -- whether the ship is carrying that module is
+  # the player's choice -- so it is named rather than presented as a fixture.
+  def model_module_name
+    parent.name if parent_type == "ModelModule"
+  end
+
   def self.ransackable_attributes(auth_object = nil)
     [
       "beam", "created_at", "dock_type", "group", "height", "id", "id_value", "length",

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -35,12 +35,6 @@ class Dock < ApplicationRecord
 
   validates :parent_type, inclusion: {in: PARENT_TYPES}
 
-  # The admin form used to preselect landingpad/medium for anyone who did not
-  # touch the dropdowns, so a garage could be saved as a landing pad and offered
-  # to ships. The form now starts empty, which only works if a berth with no
-  # type cannot be stored. All 28 ship docks carry both today.
-  validates :dock_type, :ship_size, presence: true
-
   enum :dock_type,
     {vehiclepad: 0, garage: 1, landingpad: 2, dockingport: 3, hangar: 4}
   ransacker :dock_type, formatter: proc { |v| Dock.dock_types[v] } do |parent|

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -35,6 +35,12 @@ class Dock < ApplicationRecord
 
   validates :parent_type, inclusion: {in: PARENT_TYPES}
 
+  # The admin form used to preselect landingpad/medium for anyone who did not
+  # touch the dropdowns, so a garage could be saved as a landing pad and offered
+  # to ships. The form now starts empty, which only works if a berth with no
+  # type cannot be stored. All 28 ship docks carry both today.
+  validates :dock_type, :ship_size, presence: true
+
   enum :dock_type,
     {vehiclepad: 0, garage: 1, landingpad: 2, dockingport: 3, hangar: 4}
   ransacker :dock_type, formatter: proc { |v| Dock.dock_types[v] } do |parent|

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -13,13 +13,19 @@
 #  max_ship_size :integer
 #  min_ship_size :integer
 #  name          :string
+#  parent_type   :string           not null
 #  ship_size     :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  model_id      :uuid
+#  parent_id     :uuid             not null
+#
+# Indexes
+#
+#  index_docks_on_parent_type_and_parent_id  (parent_type,parent_id)
 #
 class Dock < ApplicationRecord
-  belongs_to :model, optional: true
+  belongs_to :parent, polymorphic: true, touch: true
 
   enum :dock_type,
     {vehiclepad: 0, garage: 1, landingpad: 2, dockingport: 3, hangar: 4}
@@ -39,7 +45,8 @@ class Dock < ApplicationRecord
   def self.ransackable_attributes(auth_object = nil)
     [
       "beam", "created_at", "dock_type", "group", "height", "id", "id_value", "length",
-      "max_ship_size", "min_ship_size", "model_id", "name", "ship_size", "station_id", "updated_at"
+      "max_ship_size", "min_ship_size", "name", "parent_id", "parent_type", "ship_size",
+      "updated_at"
     ]
   end
 

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -35,8 +35,16 @@ class Dock < ApplicationRecord
 
   validates :parent_type, inclusion: {in: PARENT_TYPES}
 
+  # `cargogrid` is the berth that costs cargo capacity -- the Hammerhead's
+  # cargo lift, the Polaris, the Hercules cargo bay -- as opposed to a garage
+  # built for vehicles and nothing else, which is what the Carrack has.
+  #
+  # `vehiclepad` is what it replaces. Every one of the five that existed was
+  # named "Cargo" or "Cargolift", so the split it was meant to express was
+  # already being carried by the name. It stays in the enum because the public
+  # schema exposes these values and a row anywhere still has to read.
   enum :dock_type,
-    {vehiclepad: 0, garage: 1, landingpad: 2, dockingport: 3, hangar: 4}
+    {vehiclepad: 0, garage: 1, landingpad: 2, dockingport: 3, hangar: 4, cargogrid: 5}
   ransacker :dock_type, formatter: proc { |v| Dock.dock_types[v] } do |parent|
     parent.table[:dock_type]
   end
@@ -131,7 +139,7 @@ class Dock < ApplicationRecord
   # from a landing pad. A docking port is in neither list -- it is a connection,
   # not a place a hull is set down.
   SHIP_DOCK_TYPES = %w[landingpad hangar].freeze
-  VEHICLE_DOCK_TYPES = %w[vehiclepad garage].freeze
+  VEHICLE_DOCK_TYPES = %w[vehiclepad garage cargogrid].freeze
 
   SHIP_CLEARANCE = {length: 2.0, beam: 2.0, height: 1.0}.freeze
   VEHICLE_CLEARANCE = {length: 1.0, beam: 1.0, height: 0.5}.freeze

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -41,6 +41,13 @@ class Dock < ApplicationRecord
   validates :parent_id, presence: true
   validates :parent_type, inclusion: {in: PARENT_TYPES}
 
+  # And the row has to be there. Making the association optional took that check
+  # away with the constantizing, so a known type and any UUID at all would have
+  # saved a dock pointing at nothing -- the orphans #4864 deleted, by a new
+  # route. Guarded on the type, so this is the only place that resolves the
+  # association and it only does so for a name that is safe to constantize.
+  validates :parent, presence: true, if: -> { parent_type.in?(PARENT_TYPES) }
+
   # `cargogrid` is the berth that costs cargo capacity -- the Hammerhead's
   # cargo lift, the Polaris, the Hercules cargo bay -- as opposed to a garage
   # built for vehicles and nothing else, which is what the Carrack has.

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -26,13 +26,19 @@
 #
 class Dock < ApplicationRecord
   # A hull or a module, and nothing else. `parent_type` is a plain string
-  # column, so without this the admin API would take any class name at all and
-  # a dock could end up hanging off a User -- a new way to grow the orphans
-  # #4864 had to delete.
+  # column, so without this a dock could end up hanging off a User -- a new way
+  # to grow the orphans #4864 had to delete -- and `touch: true` would keep
+  # updating that unrelated row.
   PARENT_TYPES = %w[Model ModelModule].freeze
 
-  belongs_to :parent, polymorphic: true, touch: true
+  # `optional` and then required by hand, rather than letting `belongs_to` do
+  # it. Its presence check resolves the association, which constantizes
+  # `parent_type` -- so a class name that does not exist raises NameError out of
+  # validation instead of coming back as an invalid record. The two validations
+  # below answer the same question without ever touching the association.
+  belongs_to :parent, polymorphic: true, touch: true, optional: true
 
+  validates :parent_id, presence: true
   validates :parent_type, inclusion: {in: PARENT_TYPES}
 
   # `cargogrid` is the berth that costs cargo capacity -- the Hammerhead's

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -25,7 +25,15 @@
 #  index_docks_on_parent_type_and_parent_id  (parent_type,parent_id)
 #
 class Dock < ApplicationRecord
+  # A hull or a module, and nothing else. `parent_type` is a plain string
+  # column, so without this the admin API would take any class name at all and
+  # a dock could end up hanging off a User -- a new way to grow the orphans
+  # #4864 had to delete.
+  PARENT_TYPES = %w[Model ModelModule].freeze
+
   belongs_to :parent, polymorphic: true, touch: true
+
+  validates :parent_type, inclusion: {in: PARENT_TYPES}
 
   enum :dock_type,
     {vehiclepad: 0, garage: 1, landingpad: 2, dockingport: 3, hangar: 4}

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -330,6 +330,10 @@ class Model < ApplicationRecord
     through: :module_hardpoints,
     source: :model_module
 
+  # Berths that arrive with a module rather than being built into the hull --
+  # the Galaxy's med bay carries a vehicle lift, its refinery does not.
+  has_many :module_docks, through: :modules, source: :docks
+
   has_many :module_packages,
     class_name: "ModelModulePackage",
     dependent: :destroy
@@ -654,8 +658,16 @@ class Model < ApplicationRecord
     ["dimensions_drifted"]
   end
 
+  # A ship offers a berth either because one is built into it or because a
+  # module it can mount brings one. Two subqueries rather than a join: a model
+  # with several docks would otherwise come back several times.
   def self.with_dock
-    includes(:docks).where.not(docks: {id: nil})
+    own = Dock.where(parent_type: "Model").select(:parent_id)
+    through_modules = ModuleHardpoint
+      .where(model_module_id: Dock.where(parent_type: "ModelModule").select(:parent_id))
+      .select(:model_id)
+
+    where(id: own).or(where(id: through_modules))
   end
 
   def update_from_hardpoints
@@ -819,11 +831,19 @@ class Model < ApplicationRecord
     return [] if length.to_f <= 0 || beam.to_f <= 0 || height.to_f <= 0
 
     Model.visible.active.with_dock.with_attached_store_image.where.not(id:)
+      .preload(:docks, module_docks: :parent)
       .filter_map do |carrier|
-        dock = carrier.docks.find { |candidate| candidate.fits?(self) }
+        dock = carrier.berths.find { |candidate| candidate.fits?(self) }
         {carrier:, dock:} if dock
       end
       .sort_by { |entry| entry[:carrier].name }
+  end
+
+  # Every berth this ship can offer, whichever side it comes from. A module
+  # berth is conditional -- the Galaxy takes a med bay or a refinery, never both
+  # -- and `Dock#model_module_name` is what says so on the way out.
+  def berths
+    docks.to_a + module_docks.to_a
   end
 
   def carried_by

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -382,7 +382,7 @@ class Model < ApplicationRecord
 
   has_many :model_positions, dependent: :destroy
 
-  has_many :docks, dependent: :destroy
+  has_many :docks, as: :parent, dependent: :destroy
 
   has_many :cargo_holds_db, class_name: "CargoHold", as: :parent, dependent: :destroy
   has_many :cargo_hold_container_capacities, through: :cargo_holds_db
@@ -655,7 +655,7 @@ class Model < ApplicationRecord
   end
 
   def self.with_dock
-    includes(:docks).where.not(docks: {model_id: nil})
+    includes(:docks).where.not(docks: {id: nil})
   end
 
   def update_from_hardpoints

--- a/app/models/model_module.rb
+++ b/app/models/model_module.rb
@@ -50,6 +50,7 @@ class ModelModule < ApplicationRecord
   has_many :item_prices, as: :item, dependent: :destroy
 
   has_many :cargo_holds_db, class_name: "CargoHold", as: :parent, dependent: :destroy
+  has_many :docks, as: :parent, dependent: :destroy
 
   serialize :cargo_holds, coder: YAML
 

--- a/app/views/admin/api/v1/docks/_base.jbuilder
+++ b/app/views/admin/api/v1/docks/_base.jbuilder
@@ -12,6 +12,7 @@ json.beam dock.beam&.to_f
 json.height dock.height&.to_f
 json.min_ship_size dock.min_ship_size
 json.max_ship_size dock.max_ship_size
-json.model_id dock.model_id
+json.parent_id dock.parent_id
+json.parent_type dock.parent_type
 
 json.partial! "api/shared/dates", record: dock

--- a/app/views/api/v1/models/show.jbuilder
+++ b/app/views/api/v1/models/show.jbuilder
@@ -11,6 +11,11 @@ json.carried_by @model.carried_by_with_docks do |entry|
   json.name carrier.name
   json.dock_type entry[:dock].dock_type
 
+  # Present only for a berth a module brings, which is what makes the carrier
+  # conditional rather than a fixture.
+  module_name = entry[:dock].model_module_name
+  json.module_name module_name if module_name.present?
+
   # Absent rather than empty when the carrier has no picture: MediaFile requires
   # four fields, and the panel falls back on its own.
   if carrier.store_image.attached?

--- a/config/locales/de/activerecord.yml
+++ b/config/locales/de/activerecord.yml
@@ -52,6 +52,7 @@ de:
           infrared: Infrarot
       dock:
         dock_types:
+          cargogrid: Frachtgitter
           dockingport: Andockport
           garage: Garage
           hangar: Hangar

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -52,6 +52,7 @@ en:
           infrared: infrared
       dock:
         dock_types:
+          cargogrid: Cargo Grid
           dockingport: Dockingport
           garage: Garage
           hangar: Hangar

--- a/config/locales/es/activerecord.yml
+++ b/config/locales/es/activerecord.yml
@@ -52,6 +52,7 @@ es:
           infrared: infrarrojo
       dock:
         dock_types:
+          cargogrid: Rejilla de carga
           dockingport: Puerto de acoplamiento
           garage: Garaje
           hangar: Hangar

--- a/config/locales/fr/activerecord.yml
+++ b/config/locales/fr/activerecord.yml
@@ -52,6 +52,7 @@ fr:
           infrared: infrarouge
       dock:
         dock_types:
+          cargogrid: Grille de fret
           dockingport: Port d'amarrage
           garage: Garage
           hangar: Hangar

--- a/config/locales/it/activerecord.yml
+++ b/config/locales/it/activerecord.yml
@@ -52,6 +52,7 @@ it:
           infrared: infrarosso
       dock:
         dock_types:
+          cargogrid: Griglia di carico
           dockingport: Porta di attracco
           garage: Garage
           hangar: Hangar

--- a/config/locales/zh-CN/activerecord.yml
+++ b/config/locales/zh-CN/activerecord.yml
@@ -52,6 +52,7 @@ zh-CN:
           infrared: 红外
       dock:
         dock_types:
+          cargogrid: 货运格栅
           dockingport: 对接端口
           garage: 车库
           hangar: 机库

--- a/config/locales/zh-TW/activerecord.yml
+++ b/config/locales/zh-TW/activerecord.yml
@@ -52,6 +52,7 @@ zh-TW:
           infrared: 紅外
       dock:
         dock_types:
+          cargogrid: 貨運格柵
           dockingport: 對接口
           garage: 車庫
           hangar: 機庫

--- a/db/data/20260911180000_move_vehicle_pads_to_the_cargo_grid.rb
+++ b/db/data/20260911180000_move_vehicle_pads_to_the_cargo_grid.rb
@@ -13,29 +13,26 @@
 # or Cargobay and six are dedicated bays, and only somebody who knows the ships
 # can say which is which. That is a curation pass, not a migration.
 class MoveVehiclePadsToTheCargoGrid < ActiveRecord::Migration[8.1]
-  # What identified the five in the first place, and the only thing that can
-  # identify them again afterwards. `up` moves every vehicle pad; every one of
-  # them happens to be named this way, which is the evidence the move rests on.
-  MOVED_NAMES = "Cargo%"
-
   def up
     moved = Dock.where(dock_type: :vehiclepad).update_all(dock_type: Dock.dock_types[:cargogrid])
 
     say("moved #{moved} vehicle pad(s) to the cargo grid")
   end
 
+  # Not reversible, and no heuristic makes it so. Nothing on a dock records
+  # which type it used to carry, and the editor offers `cargogrid` now -- so
+  # after this runs, a row curated by hand is indistinguishable from one this
+  # migration moved. Scoping the reverse to the names the five happened to have
+  # was the first attempt and is no better: an admin can name a new one "Cargo"
+  # too.
+  #
+  # Turning somebody's curation back into a legacy type is worse than refusing,
+  # and the forward direction is five rows. Undo it by hand if it ever needs
+  # undoing.
   def down
-    # Not every cargo grid came from here. The admin can create one now, and
-    # turning those back into vehicle pads would undo curation this migration
-    # never touched -- so the reverse is scoped to the names that identified the
-    # original five, and says what it left alone.
-    scope = Dock.where(dock_type: :cargogrid)
-    revertible = scope.where("docks.name ILIKE ?", MOVED_NAMES)
-
-    kept = scope.count - revertible.count
-    moved = revertible.update_all(dock_type: Dock.dock_types[:vehiclepad])
-
-    say("moved #{moved} cargo grid(s) back to vehicle pads")
-    say("left #{kept} cargo grid(s) alone: they were not named by this migration") if kept.positive?
+    raise ActiveRecord::IrreversibleMigration,
+      "nothing records which docks were vehicle pads before this ran, and the " \
+      "admin can create a cargo grid now -- reverting would take hand-curated " \
+      "rows with it. Set the types back by hand if this really has to go."
   end
 end

--- a/db/data/20260911180000_move_vehicle_pads_to_the_cargo_grid.rb
+++ b/db/data/20260911180000_move_vehicle_pads_to_the_cargo_grid.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# `vehiclepad` never expressed what it was meant to. It was supposed to separate
+# a berth on the cargo grid from a dedicated vehicle bay, and it did not: the
+# Carrack's dedicated garage and the Hammerhead's cargo lift were both reachable
+# under either value, and the dimensions matched too.
+#
+# What did carry the distinction was the name. All five surviving `vehiclepad`
+# rows are called "Cargo" or "Cargolift" -- Valkyrie, Hammerhead, and the three
+# Hercules -- so every one of them is a cargo grid, and this moves them.
+#
+# The mixed `garage` rows are not touched. Six of the twelve are named Cargohold
+# or Cargobay and six are dedicated bays, and only somebody who knows the ships
+# can say which is which. That is a curation pass, not a migration.
+class MoveVehiclePadsToTheCargoGrid < ActiveRecord::Migration[8.1]
+  def up
+    moved = Dock.where(dock_type: :vehiclepad).update_all(dock_type: Dock.dock_types[:cargogrid])
+
+    say("moved #{moved} vehicle pad(s) to the cargo grid")
+  end
+
+  def down
+    Dock.where(dock_type: :cargogrid).update_all(dock_type: Dock.dock_types[:vehiclepad])
+  end
+end

--- a/db/data/20260911180000_move_vehicle_pads_to_the_cargo_grid.rb
+++ b/db/data/20260911180000_move_vehicle_pads_to_the_cargo_grid.rb
@@ -13,6 +13,11 @@
 # or Cargobay and six are dedicated bays, and only somebody who knows the ships
 # can say which is which. That is a curation pass, not a migration.
 class MoveVehiclePadsToTheCargoGrid < ActiveRecord::Migration[8.1]
+  # What identified the five in the first place, and the only thing that can
+  # identify them again afterwards. `up` moves every vehicle pad; every one of
+  # them happens to be named this way, which is the evidence the move rests on.
+  MOVED_NAMES = "Cargo%"
+
   def up
     moved = Dock.where(dock_type: :vehiclepad).update_all(dock_type: Dock.dock_types[:cargogrid])
 
@@ -20,6 +25,17 @@ class MoveVehiclePadsToTheCargoGrid < ActiveRecord::Migration[8.1]
   end
 
   def down
-    Dock.where(dock_type: :cargogrid).update_all(dock_type: Dock.dock_types[:vehiclepad])
+    # Not every cargo grid came from here. The admin can create one now, and
+    # turning those back into vehicle pads would undo curation this migration
+    # never touched -- so the reverse is scoped to the names that identified the
+    # original five, and says what it left alone.
+    scope = Dock.where(dock_type: :cargogrid)
+    revertible = scope.where("docks.name ILIKE ?", MOVED_NAMES)
+
+    kept = scope.count - revertible.count
+    moved = revertible.update_all(dock_type: Dock.dock_types[:vehiclepad])
+
+    say("moved #{moved} cargo grid(s) back to vehicle pads")
+    say("left #{kept} cargo grid(s) alone: they were not named by this migration") if kept.positive?
   end
 end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 2026_09_11_131018)
+DataMigrate::Data.define(version: 2026_09_11_180000)

--- a/db/migrate/20260911150000_give_docks_a_polymorphic_parent.rb
+++ b/db/migrate/20260911150000_give_docks_a_polymorphic_parent.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# A dock belongs to something, and until now that something could only be a
+# model -- or nothing at all, since `model_id` was nullable. Both halves were
+# wrong. The Galaxy's medic module carries a vehicle lift, and the Caterpillar
+# may get one, so a dock hangs off a `ModelModule` just as readily as off a
+# ship. `cargo_holds` already works this way and is the shape copied here.
+#
+# Nullable was never a state that meant anything: #4864 deleted the 391 rows
+# that had drifted into it, all of them left over from a 2021 station script.
+#
+# `model_id` stays behind for one release. The running containers are migrated
+# before the new ones boot, so a column the old code still selects cannot be
+# dropped in the same deploy without 500ing every dock read in between.
+class GiveDocksAPolymorphicParent < ActiveRecord::Migration[8.1]
+  def up
+    add_column :docks, :parent_type, :string
+    add_column :docks, :parent_id, :uuid
+
+    execute(<<~SQL)
+      UPDATE docks
+      SET parent_type = 'Model', parent_id = model_id
+      WHERE model_id IS NOT NULL
+    SQL
+
+    # #4864 cleared these, so this is a guard rather than a step: a dock with no
+    # parent cannot be expressed once the columns are NOT NULL, and silently
+    # keeping one is not an option the schema leaves open.
+    orphans = select_value("SELECT COUNT(*) FROM docks WHERE parent_id IS NULL").to_i
+    if orphans.positive?
+      say("deleting #{orphans} dock(s) that belong to nothing")
+      execute("DELETE FROM docks WHERE parent_id IS NULL")
+    end
+
+    change_column_null :docks, :parent_type, false
+    change_column_null :docks, :parent_id, false
+
+    add_index :docks, [:parent_type, :parent_id]
+  end
+
+  def down
+    remove_index :docks, [:parent_type, :parent_id]
+
+    # Only the model-owned docks can be expressed by `model_id`; a dock on a
+    # module has nowhere to go and would come back pointing at the wrong ship.
+    execute("DELETE FROM docks WHERE parent_type <> 'Model'")
+    execute("UPDATE docks SET model_id = parent_id WHERE parent_type = 'Model'")
+
+    remove_column :docks, :parent_id
+    remove_column :docks, :parent_type
+  end
+end

--- a/db/migrate/20260911150000_give_docks_a_polymorphic_parent.rb
+++ b/db/migrate/20260911150000_give_docks_a_polymorphic_parent.rb
@@ -12,6 +12,13 @@
 # `model_id` stays behind for one release. The running containers are migrated
 # before the new ones boot, so a column the old code still selects cannot be
 # dropped in the same deploy without 500ing every dock read in between.
+#
+# Reads are what that protects. Writes are not: for the length of the pre-deploy
+# window the old code still creates docks with `model_id` alone, and the NOT NULL
+# below rejects those. The alternative is two releases -- nullable here, enforced
+# later -- and the trade was made knowingly: the catalogue holds 28 docks in
+# total, creating one is a rare admin action, and the failure is a retryable
+# error on that one request rather than anything the data carries afterwards.
 class GiveDocksAPolymorphicParent < ActiveRecord::Migration[8.1]
   def up
     add_column :docks, :parent_type, :string
@@ -41,9 +48,17 @@ class GiveDocksAPolymorphicParent < ActiveRecord::Migration[8.1]
   def down
     remove_index :docks, [:parent_type, :parent_id]
 
-    # Only the model-owned docks can be expressed by `model_id`; a dock on a
-    # module has nowhere to go and would come back pointing at the wrong ship.
-    execute("DELETE FROM docks WHERE parent_type <> 'Model'")
+    # `model_id` cannot express a dock on a module, so rolling back would have to
+    # throw those rows away. A rollback is usually run to get out of an
+    # unrelated problem, and losing curation nobody was thinking about is not an
+    # acceptable side effect of that -- so it refuses instead.
+    orphaned = select_value("SELECT COUNT(*) FROM docks WHERE parent_type <> 'Model'").to_i
+    if orphaned.positive?
+      raise ActiveRecord::IrreversibleMigration,
+        "#{orphaned} dock(s) hang off something other than a Model and cannot be " \
+        "expressed by model_id. Move or delete them first if this really has to roll back."
+    end
+
     execute("UPDATE docks SET model_id = parent_id WHERE parent_type = 'Model'")
 
     remove_column :docks, :parent_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_09_11_133041) do
+ActiveRecord::Schema[8.1].define(version: 2026_09_11_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
   enable_extension "pg_catalog.plpgsql"
@@ -315,8 +315,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_09_11_133041) do
     t.integer "min_ship_size"
     t.uuid "model_id"
     t.string "name"
+    t.uuid "parent_id", null: false
+    t.string "parent_type", null: false
     t.integer "ship_size"
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["parent_type", "parent_id"], name: "index_docks_on_parent_type_and_parent_id"
   end
 
   create_table "email_rejections", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/docs/exec-plans/4863-berth-model.md
+++ b/docs/exec-plans/4863-berth-model.md
@@ -77,6 +77,10 @@ So `docks` wants `parent_type` / `parent_id`, **not optional**: a dock always be
 
 Sequenced after #4864 and #4856: the orphans have to go first — they would have no parent — and `Model.with_dock` is what #4856 builds on, so reshaping under it would mean rebasing seven commits against a schema change.
 
+**Done.** `model_id` stays on the table for one release: the pre-deploy migration runs against the containers still serving the old code, and that code selects the column. Dropping it in the same deploy 500s every dock read in the window between. A follow-up removes it.
+
+The admin API moved with it — `modelId` became `parentId` + `parentType` on the payload, the input and the query — and the docks editor is now one component both the model and the module pages render, so a module dock can actually be created rather than merely expressed.
+
 Touches `Model.with_dock`, the dock associations on `Model` and newly on `ModelModule`, `docks_controller` (`model_id_eq` and the create params), `dock_input` and `dock_query`, and three places in `admin/pages/models/[id]/edit/docks.vue`.
 
 ### D2 — `size`, never `ground`
@@ -119,12 +123,13 @@ Letting players record what a specific berth holds — "the garage on my Carrack
 
 ## Discovery Log
 
+- **2026-09-11** D1 built. Two columns turned out not to exist at all: `dock.rb` annotated a `ramp` boolean, and `ransackable_attributes` offered `station_id` — the same 2021 station era that left the 391 orphans. Neither was reachable, both are gone.
 - **2026-09-11** Written after #4856. The polymorphic parent (D1) came out of a question about modules mid-review, and stopped that PR from shipping a `NOT NULL model_id` that would have had to be undone.
 - **2026-09-10/11** Measurements taken while building #4856. Two of them corrected earlier conclusions of mine: the dock data is healthy once the 391 orphans are excluded, and `ground` is not what distinguishes a vehicle.
 
 ## Progress
 
-- [ ] D1 — polymorphic parent, after #4864 and #4856
+- [x] D1 — polymorphic parent, after #4864 and #4856
 - [ ] Vehicle class ladder, curated
 - [ ] Pads: count and size per berth
 - [ ] Access: ramp / lift / tractor beam, on the label

--- a/docs/exec-plans/4863-berth-model.md
+++ b/docs/exec-plans/4863-berth-model.md
@@ -43,21 +43,38 @@ A ladder of t-shirt sizes rather than measurements, because "holds an Ursa" is t
 
 ATLS → hover bikes (Dragonfly down to Pulse) → PTV/UTV → Cyclone → Ursa → Nova/Ballista
 
-The ladder is visible in the data. Ground vehicles by volume (m³):
+A **proposal** for the curation pass, not a derivation. Six anchors from @mortik; the seventh size is left open rather than invented. The 44 vehicles fall out roughly as:
 
-| class | vehicles | volume |
+| size | anchor | vehicles |
+|---|---|---|
+| `extra_extra_small` | ATLS | ATLS, ATLS GEO |
+| `extra_small` | hover bikes | Pulse, Pulse LX, Nox, Nox Kue, HoverQuad, X1, X1 Force, X1 Velocity, Dragonfly ×3 |
+| `small` | PTV / UTV | PTV, UTV, STV, Ranger CV/RC/TR |
+| `medium` | Cyclone | Cyclone ×6, Mule, ROC, CSV-SM, MDC, MTC |
+| `large` | Ursa | Ursa, Ursa Fortuna, Ursa Medivac, Lynx, ROC-DS, G12 ×3 |
+| `extra_large` | Storm | Storm, Storm AA |
+| `extra_extra_large` | Nova / Ballista | Nova, Centurion, Spartan, Ballista |
+
+Three placements are guesses and want a decision: the **Dragonfly** sits at 63–72 m³, Cyclone territory by volume, yet it is a bike and stows like one. The **Storm** at 284 m³ is alone between the Ursa and the Nova. And **MDC/MTC** at 77 m³ sit between the Cyclone and the Ursa with nothing to break the tie.
+
+Volume gets the rough shape right and the boundaries wrong, which is the whole argument for curating it rather than deriving it. Two families prove the point.
+
+**The Cyclone.** Recorded 6.0 × 8.75 × 3.5 — wider than long, wider than an Ursa — so 184 m³ against the Ursa's 92, a class above the vehicle it sits beside. `Cyclone MT` at 6.0 × 4.0 × 2.5 is sane, so the family disagrees with itself. This is the class where "does it fit the Carrack garage" is decided.
+
+**The Ursa.** Not a class question, and not quite a data error either.
+
+| | L × B × H | m³ |
 |---|---|---:|
-| ATLS | ATLS, ATLS GEO | 10 |
-| bikes / small | PTV, Ranger ×3 | 13–15 |
-| UTV/STV | UTV, STV | 23 |
-| Cyclone | Cyclone MT, ROC, CSV-SM | 60–62 |
-| Ursa | MTC, MDC, Ursa, ROC-DS, G12 | 77–113 |
-| large | Ursa Medivac, Lynx, Storm | 141–284 |
-| Nova/Ballista | Nova, Centurion, Spartan, Ballista | 560–655 |
+| Ursa | 7.60 × 5.50 × **2.20** | 92 |
+| Ursa Fortuna | 7.60 × 5.50 × **2.20** | 92 |
+| Ursa Medivac | 8.00 × 5.50 × **3.20** | 141 |
+| Lynx *(different chassis)* | 7.75 × 5.70 × 3.50 | 155 |
+
+The Ursa carries a turret that can be lowered, so it has two legitimate heights. **2.20 is the lowered figure**, and it is the one to keep: a vehicle that can make itself shorter to get into a bay should be judged on the shorter measurement. The Medivac is the same chassis with a different interior and is to be corrected to 2.20.
+
+Grouped by volume this reads as two classes. It is one class, one retractable turret, and one row that measured the other configuration.
 
 The ATLS is its own smallest class at half a PTV, and its rule of thumb — fits wherever two 1 SCU boxes stack — checks out: 1 SCU is a 1.25 m cube, so two is 2.5 m against a recorded ATLS height of 2.8 m.
-
-**It cannot be derived.** The Cyclone base variants are recorded as 6.0 × **8.75** × 3.5 — wider than long, wider than an Ursa — which puts Cyclone above Ursa by volume and inverts the real order, on exactly the class where "does it fit the Carrack" is decided. `Cyclone MT` at 6.0 × 4.0 × 2.5 is sane, so the family disagrees with itself.
 
 ### Access — how a vehicle gets in
 
@@ -111,11 +128,21 @@ Code cannot answer these; they need somebody who knows the ships.
 
 The Idris is the tell that the column already carries two meanings.
 
+**Variants that are not linked.** None of the Ursa, Ursa Fortuna or Ursa Medivac carries a `base_model_id`, so they are not recorded as variants of one another and none appears in the others' variants section.
+
 **Unmeasured ship docks:** the Merchantman hangar and both of the Odyssey's docking collars. Silent today rather than wrong, since an unmeasured dock declines to answer.
 
 **Vehicle dock outliers:** the three listed above.
 
-**Cyclone dimensions:** filed separately; the beam is wrong and it misorders the class ladder.
+**Cyclone dimensions:** the beam is wrong and it misorders the ladder. **Ursa Medivac:** to be corrected to 2.20, matching the chassis it shares with the Ursa. Per @mortik. Both filed separately.
+
+### The extended columns are already there, and empty
+
+`models` carries `extended_length`, `extended_beam` and `extended_height`. They are populated on **0 of 245** models.
+
+They are not vestigial: they are rendered into `metrics`, and the fleetchart's extended toggle decides whether to appear by asking `model.metrics.extendedLength`. So a whole control is unreachable because nobody ever filled the data behind it.
+
+This is where a second configuration belongs — the Ursa with its turret raised, or anything else that unfolds. It also means #4856 is accidentally right today: it compares `height`, which for the Ursa is the lowered figure, and a berth should be judged on the smaller of the two. It would be wrong the moment a model is recorded in its extended state instead.
 
 ## Not in this plan
 
@@ -123,8 +150,10 @@ Letting players record what a specific berth holds — "the garage on my Carrack
 
 ## Discovery Log
 
+- **2026-09-11** Four commits refining this plan — the ladder table and the Ursa correction — were pushed to `docs/4863-berth-model` after #4865 had already merged, so they sat on a dead branch and never reached main. Recovered here. A merged PR does not stop accepting pushes; it stops delivering them.
 - **2026-09-11** D1 built. Two columns turned out not to exist at all: `dock.rb` annotated a `ramp` boolean, and `ransackable_attributes` offered `station_id` — the same 2021 station era that left the 391 orphans. Neither was reachable, both are gone.
 - **2026-09-11** Written after #4856. The polymorphic parent (D1) came out of a question about modules mid-review, and stopped that PR from shipping a `NOT NULL model_id` that would have had to be undone.
+- **2026-09-11** The Ursa family was grouped by volume into two classes and corrected by @mortik — one class, one under-recorded height. Written down because it is the second time volume misled here, and the first draft of this plan made exactly the mistake the plan warns about.
 - **2026-09-10/11** Measurements taken while building #4856. Two of them corrected earlier conclusions of mine: the dock data is healthy once the 391 orphans are excluded, and `ground` is not what distinguishes a vehicle.
 
 ## Progress

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -10478,9 +10478,11 @@ components:
           type: integer
         maxShipSize:
           type: integer
-        modelId:
+        parentId:
           type: string
           format: uuid
+        parentType:
+          type: string
         createdAt:
           type: string
           format: date-time
@@ -10494,6 +10496,8 @@ components:
       - dockTypeLabel
       - shipSize
       - shipSizeLabel
+      - parentId
+      - parentType
       - createdAt
       - updatedAt
       title: Dock
@@ -10550,19 +10554,21 @@ components:
           type:
           - integer
           - 'null'
-        modelId:
-          type:
-          - string
-          - 'null'
+        parentId:
+          type: string
           format: uuid
+        parentType:
+          type: string
       additionalProperties: false
       title: DockInput
     DockQuery:
       type: object
       properties:
-        modelIdEq:
+        parentIdEq:
           type: string
           format: uuid
+        parentTypeEq:
+          type: string
         dockTypeEq:
           type: string
         shipSizeEq:

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -10608,12 +10608,14 @@ components:
       - landingpad
       - dockingport
       - hangar
+      - cargogrid
       x-enumNames:
       - VEHICLEPAD
       - GARAGE
       - LANDINGPAD
       - DOCKINGPORT
       - HANGAR
+      - CARGOGRID
       title: DockTypeEnum
     Docks:
       type: object

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -10559,6 +10559,9 @@ components:
           format: uuid
         parentType:
           type: string
+          enum:
+          - Model
+          - ModelModule
       additionalProperties: false
       title: DockInput
     DockQuery:

--- a/swagger/v1/schema.yaml
+++ b/swagger/v1/schema.yaml
@@ -18362,6 +18362,8 @@ components:
                 type: string
               dockType:
                 type: string
+              moduleName:
+                type: string
               storeImage:
                 "$ref": "#/components/schemas/MediaFile"
             additionalProperties: false

--- a/test/factories/docks.rb
+++ b/test/factories/docks.rb
@@ -11,10 +11,16 @@
 #  max_ship_size :integer
 #  min_ship_size :integer
 #  name          :string
+#  parent_type   :string           not null
 #  ship_size     :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #  model_id      :uuid
+#  parent_id     :uuid             not null
+#
+# Indexes
+#
+#  index_docks_on_parent_type_and_parent_id  (parent_type,parent_id)
 #
 FactoryBot.define do
   factory :dock do
@@ -22,9 +28,9 @@ FactoryBot.define do
     dock_type { :hangar }
     ship_size { :small }
 
-    trait :with_model do
-      model
-    end
+    # A dock always belongs to something, and a ship is the common case. Pass
+    # `parent:` a ModelModule for the other one.
+    parent { association(:model) }
 
     trait :with_dimensions do
       beam { 25.0 }

--- a/test/factories/models.rb
+++ b/test/factories/models.rb
@@ -240,7 +240,7 @@ FactoryBot.define do
 
     trait :with_docks do
       after(:create) do |model|
-        create_list(:dock, 3, model: model)
+        create_list(:dock, 3, parent: model)
       end
     end
 

--- a/test/integration/admin/api/v1/docks_test.rb
+++ b/test/integration/admin/api/v1/docks_test.rb
@@ -143,8 +143,21 @@ class Admin::Api::V1::DocksTest < ActionDispatch::IntegrationTest
     model = create(:model)
     sign_in @user
 
-    body = {name: "Pad 01", dockType: "landingpad", shipSize: "medium", modelId: model.id}
+    body = {name: "Pad 01", dockType: "landingpad", shipSize: "medium", parentId: model.id, parentType: "Model"}
     assert_api_response :post, 201, body: body
+  end
+
+  test "POST /docks creates a dock on a module" do
+    model_module = create(:model_module)
+    sign_in @user
+
+    body = {
+      name: "Vehicle Lift", dockType: "garage", shipSize: "small",
+      parentId: model_module.id, parentType: "ModelModule"
+    }
+    assert_api_response :post, 201, body: body do
+      assert_equal 1, model_module.docks.count
+    end
   end
 
   test "POST /docks returns 400 for missing required fields" do
@@ -156,7 +169,7 @@ class Admin::Api::V1::DocksTest < ActionDispatch::IntegrationTest
   test "POST /docks returns 401 when not signed in" do
     model = create(:model)
 
-    body = {name: "x", dockType: "landingpad", shipSize: "medium", modelId: model.id}
+    body = {name: "x", dockType: "landingpad", shipSize: "medium", parentId: model.id, parentType: "Model"}
     assert_api_response :post, 401, body: body
   end
 
@@ -164,7 +177,7 @@ class Admin::Api::V1::DocksTest < ActionDispatch::IntegrationTest
     model = create(:model)
     sign_in create(:admin_user, resource_access: [])
 
-    body = {name: "x", dockType: "landingpad", shipSize: "medium", modelId: model.id}
+    body = {name: "x", dockType: "landingpad", shipSize: "medium", parentId: model.id, parentType: "Model"}
     assert_api_response :post, 403, body: body
   end
 
@@ -175,6 +188,18 @@ class Admin::Api::V1::DocksTest < ActionDispatch::IntegrationTest
 
     assert_api_response :get, 200 do
       assert_equal 3, parsed_body["items"].count
+    end
+  end
+
+  test "GET /docks filters by parent" do
+    model = create(:model)
+    model_module = create(:model_module)
+    create(:dock, parent: model)
+    create_list(:dock, 2, parent: model_module)
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {parentTypeEq: "ModelModule"}} do
+      assert_equal 2, parsed_body["items"].count
     end
   end
 

--- a/test/integration/admin/api/v1/docks_test.rb
+++ b/test/integration/admin/api/v1/docks_test.rb
@@ -160,6 +160,19 @@ class Admin::Api::V1::DocksTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # A class name that is not a berth would reach `belongs_to :parent` and be
+  # constantized there, so an unknown one raises rather than answering. The
+  # schema enum turns that into a 400 before the model is asked.
+  test "POST /docks returns 400 for a parent that is not a berth" do
+    sign_in @user
+
+    body = {
+      name: "x", dockType: "landingpad", shipSize: "medium",
+      parentId: SecureRandom.uuid, parentType: "User"
+    }
+    assert_api_response :post, 400, body: body
+  end
+
   test "POST /docks returns 400 for missing required fields" do
     sign_in @user
 

--- a/test/integration/admin/api/v1/docks_test.rb
+++ b/test/integration/admin/api/v1/docks_test.rb
@@ -173,6 +173,19 @@ class Admin::Api::V1::DocksTest < ActionDispatch::IntegrationTest
     assert_api_response :post, 400, body: body
   end
 
+  # A class name that does not exist raises out of `belongs_to :parent` when it
+  # is constantized, which would be a 500. The schema enum has to catch it
+  # first, and this is the proof rather than the assumption.
+  test "POST /docks returns 400 for a parent class that does not exist" do
+    sign_in @user
+
+    body = {
+      name: "x", dockType: "landingpad", shipSize: "medium",
+      parentId: SecureRandom.uuid, parentType: "NoSuchClass"
+    }
+    assert_api_response :post, 400, body: body
+  end
+
   test "POST /docks returns 400 for missing required fields" do
     sign_in @user
 

--- a/test/integration/api/v1/hangar_test.rb
+++ b/test/integration/api/v1/hangar_test.rb
@@ -68,8 +68,8 @@ class Api::V1::HangarTest < ActionDispatch::IntegrationTest
   test "GET /hangar filters by a carrier that takes both ships and vehicles" do
     user = create(:user)
     carrier = create(:model, slug: "carrier-with-both")
-    create(:dock, :with_dimensions, model: carrier, dock_type: :hangar)
-    create(:dock, :with_dimensions, model: carrier, dock_type: :garage)
+    create(:dock, :with_dimensions, parent: carrier, dock_type: :hangar)
+    create(:dock, :with_dimensions, parent: carrier, dock_type: :garage)
 
     fits = create(:model, ground: false, length: 20.0, beam: 10.0, height: 5.0)
     too_big = create(:model, ground: false, length: 200.0, beam: 100.0, height: 50.0)

--- a/test/integration/api/v1/models_index_test.rb
+++ b/test/integration/api/v1/models_index_test.rb
@@ -87,7 +87,7 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
   # for a uuid — so every real request was rejected before reaching the action.
   test "GET /models accepts a slug for willItFit" do
     carrier = create(:model, slug: "fitting-carrier")
-    create(:dock, :with_dimensions, model: carrier, dock_type: :hangar)
+    create(:dock, :with_dimensions, parent: carrier, dock_type: :hangar)
 
     fits = create(:model, length: 20.0, beam: 10.0, height: 5.0)
     too_big = create(:model, length: 300.0, beam: 100.0, height: 60.0)
@@ -104,7 +104,7 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
   # answered "nothing fits" rather than declining to answer.
   test "GET /models does not empty the list for a carrier with unmeasured docks" do
     carrier = create(:model, slug: "unmeasured-carrier")
-    create(:dock, model: carrier, dock_type: :hangar)
+    create(:dock, parent: carrier, dock_type: :hangar)
     other = create(:model, length: 20.0, beam: 10.0, height: 5.0)
 
     assert_api_response :get, 200, params: {q: {willItFit: carrier.slug}} do

--- a/test/integration/api/v1/models_index_test.rb
+++ b/test/integration/api/v1/models_index_test.rb
@@ -85,6 +85,25 @@ class Api::V1::ModelsIndexTest < ActionDispatch::IntegrationTest
 
   # The picker sends a slug and the controller resolves one, but the schema asked
   # for a uuid — so every real request was rejected before reaching the action.
+  # The filter and the detail page answer from the same berths, so a module's
+  # lift has to count here too or the two disagree again.
+  test "GET /models counts a module's berth for willItFit" do
+    carrier = create(:model, slug: "modular-carrier")
+    model_module = create(:model_module)
+    create(:module_hardpoint, model: carrier, model_module: model_module)
+    create(:dock, :with_dimensions, parent: model_module, dock_type: :hangar)
+
+    fits = create(:model, length: 20.0, beam: 10.0, height: 5.0)
+    too_big = create(:model, length: 300.0, beam: 100.0, height: 60.0)
+
+    assert_api_response :get, 200, params: {q: {willItFit: carrier.slug}} do
+      slugs = parsed_body["items"].map { |item| item["slug"] }
+
+      assert_includes slugs, fits.slug
+      assert_not_includes slugs, too_big.slug
+    end
+  end
+
   test "GET /models accepts a slug for willItFit" do
     carrier = create(:model, slug: "fitting-carrier")
     create(:dock, :with_dimensions, parent: carrier, dock_type: :hangar)

--- a/test/integration/api/v1/models_show_test.rb
+++ b/test/integration/api/v1/models_show_test.rb
@@ -42,6 +42,39 @@ class Api::V1::ModelsShowTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # The Galaxy's med bay carries a vehicle lift and its refinery does not, so a
+  # berth that arrives with a module counts -- and says which module, because
+  # the carrier is conditional on the owner having mounted it.
+  test "GET /models/:slug names a carrier whose berth comes with a module" do
+    carrier = create(:model, name: "Modular Carrier")
+    model_module = create(:model_module, name: "Med Bay Module")
+    create(:module_hardpoint, model: carrier, model_module: model_module)
+    create(:dock, :with_dimensions, parent: model_module, dock_type: :hangar)
+
+    model = create(:model, length: 20.0, beam: 10.0, height: 5.0, size: "small")
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      entry = parsed_body["carriedBy"].find { |item| item["name"] == carrier.name }
+
+      assert_not_nil entry
+      assert_equal "Med Bay Module", entry["moduleName"]
+    end
+  end
+
+  test "GET /models/:slug leaves moduleName off a berth built into the hull" do
+    carrier = create(:model, name: "Fixed Carrier")
+    create(:dock, :with_dimensions, parent: carrier, dock_type: :hangar)
+
+    model = create(:model, length: 20.0, beam: 10.0, height: 5.0, size: "small")
+
+    assert_api_response :get, 200, path_params: {slug: model.slug} do
+      entry = parsed_body["carriedBy"].find { |item| item["name"] == carrier.name }
+
+      assert_not_nil entry
+      assert_nil entry["moduleName"]
+    end
+  end
+
   # A hover bike is size vehicle and ground false, so `ground` would have sent it
   # to a hangar instead of a bay.
   test "GET /models/:slug offers a bay to a hover bike" do

--- a/test/integration/api/v1/models_show_test.rb
+++ b/test/integration/api/v1/models_show_test.rb
@@ -27,9 +27,9 @@ class Api::V1::ModelsShowTest < ActionDispatch::IntegrationTest
 
   test "GET /models/:slug names the ships that can carry it" do
     carrier = create(:model, name: "Big Carrier")
-    create(:dock, :with_dimensions, model: carrier, dock_type: :hangar)
+    create(:dock, :with_dimensions, parent: carrier, dock_type: :hangar)
     too_small = create(:model, name: "Small Carrier")
-    create(:dock, model: too_small, dock_type: :hangar, length: 8.0, beam: 6.0, height: 4.0)
+    create(:dock, parent: too_small, dock_type: :hangar, length: 8.0, beam: 6.0, height: 4.0)
 
     model = create(:model, length: 20.0, beam: 10.0, height: 5.0, size: "small")
 
@@ -46,7 +46,7 @@ class Api::V1::ModelsShowTest < ActionDispatch::IntegrationTest
   # to a hangar instead of a bay.
   test "GET /models/:slug offers a bay to a hover bike" do
     carrier = create(:model, name: "Bay Carrier")
-    create(:dock, :with_dimensions, model: carrier, dock_type: :garage)
+    create(:dock, :with_dimensions, parent: carrier, dock_type: :garage)
 
     bike = create(:model, length: 4.0, beam: 2.0, height: 2.0, size: "vehicle", ground: false)
 
@@ -59,7 +59,7 @@ class Api::V1::ModelsShowTest < ActionDispatch::IntegrationTest
   # bound and the answer would be confident and wrong.
   test "GET /models/:slug carries nothing for a model without dimensions" do
     carrier = create(:model)
-    create(:dock, :with_dimensions, model: carrier, dock_type: :hangar)
+    create(:dock, :with_dimensions, parent: carrier, dock_type: :hangar)
 
     unmeasured = create(:model, length: 0, beam: 0, height: 0, size: "small")
 
@@ -71,7 +71,7 @@ class Api::V1::ModelsShowTest < ActionDispatch::IntegrationTest
   # A ship in a garage is the case that stays impossible.
   test "GET /models/:slug does not offer a garage to a ship" do
     carrier = create(:model)
-    create(:dock, :with_dimensions, model: carrier, dock_type: :garage)
+    create(:dock, :with_dimensions, parent: carrier, dock_type: :garage)
 
     ship = create(:model, length: 4.0, beam: 2.0, height: 2.0, size: "small")
 

--- a/test/models/dock_test.rb
+++ b/test/models/dock_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DockTest < ActiveSupport::TestCase
+  test "a dock belongs to a ship" do
+    model = create(:model)
+
+    assert create(:dock, parent: model).valid?
+    assert_equal 1, model.docks.count
+  end
+
+  # The reason the parent is polymorphic at all: the Galaxy's medic module
+  # carries a vehicle lift, and a module is not a ship.
+  test "a dock belongs to a module" do
+    model_module = create(:model_module)
+
+    assert create(:dock, parent: model_module).valid?
+    assert_equal 1, model_module.docks.count
+  end
+
+  # `parent_type` is a plain string column, so without the guard the admin API
+  # would take any class name and a dock could hang off something that is not a
+  # berth at all -- a fresh way to grow the orphans #4864 had to delete.
+  test "a dock belongs to nothing else" do
+    manufacturer = create(:manufacturer)
+
+    dock = build(:dock, parent: manufacturer)
+
+    assert_not dock.valid?
+    assert_includes dock.errors[:parent_type], "is not included in the list"
+  end
+
+  test "a dock belongs to something" do
+    dock = build(:dock, parent: nil)
+
+    assert_not dock.valid?
+  end
+
+  # Destroying the carrier takes its berths, whichever side they hang off.
+  test "a module takes its docks with it" do
+    model_module = create(:model_module)
+    create(:dock, parent: model_module)
+
+    assert_difference("Dock.count", -1) { model_module.destroy }
+  end
+end

--- a/test/models/dock_test.rb
+++ b/test/models/dock_test.rb
@@ -61,6 +61,16 @@ class DockTest < ActiveSupport::TestCase
     assert_not dock.valid?
   end
 
+  # Making the association optional removed the check that the row exists along
+  # with the constantizing. A known type plus any UUID would have saved a dock
+  # hanging off nothing.
+  test "a dock refuses a parent that does not exist" do
+    dock = build(:dock, parent_type: "Model", parent_id: SecureRandom.uuid)
+
+    assert_not dock.valid?
+    assert_includes dock.errors[:parent], "can't be blank"
+  end
+
   # `belongs_to`'s own presence check would constantize `parent_type` and raise
   # NameError out of validation, which is a 500 where an invalid record belongs.
   test "a dock refuses a class that does not exist, without raising" do

--- a/test/models/dock_test.rb
+++ b/test/models/dock_test.rb
@@ -61,6 +61,15 @@ class DockTest < ActiveSupport::TestCase
     assert_not dock.valid?
   end
 
+  # `belongs_to`'s own presence check would constantize `parent_type` and raise
+  # NameError out of validation, which is a 500 where an invalid record belongs.
+  test "a dock refuses a class that does not exist, without raising" do
+    dock = build(:dock, parent_type: "NoSuchClass", parent_id: SecureRandom.uuid)
+
+    assert_not dock.valid?
+    assert_includes dock.errors[:parent_type], "is not included in the list"
+  end
+
   # The create form no longer preselects a type, so nothing else may either: a
   # berth saved without one would be a landing pad or a garage by accident.
   test "a dock needs a type and a size" do

--- a/test/models/dock_test.rb
+++ b/test/models/dock_test.rb
@@ -68,6 +68,26 @@ class DockTest < ActiveSupport::TestCase
     assert_not build(:dock, ship_size: nil).valid?
   end
 
+  # A cargo grid costs cargo capacity and a garage does not, but both take a
+  # vehicle -- so the new type has to be classified with the vehicle berths or
+  # it would silently be offered to ships.
+  test "a cargo grid is a vehicle berth" do
+    dock = build(:dock, dock_type: :cargogrid)
+
+    assert dock.for_vehicles?
+    assert_not dock.for_ships?
+    assert dock.berth?
+  end
+
+  test "a cargo grid takes a vehicle and refuses a ship" do
+    dock = create(:dock, :with_dimensions, dock_type: :cargogrid)
+    vehicle = create(:model, length: 8.0, beam: 5.0, height: 3.0, size: "vehicle")
+    ship = create(:model, length: 8.0, beam: 5.0, height: 3.0, size: "small")
+
+    assert dock.fits?(vehicle)
+    assert_not dock.fits?(ship)
+  end
+
   # Destroying the carrier takes its berths, whichever side they hang off.
   test "a module takes its docks with it" do
     model_module = create(:model_module)

--- a/test/models/dock_test.rb
+++ b/test/models/dock_test.rb
@@ -2,6 +2,30 @@
 
 require "test_helper"
 
+# == Schema Information
+#
+# Table name: docks
+#
+#  id            :uuid             not null, primary key
+#  beam          :decimal(15, 2)
+#  dock_type     :integer
+#  group         :string
+#  height        :decimal(15, 2)
+#  length        :decimal(15, 2)
+#  max_ship_size :integer
+#  min_ship_size :integer
+#  name          :string
+#  parent_type   :string           not null
+#  ship_size     :integer
+#  created_at    :datetime         not null
+#  updated_at    :datetime         not null
+#  model_id      :uuid
+#  parent_id     :uuid             not null
+#
+# Indexes
+#
+#  index_docks_on_parent_type_and_parent_id  (parent_type,parent_id)
+#
 class DockTest < ActiveSupport::TestCase
   test "a dock belongs to a ship" do
     model = create(:model)
@@ -35,6 +59,13 @@ class DockTest < ActiveSupport::TestCase
     dock = build(:dock, parent: nil)
 
     assert_not dock.valid?
+  end
+
+  # The create form no longer preselects a type, so nothing else may either: a
+  # berth saved without one would be a landing pad or a garage by accident.
+  test "a dock needs a type and a size" do
+    assert_not build(:dock, dock_type: nil).valid?
+    assert_not build(:dock, ship_size: nil).valid?
   end
 
   # Destroying the carrier takes its berths, whichever side they hang off.


### PR DESCRIPTION
Implements **D1** from `docs/exec-plans/4863-berth-model.md`, the follow-up the berth work was sequenced behind.

## Why

`docks` hung off `models` alone, through a nullable `model_id`. Both halves were wrong.

A dock belongs to a **module** as readily as to a ship — the Galaxy's medic module carries a vehicle lift, and the Caterpillar may get one. `cargo_holds` already solved this, and six of its rows hang off a `ModelModule` today, so this copies its shape rather than inventing one.

And "belongs to nothing" was never a state that meant anything. It was how the 391 orphans #4864 deleted came to exist in the first place.

## What changed

`parent_type` / `parent_id`, **NOT NULL**, indexed as a pair. `Dock belongs_to :parent, polymorphic: true, touch: true`; `Model` and now `ModelModule` both `has_many :docks, as: :parent`.

The admin API moved with it: `modelId` became `parentId` + `parentType` on the payload, the input and the query. Only the admin frontend consumes the admin API and it ships in the same deploy, so there is nothing to keep compatible. The public API is untouched.

The docks editor is now **one component** rendered by both the model and the module edit pages, instead of a duplicated 235-line page. Without the module page the relation would be structure with no way to put content in it.

## Two columns that do not exist

`dock.rb` annotated a `ramp` boolean and `ransackable_attributes` offered `station_id`. Neither column is in the schema — `station_id` would have raised on any query that used it. Both are leftovers from the same 2021 station era as the orphans, and both are gone.

## `model_id` stays for one release

Deliberately. Pre-deploy migrates while the old containers are still serving, and that code selects `docks.model_id`; dropping it here would 500 every dock read in the window between. A follow-up removes it once this is out.

## Not in this change

Will-it-fit still only consults a **ship's** docks. Whether a module's lift should count toward its host ship is a real question and a different one — it depends on the module actually being installed, which `module_hardpoints` models separately.

## Verification

- 105 tests green across the dock-related files, including two new ones: creating a dock on a module through the admin API, and filtering the list by `parentType`
- `ruby-lint`, `lint:ts`, `lint:js`, prettier clean
- Schema and clients regenerated

Part of #4863.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Docks can be managed for models and model modules through a shared editor with pagination, inline CRUD, dimensions, ship-size selection, and error handling.
  - Added Cargo Grid dock support.
  - Model results identify the supplying module when applicable.
  - Added vehicle-size data and dimension-drift filtering.
  - Imports now support cancellation and cancelled status.
- **API Changes**
  - Dock ownership and filtering use parent identifiers and types.
  - Module-provided berths are included in fit checks and model results.
- **Localization**
  - Added dock labels, navigation, titles, placeholders, and messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->