### PR TITLE
refactor(sc-data): move the source switch into the navigation

### DIFF
--- a/app/frontend/frontend/App.vue
+++ b/app/frontend/frontend/App.vue
@@ -10,7 +10,6 @@ import AppNavigationHeader from "@/shared/components/AppNavigation/Header/index.
 import FrontendNavigationMobile from "@/frontend/components/Navigation/Mobile/index.vue";
 import AppFooter from "@/shared/components/AppFooter/index.vue";
 import SupportBtn from "@/frontend/components/SupportBtn/index.vue";
-import ScDataSourceBar from "@/frontend/components/ScDataSource/index.vue";
 import AppEnvironment from "@/shared/components/AppEnvironment/index.vue";
 import AppModal from "@/shared/components/AppModal/index.vue";
 import OffCanvas from "@/shared/components/OffCanvas/index.vue";
@@ -285,8 +284,6 @@ const setLocale = (locale: string) => {
           }"
         >
           <AppNavigationHeader />
-
-          <ScDataSourceBar />
 
           <router-view v-slot="{ Component, route: viewRoute }">
             <transition name="fade" mode="out-in">

--- a/app/frontend/frontend/components/Navigation/index.vue
+++ b/app/frontend/frontend/components/Navigation/index.vue
@@ -11,6 +11,8 @@ import { useI18n } from "@/shared/composables/useI18n";
 import AppNavigation from "@/shared/components/AppNavigation/index.vue";
 import NavItem from "@/shared/components/AppNavigation/NavItem/index.vue";
 
+import ScDataSourceSwitch from "@/frontend/components/ScDataSource/index.vue";
+
 import FleetNav from "./FleetNav/index.vue";
 import NotificationsNav from "./NotificationsNav/index.vue";
 import FleetsNav from "./FleetsNav/index.vue";
@@ -191,6 +193,7 @@ const settingsActive = computed(() => {
       </template>
     </template>
     <template #footer>
+      <ScDataSourceSwitch />
       <template v-if="isAuthenticated && currentUser">
         <NotificationsNav />
         <NavItem

--- a/app/frontend/frontend/components/ScDataSource/index.scss
+++ b/app/frontend/frontend/components/ScDataSource/index.scss
@@ -1,0 +1,63 @@
+/*
+ * The row's own inner, because the navigation's carries an icon and this row
+ * carries the build's name instead. Geometry is the one NavItemInner sets - a
+ * 30px column and 15px to the text, 6px of it once the navigation collapses -
+ * so this row lines up with the ones above it rather than sitting a few pixels
+ * off on its own.
+ */
+.sc-data-source-switch {
+  &__inner {
+    min-height: 30px;
+    display: flex;
+    flex-grow: 1;
+    align-items: center;
+  }
+
+  /*
+   * Holds the icon column's 30px and 15px gap as *layout* -- NavItemInner's
+   * geometry, so this row's label starts where every other row's does -- but the
+   * name itself is allowed out of that box. A fixed, unshrinkable width means
+   * what spills is painted, not measured, so the label stays put however long
+   * the environment's name is. Centred, so the spill is halved either side and
+   * lands in the 25px of padding on the left and the gap on the right.
+   */
+  &__build {
+    width: 30px;
+    margin-inline-end: 15px;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-primary, #428bca);
+    /*
+     * Orbitron, the face the app uses wherever a value is read rather than a
+     * sentence. It is wide, which is what made it push the label out of line
+     * while the column still measured its content -- now that the name is only
+     * painted past the box, the width costs nothing but the spill.
+     */
+    font-family: "Orbitron", sans-serif;
+    font-size: 14px;
+    font-weight: bold;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  &__label {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  &.nav-item--slim .sc-data-source-switch__build {
+    margin-inline-end: 6px;
+  }
+
+  /*
+   * Reading a build that is not live: the name leaves the primary the rest of
+   * the navigation accents with and takes the warning colour. It carries that
+   * on its own, so nothing else in the row has to -- a rail here would say
+   * "this is the open page", which is what it means on every other row.
+   */
+  &--preview .sc-data-source-switch__build {
+    color: $warning;
+  }
+}

--- a/app/frontend/frontend/components/ScDataSource/index.spec.ts
+++ b/app/frontend/frontend/components/ScDataSource/index.spec.ts
@@ -129,6 +129,23 @@ describe("ScDataSourceSwitch", () => {
     expect(useScDataSourceStore().requestParam).toBe("eptu");
   });
 
+  // The switch reads against the build it offers, not against "is this the
+  // default one". A reader left on a preview that is no longer the newest --
+  // restored from a previous session, or passed by a second channel -- would
+  // otherwise be sent to live first and need a second press to arrive.
+  it("offers the newest preview from an older one in a single press", async () => {
+    sources.value = { items: [live, ptu, eptu] };
+    const wrapper = await mountSwitch();
+
+    useScDataSourceStore().select("ptu");
+    await nextTick();
+
+    await press(wrapper);
+
+    expect(useScDataSourceStore().requestParam).toBe("eptu");
+    expect(wrapper.find(BUILD).text()).toBe("eptu");
+  });
+
   // The name is the marker and it takes the warning colour through this class.
   // No rail: on every other row that means "this is the open page".
   it("marks the row while the build is not the default one", async () => {

--- a/app/frontend/frontend/components/ScDataSource/index.spec.ts
+++ b/app/frontend/frontend/components/ScDataSource/index.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount, enableAutoUnmount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import { ref, nextTick } from "vue";
 
@@ -51,6 +51,13 @@ const press = async (wrapper: Awaited<ReturnType<typeof mountSwitch>>) => {
   await wrapper.findComponent({ name: "NavItem" }).props("action")();
   await nextTick();
 };
+
+// `sources` is a module ref every mounted switch watches, so a wrapper left
+// standing keeps answering later tests: it writes the new list into the pinia it
+// was mounted with, and whichever store wrote last is the one the test's own
+// `useScDataSourceStore()` no longer holds. That made assertions pass against a
+// component that had never seen the state under test.
+enableAutoUnmount(afterEach);
 
 describe("ScDataSourceSwitch", () => {
   beforeEach(() => {

--- a/app/frontend/frontend/components/ScDataSource/index.spec.ts
+++ b/app/frontend/frontend/components/ScDataSource/index.spec.ts
@@ -3,11 +3,9 @@ import { mount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import { ref, nextTick } from "vue";
 
-const SWITCH = '[data-test="sc-data-source-switch"]';
-const WARNING_THUMB = ".btn-group__thumb--tone-warning";
-
-const live = { environment: "live", version: "1.0.0", default: true };
-const ptu = { environment: "ptu", version: "1.1.0", default: false };
+const live = { environment: "live", version: "4.9.0", default: true };
+const ptu = { environment: "ptu", version: "4.10.0", default: false };
+const eptu = { environment: "eptu", version: "4.11.0", default: false };
 
 const sources = ref<{ items: (typeof live)[] } | undefined>(undefined);
 vi.mock("@/services/fyApi", () => ({
@@ -23,22 +21,21 @@ vi.mock("@/shared/composables/useI18n", () => ({
   useI18n: () => ({ t: (key: string) => key }),
 }));
 
-import ScDataSourceBar from "./index.vue";
+import ScDataSourceSwitch from "./index.vue";
 import { useScDataSourceStore } from "@/shared/stores/scDataSource";
 
-// The teleport waits for `onMounted`, so the first render carries nothing.
-const mountBar = async () => {
-  const wrapper = mount(ScDataSourceBar, {
+const ITEM = ".sc-data-source-switch";
+const BUILD = ".sc-data-source-switch__build";
+const PREVIEW = ".sc-data-source-switch--preview";
+
+const mountSwitch = async () => {
+  const wrapper = mount(ScDataSourceSwitch, {
     global: {
-      directives: {
-        // The app registers this globally; without it every mount warns.
-        tooltip: {},
-      },
-      stubs: {
-        // Rendered in place: the bar teleports into the header, which does not
-        // exist in a mounted component's own tree.
-        Teleport: true,
-      },
+      // Stubbed rather than rendered: the real item reaches for the router and
+      // for tooltips, neither of which this component decides anything about.
+      // Its slot still renders, because the build's name lives in there.
+      stubs: { NavItem: true },
+      renderStubDefaultSlot: true,
     },
   });
 
@@ -47,28 +44,44 @@ const mountBar = async () => {
   return wrapper;
 };
 
-describe("ScDataSourceBar", () => {
+const item = (wrapper: Awaited<ReturnType<typeof mountSwitch>>) =>
+  wrapper.find(ITEM);
+
+const press = async (wrapper: Awaited<ReturnType<typeof mountSwitch>>) => {
+  await wrapper.findComponent({ name: "NavItem" }).props("action")();
+  await nextTick();
+};
+
+describe("ScDataSourceSwitch", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     sources.value = undefined;
     invalidateQueries.mockClear();
   });
 
-  it("stays out of the way when there is only one build", async () => {
-    sources.value = { items: [live] };
-    const wrapper = await mountBar();
+  it("offers the choice on every page", async () => {
+    sources.value = { items: [live, ptu] };
+    const wrapper = await mountSwitch();
 
-    expect(wrapper.find(SWITCH).exists()).toBe(false);
+    expect(item(wrapper).exists()).toBe(true);
   });
 
-  it("offers every build the server named", async () => {
-    sources.value = { items: [live, ptu] };
-    const wrapper = await mountBar();
+  // A ptu cycle ends by live catching up, and the server stops offering the
+  // preview from that moment -- which is the whole of how the row goes away.
+  it("stays out of the navigation when there is only one build", async () => {
+    sources.value = { items: [live] };
+    const wrapper = await mountSwitch();
 
-    expect(wrapper.findAll("button").map((btn) => btn.text())).toEqual([
-      "live",
-      "ptu",
-    ]);
+    expect(item(wrapper).exists()).toBe(false);
+  });
+
+  // The row says which build in words, where every other row has an icon: one
+  // glyph cannot tell two builds apart, and this is the one row about which.
+  it("names the build being read", async () => {
+    sources.value = { items: [live, ptu] };
+    const wrapper = await mountSwitch();
+
+    expect(wrapper.find(BUILD).text()).toBe("live");
   });
 
   // Everything cached was fetched against another build, so it all goes --
@@ -79,35 +92,47 @@ describe("ScDataSourceBar", () => {
   // no request goes out. Invalidating is what reloads the page.
   it("invalidates every query when the build changes", async () => {
     sources.value = { items: [live, ptu] };
-    const wrapper = await mountBar();
+    const wrapper = await mountSwitch();
 
-    await wrapper.findAll("button")[1].trigger("click");
+    await press(wrapper);
 
     expect(useScDataSourceStore().requestParam).toBe("ptu");
     expect(invalidateQueries).toHaveBeenCalledOnce();
   });
 
-  it("does nothing when the build already selected is picked again", async () => {
+  it("goes back to the default build on the next press", async () => {
     sources.value = { items: [live, ptu] };
-    const wrapper = await mountBar();
+    const wrapper = await mountSwitch();
 
-    await wrapper.findAll("button")[0].trigger("click");
+    await press(wrapper);
+    await press(wrapper);
 
-    expect(invalidateQueries).not.toHaveBeenCalled();
+    expect(useScDataSourceStore().requestParam).toBeUndefined();
+    expect(wrapper.find(BUILD).text()).toBe("live");
   });
 
-  // A grouped button drops its cap, so a member's own tone would show nothing at
-  // rest. The group's thumb is what marks the choice, so it carries the warning.
-  it("warns through the group when the build is not the default one", async () => {
+  // Two states, never a list: a second preview channel would make the switch
+  // offer the newer of them rather than turn into a menu.
+  it("offers the newest preview when more than one is available", async () => {
+    sources.value = { items: [live, ptu, eptu] };
+    const wrapper = await mountSwitch();
+
+    await press(wrapper);
+
+    expect(useScDataSourceStore().requestParam).toBe("eptu");
+  });
+
+  // The name is the marker and it takes the warning colour through this class.
+  // No rail: on every other row that means "this is the open page".
+  it("marks the row while the build is not the default one", async () => {
     sources.value = { items: [live, ptu] };
-    const wrapper = await mountBar();
+    const wrapper = await mountSwitch();
 
-    expect(wrapper.find(WARNING_THUMB).exists()).toBe(false);
+    expect(wrapper.find(PREVIEW).exists()).toBe(false);
 
-    await wrapper.findAll("button")[1].trigger("click");
-    // The handler awaits the query client before the group re-renders.
-    await nextTick();
+    await press(wrapper);
 
-    expect(wrapper.find(WARNING_THUMB).exists()).toBe(true);
+    expect(wrapper.find(PREVIEW).exists()).toBe(true);
+    expect(wrapper.find(BUILD).text()).toBe("ptu");
   });
 });

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -50,7 +50,15 @@ const slim = computed(() => navSlim.value && !mobile.value);
 // label until each query happened to refetch.
 const toggle = async () => {
   // Two states, never a list: the live build and the newest preview of it.
-  store.select(onPreview.value ? undefined : previewSource.value?.environment);
+  // Read against that preview rather than against "is this the default", so a
+  // reader left on a preview the server has since passed -- a second channel
+  // configured, or an older choice restored -- is one press from the build the
+  // switch offers, not one press from live and a second one back out.
+  store.select(
+    selected.value?.environment === previewSource.value?.environment
+      ? undefined
+      : previewSource.value?.environment,
+  );
 
   // Invalidated rather than cleared. `clear()` removes every query, so the
   // mounted observers have nothing left to refetch and the page keeps showing

--- a/app/frontend/frontend/components/ScDataSource/index.vue
+++ b/app/frontend/frontend/components/ScDataSource/index.vue
@@ -1,24 +1,28 @@
 <script lang="ts">
 export default {
-  name: "ScDataSourceBar",
+  name: "ScDataSourceSwitch",
 };
 </script>
 
 <script lang="ts" setup>
 import { storeToRefs } from "pinia";
 import { useQueryClient } from "@tanstack/vue-query";
+import NavItem from "@/shared/components/AppNavigation/NavItem/index.vue";
 import { useI18n } from "@/shared/composables/useI18n";
+import { useMobile } from "@/shared/composables/useMobile";
+import { useNavStore } from "@/shared/stores/nav";
 import { useScDataSourceStore } from "@/shared/stores/scDataSource";
 import { useScDataSources } from "@/services/fyApi";
-import { BtnSizesEnum, BtnTonesEnum } from "@/shared/components/base/Btn/types";
 
 const { t } = useI18n();
 const queryClient = useQueryClient();
 const store = useScDataSourceStore();
-const { available, hasChoice } = storeToRefs(store);
+const { hasChoice, previewSource } = storeToRefs(store);
 
 // The switch is also what tells the store which builds exist, so the two cannot
 // disagree: a source the server stopped offering is dropped from the choice.
+// That is what closes a ptu cycle on its own -- once live catches up the server
+// stops offering the preview, and this item goes away without anyone editing it.
 const { data } = useScDataSources();
 
 watch(
@@ -31,31 +35,22 @@ watch(
 
 const selected = computed(() => store.selected);
 
-// The header is a sibling in this same tree, so its target is not in the
-// document while this mounts -- Vue would fail to locate it and render nothing.
-// Route components teleport into it fine because they mount after the layout.
-const mounted = ref(false);
-onMounted(() => {
-  mounted.value = true;
-});
+const onPreview = computed(() => !!selected.value && !selected.value.default);
 
-const hint = computed(() =>
-  selected.value && !selected.value.default
-    ? t("labels.scDataSource.notLive")
-    : t("labels.scDataSource.dataSource"),
-);
+const label = computed(() => t("nav.scDataSource"));
+
+// The same two conditions NavItem collapses on, because the item's own slot is
+// what carries the build here and the slot is handed no state.
+const mobile = useMobile();
+const { slim: navSlim } = storeToRefs(useNavStore());
+const slim = computed(() => navSlim.value && !mobile.value);
 
 // Everything cached was fetched against another build, so it all goes. Sending
 // the new source without this would show the old build's data under the new
 // label until each query happened to refetch.
-const select = async (environment: string) => {
-  if (selected.value?.environment === environment) return;
-
-  const option = available.value.find(
-    (source) => source.environment === environment,
-  );
-
-  store.select(option?.default ? undefined : environment);
+const toggle = async () => {
+  // Two states, never a list: the live build and the newest preview of it.
+  store.select(onPreview.value ? undefined : previewSource.value?.environment);
 
   // Invalidated rather than cleared. `clear()` removes every query, so the
   // mounted observers have nothing left to refetch and the page keeps showing
@@ -66,29 +61,38 @@ const select = async (environment: string) => {
 </script>
 
 <template>
-  <!-- Into the header rather than a row of its own: this is a global control
-       like Compare and Fleetchart beside it, and a full-width bar of its own
-       pushed every page's toolbar down and lined up with nothing. -->
-  <Teleport v-if="mounted" to="#header-right">
-    <BtnGroup
-      v-if="hasChoice"
-      v-tooltip="hint"
-      segmented
-      :size="BtnSizesEnum.MD"
-      data-test="sc-data-source-switch"
-    >
-      <!-- The tone sits on the source rather than on the group: it is this
-           particular choice that is worth flagging, so the thumb only colours
-           once it is parked on one. -->
-      <Btn
-        v-for="source in available"
-        :key="source.environment"
-        :tone="source.default ? undefined : BtnTonesEnum.WARNING"
-        :active="source.environment === selected?.environment"
-        @click="select(source.environment)"
-      >
-        {{ source.environment }}
-      </Btn>
-    </BtnGroup>
-  </Teleport>
+  <!-- A row of the navigation rather than a control on the page: it belongs to
+       the app the way the collapse toggle does. It stood in the header first,
+       where it fought the page's own toolbar for the same slot and had to be
+       kept off the pages that had no room for it -- here it costs a row, so it
+       is offered wherever the choice exists at all.
+       `label` is still handed over for the tooltip the item shows once the
+       navigation is collapsed. -->
+  <NavItem
+    v-if="hasChoice"
+    :action="() => void toggle()"
+    menu-key="sc-data-source"
+    :label="label"
+    class="sc-data-source-switch"
+    :class="{ 'sc-data-source-switch--preview': onPreview }"
+  >
+    <span class="sc-data-source-switch__inner">
+      <!-- The build stands where every other row has its icon. One glyph cannot
+           say which of two builds is being read, and this is the one row whose
+           whole point is which -- so it says it in words, and it is all that is
+           left once the navigation collapses to the icon column. -->
+      <!-- On one line: a newline either side of the interpolation leaves text
+           nodes in the box, and the name stops sitting centred in it. -->
+      <span class="sc-data-source-switch__build">{{
+        selected?.environment
+      }}</span>
+      <span v-if="!slim" class="sc-data-source-switch__label">
+        {{ label }}
+      </span>
+    </span>
+  </NavItem>
 </template>
+
+<style lang="scss" scoped>
+@import "index";
+</style>

--- a/app/frontend/shared/components/AppNavigation/NavItem/index.scss
+++ b/app/frontend/shared/components/AppNavigation/NavItem/index.scss
@@ -10,6 +10,12 @@
     align-items: center;
     padding: 10px 10px 10px 25px;
     color: darken($text-color, 10%);
+    /*
+     * A button does not inherit the page's face -- the UA sets the whole `font`
+     * shorthand on it -- so without this a row rendered as a button reads in the
+     * default sans while the rows either side of it read in Open Sans.
+     */
+    font: inherit;
     font-size: 18px;
     white-space: nowrap;
     text-transform: uppercase;

--- a/app/frontend/shared/components/AppNavigation/NavItem/index.spec.ts
+++ b/app/frontend/shared/components/AppNavigation/NavItem/index.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+
+// The item reads the route to mark the open page. The action branch never does,
+// but the setup runs whichever branch renders.
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ name: "home" }),
+}));
+
+import NavItem from "./index.vue";
+
+const mountItem = (props: Record<string, unknown>) =>
+  mount(NavItem, {
+    props,
+    // The tooltip is a directive the app installs as a plugin; nothing the item
+    // decides depends on it.
+    global: { directives: { tooltip: {} } },
+    attachTo: document.body,
+  });
+
+describe("NavItem", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  // An anchor with no href is not a tab stop and answers to no key, so a row
+  // built that way -- logout, the collapse toggle, the build switch -- could
+  // only ever be reached with a pointer. A button is both for free.
+  describe("an action row", () => {
+    it("takes focus", () => {
+      const wrapper = mountItem({ action: vi.fn(), label: "Logout" });
+
+      const button = wrapper.get("button");
+      button.element.focus();
+
+      expect(wrapper.find("a").exists()).toBe(false);
+      expect(document.activeElement).toBe(button.element);
+    });
+
+    it("runs its action from the control itself", async () => {
+      const action = vi.fn();
+      const wrapper = mountItem({ action, label: "Logout" });
+
+      // Where Enter and Space on a focused button arrive, and the reason the
+      // handler sits on the button rather than on the row around it.
+      await wrapper.get("button").trigger("click");
+
+      expect(action).toHaveBeenCalledOnce();
+    });
+
+    // Nothing in the navigation is in a form today, and a bare button would
+    // submit the first one it ever ends up in.
+    it("is not a submit button", () => {
+      const wrapper = mountItem({ action: vi.fn(), label: "Logout" });
+
+      expect(wrapper.get("button").attributes("type")).toBe("button");
+    });
+  });
+});

--- a/app/frontend/shared/components/AppNavigation/NavItem/index.vue
+++ b/app/frontend/shared/components/AppNavigation/NavItem/index.vue
@@ -180,9 +180,12 @@ const toggleMenu = () => {
     }"
     :data-test="`nav-${navKey}`"
     class="nav-item"
-    @click="action"
   >
-    <a v-tooltip="tooltip">
+    <!-- A button rather than an anchor with a click handler on the row: an
+         anchor with no href is not a tab stop and answers to no key, so a row
+         built this way -- logout, the collapse toggle, the build switch -- could
+         only ever be reached with a pointer. -->
+    <button v-tooltip="tooltip" type="button" @click="action">
       <slot>
         <NavItemInner
           :label="label"
@@ -193,7 +196,7 @@ const toggleMenu = () => {
           :badge="badge"
         />
       </slot>
-    </a>
+    </button>
   </li>
   <router-link
     v-else-if="to"

--- a/app/frontend/shared/stores/scDataSource.spec.ts
+++ b/app/frontend/shared/stores/scDataSource.spec.ts
@@ -39,6 +39,26 @@ describe("scDataSource store", () => {
     expect(store.hasChoice).toBe(true);
   });
 
+  // The switch has two states and stays that way: a second preview channel
+  // makes it offer the newer of them rather than turn into a list.
+  it("offers the newest preview build", () => {
+    const store = useScDataSourceStore();
+    store.setAvailable([
+      live,
+      { environment: "eptu", version: "1.9.0", default: false },
+      { environment: "ptu", version: "1.10.0", default: false },
+    ]);
+
+    expect(store.previewSource?.environment).toBe("ptu");
+  });
+
+  it("has no preview when the server offers the default alone", () => {
+    const store = useScDataSourceStore();
+    store.setAvailable([live]);
+
+    expect(store.previewSource).toBeUndefined();
+  });
+
   // A source that has gone away must not stay selected, or every request would
   // carry a parameter the server ignores while the switch claims otherwise.
   it("drops a selection the server stopped offering", () => {

--- a/app/frontend/shared/stores/scDataSource.ts
+++ b/app/frontend/shared/stores/scDataSource.ts
@@ -36,9 +36,22 @@ export const useScDataSourceStore = defineStore("scDataSource", {
       );
     },
 
+    // The one build the switch offers next to the default. The server only ever
+    // offers a preview that is ahead of the default, so any non-default source
+    // here is one -- and if a second channel is ever configured, the switch
+    // still stays a switch: the newest of them wins.
+    previewSource(state): ScDataSourceOption | undefined {
+      return state.available
+        .filter((source) => !source.default)
+        .sort((a, b) =>
+          a.version.localeCompare(b.version, undefined, { numeric: true }),
+        )
+        .at(-1);
+    },
+
     // Only worth a switch when there is something to switch to.
-    hasChoice(state): boolean {
-      return state.available.length > 1;
+    hasChoice(): boolean {
+      return !!this.defaultSource && !!this.previewSource;
     },
 
     // What the axios client puts on a request. Nothing for the default, so a

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -2188,10 +2188,6 @@
           "units": "Stück"
         }
       },
-      "scDataSource": {
-        "dataSource": "Datenquelle",
-        "notLive": "Nicht der Live-Build"
-      },
       "erkul": {
         "prefix": "Tryout Loadouts with",
         "link": "Erkul's DPS Calculator"

--- a/app/frontend/translations/de/nav.json
+++ b/app/frontend/translations/de/nav.json
@@ -278,7 +278,8 @@
           "system": "System"
         }
       },
-      "notifications": "Benachrichtigungen"
+      "notifications": "Benachrichtigungen",
+      "scDataSource": "Datenquelle"
     }
   }
 }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -2189,10 +2189,6 @@
           "units": "units"
         }
       },
-      "scDataSource": {
-        "dataSource": "Data source",
-        "notLive": "Not the live build"
-      },
       "shipHistory": {
         "sales": "Sale History",
         "salesCount": "Recorded sales",

--- a/app/frontend/translations/en/nav.json
+++ b/app/frontend/translations/en/nav.json
@@ -278,7 +278,8 @@
           "system": "System"
         }
       },
-      "notifications": "Notifications"
+      "notifications": "Notifications",
+      "scDataSource": "Data source"
     }
   }
 }

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -2188,10 +2188,6 @@
           "units": "unidades"
         }
       },
-      "scDataSource": {
-        "dataSource": "Fuente de datos",
-        "notLive": "No es la compilación live"
-      },
       "erkul": {
         "prefix": "Tryout Loadouts with",
         "link": "Erkul's DPS Calculator"

--- a/app/frontend/translations/es/nav.json
+++ b/app/frontend/translations/es/nav.json
@@ -278,7 +278,8 @@
           "system": "Sistema"
         }
       },
-      "notifications": "Notificaciones"
+      "notifications": "Notificaciones",
+      "scDataSource": "Fuente de datos"
     }
   }
 }

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -2188,10 +2188,6 @@
           "units": "unités"
         }
       },
-      "scDataSource": {
-        "dataSource": "Source des données",
-        "notLive": "Pas la version live"
-      },
       "erkul": {
         "prefix": "Essayer la configuration avec",
         "link": "Calculatrice de DPS d'Erkul"

--- a/app/frontend/translations/fr/nav.json
+++ b/app/frontend/translations/fr/nav.json
@@ -278,7 +278,8 @@
           "system": "Système"
         }
       },
-      "notifications": "Notifications"
+      "notifications": "Notifications",
+      "scDataSource": "Source des données"
     }
   }
 }

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -2188,10 +2188,6 @@
           "units": "unità"
         }
       },
-      "scDataSource": {
-        "dataSource": "Fonte dati",
-        "notLive": "Non è la build live"
-      },
       "erkul": {
         "prefix": "Prova Loadouts con",
         "link": "Calcolatore DPS Di Erkul"

--- a/app/frontend/translations/it/nav.json
+++ b/app/frontend/translations/it/nav.json
@@ -278,7 +278,8 @@
           "system": "Sistema"
         }
       },
-      "notifications": "Notifiche"
+      "notifications": "Notifiche",
+      "scDataSource": "Fonte dati"
     }
   }
 }

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -2184,10 +2184,6 @@
           "units": "件"
         }
       },
-      "scDataSource": {
-        "dataSource": "数据来源",
-        "notLive": "不是 live 版本"
-      },
       "erkul": {
         "prefix": "Tryout Loadouts with",
         "link": "Erkul's DPS Calculator"

--- a/app/frontend/translations/zh-CN/nav.json
+++ b/app/frontend/translations/zh-CN/nav.json
@@ -278,7 +278,8 @@
           "system": "系统"
         }
       },
-      "notifications": "通知"
+      "notifications": "通知",
+      "scDataSource": "数据来源"
     }
   }
 }

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -2184,10 +2184,6 @@
           "units": "個"
         }
       },
-      "scDataSource": {
-        "dataSource": "資料來源",
-        "notLive": "不是 live 版本"
-      },
       "erkul": {
         "prefix": "Tryout Loadouts with",
         "link": "Erkul's DPS Calculator"

--- a/app/frontend/translations/zh-TW/nav.json
+++ b/app/frontend/translations/zh-TW/nav.json
@@ -278,7 +278,8 @@
           "system": "系統"
         }
       },
-      "notifications": "通知"
+      "notifications": "通知",
+      "scDataSource": "資料來源"
     }
   }
 }


### PR DESCRIPTION
## What

The live/PTU source switch moves out of the page header and into the navigation footer.

As a button group teleported into `#header-right` it shared that slot with every page's own toolbar — and the pages that carry a toolbar (ships, hangar, fleet ships, compare) are exactly the ones the switch belongs on, so the two fought for the same corner on all of them, in an order that depended on which mounted first.

It is a `NavItem` now, first row of the navigation footer, next to the collapse toggle. Its icon column carries the build's name instead of a glyph: one symbol cannot say which of two builds is being read, and the name is all that is left of the row once the navigation collapses to 80px. Live reads in the navigation's primary, a preview in the warning colour.

## Notes

- `previewSource` on the store names the build the switch toggles to — the newest non-default source the server offers. Two states, never a list, even if a third channel is ever configured.
- The switch reads its state against that build by identity, rather than against "is this the default one". The two questions only agree while there is exactly one preview: a reader sitting on a preview that is no longer the newest — a second channel configured, or a choice restored from a previous session — would otherwise be handed live on the first press and have to press again to reach the build the row names.
- Nothing changes about when the switch appears: `ScData::Source.available` only offers a source that is loaded and ahead of the default, so a finished PTU cycle takes the row away on its own once live catches up.
- `labels.scDataSource.*` is gone and `nav.scDataSource` takes its place, in all seven locales.
- No rail on the row. `NavItem` only applies `nav-item--active` on its router-link branch, so an `:action` row is handed the prop and ignores it — the build's colour is the marker instead.

## `NavItem`'s action row

Reaching for `:action` turned up a second gap in that branch, and it is fixed here rather than worked around: it rendered an anchor with no href and hung the click handler on the row around it. An anchor without an href is not a tab stop and answers to no key, so the switch could only ever be reached with a pointer. It is a `<button>` now, with the handler on the control itself — a tab stop that turns Enter and Space into a click on its own.

That is a shared component, so the change is wider than this switch:

- **Logout**, in both the frontend and the admin navigation, and the **collapse toggle** are the other two `:action` rows. All three become keyboard-operable; nothing about how they look or what they do changes.
- A button does not inherit the page's face — the UA sets the whole `font` shorthand on it — and the rule that dresses these rows only ever set a size. `font: inherit` on the shared declaration keeps the converted rows exactly where they were, and incidentally fixes the **submenu rows** (Tools, Fleets, and the admin submenus), which have been reading in the default sans next to Open Sans neighbours since they became buttons.

## Testing

- `app/frontend/shared/components/AppNavigation/NavItem/index.spec.ts` — new, 3 cases for the action row: it takes focus, its action runs from the control itself, and it is not a submit button
- `app/frontend/frontend/components/ScDataSource/index.spec.ts` — 8 cases, reworked for the nav row
- `app/frontend/shared/stores/scDataSource.spec.ts` — 11 cases, `previewSource` added

One note on the first spec, because it changes what the others were worth: Vue Test Utils leaves a wrapper mounted when a test ends, and the spec recreates pinia per case. Every earlier switch therefore stayed mounted and kept watching the module-level `sources` ref, so setting it in a later case fired those watchers too and each wrote the list into the pinia it had been mounted with. From there the store the test body reaches and the one the component holds are two different objects, both populated and both plausible — a selection seeded from the test body never reaches the component, whose own computed goes on reporting the previous build. `enableAutoUnmount(afterEach)` closes it; the added toggle case fails without the fix it covers, which it did not before.

🤖
