### PR TITLE
fix(hangar): clear what hangs off a vehicle on a bulk delete

### DIFF
--- a/app/controllers/api/v1/vehicles_controller.rb
+++ b/app/controllers/api/v1/vehicles_controller.rb
@@ -97,9 +97,7 @@ module Api
 
           vehicle_ids = scope.pluck(:id)
 
-          VehicleUpgrade.where(vehicle_id: vehicle_ids).delete_all
-          VehicleModule.where(vehicle_id: vehicle_ids).delete_all
-          Vehicle.where(id: vehicle_ids).delete_all
+          Vehicle.delete_with_dependents(vehicle_ids)
         end
       end
 
@@ -113,9 +111,7 @@ module Api
 
           vehicle_ids = current_resource_owner.vehicles.purchased.where(bought_via: :ingame).pluck(:id)
 
-          VehicleUpgrade.where(vehicle_id: vehicle_ids).delete_all
-          VehicleModule.where(vehicle_id: vehicle_ids).delete_all
-          Vehicle.where(id: vehicle_ids).delete_all
+          Vehicle.delete_with_dependents(vehicle_ids)
         end
       end
 

--- a/app/controllers/api/v1/wishlists_controller.rb
+++ b/app/controllers/api/v1/wishlists_controller.rb
@@ -58,9 +58,7 @@ module Api
 
           vehicle_ids = authorized_scope(Vehicle.all).wanted.pluck(:id)
 
-          VehicleUpgrade.where(vehicle_id: vehicle_ids).delete_all
-          VehicleModule.where(vehicle_id: vehicle_ids).delete_all
-          Vehicle.where(id: vehicle_ids).delete_all
+          Vehicle.delete_with_dependents(vehicle_ids)
         end
       end
 

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -99,6 +99,13 @@ class Inventory < ApplicationRecord
   # holding its `vehicle_id`, pick the same suffix, and collide when Postgres
   # nullifies them. Taking the row being excluded as well is what keeps the two
   # from locking each other's row first and deadlocking.
+  # The label the ship leaves behind. `update_column` rather than `update` for the
+  # reason `Vehicle#detach_inventory` gives: it is derived, not entered, and the
+  # delete behind it must not turn on whether this row validates.
+  def freeze_location!(label)
+    update_column(:location, label)
+  end
+
   def claim_free_name!
     taken = self.class.where(holder_type:, holder_id:).order(:id).lock
       .pluck(:id, :name, :slug)
@@ -113,6 +120,12 @@ class Inventory < ApplicationRecord
         slugs.exclude?(self.class.slug_for("#{name} (#{candidate})"))
     end
 
-    update!(name: "#{name} (#{suffix})")
+    claimed = "#{name} (#{suffix})"
+
+    # Past validation for the same reason, and the slug alongside the name rather
+    # than left to `before_save`: skipping the callback would strand the old slug,
+    # which is one of the two indexes this exists to keep clear. `slug_for` is the
+    # derivation that callback uses.
+    update_columns(name: claimed, slug: self.class.slug_for(claimed), updated_at: Time.zone.now)
   end
 end

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -94,10 +94,17 @@ class Inventory < ApplicationRecord
   # Free among every other inventory of this holder rather than among the
   # hand-made ones: the sibling detached in the same breath is still holding its
   # `vehicle_id` while this runs, and would be invisible to the narrower check.
+  # Locked and ordered by id, including this row: two of the holder's
+  # inventories detaching at once would otherwise each read the other still
+  # holding its `vehicle_id`, pick the same suffix, and collide when Postgres
+  # nullifies them. Taking the row being excluded as well is what keeps the two
+  # from locking each other's row first and deadlocking.
   def claim_free_name!
-    taken = self.class.where(holder_type:, holder_id:).where.not(id:).pluck(:name, :slug)
-    names = taken.map { |taken_name, _| taken_name.downcase }
-    slugs = taken.map { |_, taken_slug| taken_slug }
+    taken = self.class.where(holder_type:, holder_id:).order(:id).lock
+      .pluck(:id, :name, :slug)
+      .reject { |taken_id, _, _| taken_id == id }
+    names = taken.map { |_, taken_name, _| taken_name.downcase }
+    slugs = taken.map { |_, _, taken_slug| taken_slug }
 
     return if names.exclude?(name.downcase) && slugs.exclude?(self.class.slug_for(name))
 

--- a/app/models/inventory.rb
+++ b/app/models/inventory.rb
@@ -83,4 +83,29 @@ class Inventory < ApplicationRecord
   def vehicle?
     vehicle_id.present?
   end
+
+  # Losing the ship puts this row into the two unique indexes that only cover
+  # `vehicle_id IS NULL`, on `lower(name)` and on `slug`. A ship inventory is
+  # named after its ship, so a user with two of the same model holds two rows
+  # with the same name and the second one to be detached collides. Postgres does
+  # the detaching itself, through `on_delete: :nullify`, so nothing on that path
+  # validates anything -- the name has to be free before the ship goes.
+  #
+  # Free among every other inventory of this holder rather than among the
+  # hand-made ones: the sibling detached in the same breath is still holding its
+  # `vehicle_id` while this runs, and would be invisible to the narrower check.
+  def claim_free_name!
+    taken = self.class.where(holder_type:, holder_id:).where.not(id:).pluck(:name, :slug)
+    names = taken.map { |taken_name, _| taken_name.downcase }
+    slugs = taken.map { |_, taken_slug| taken_slug }
+
+    return if names.exclude?(name.downcase) && slugs.exclude?(self.class.slug_for(name))
+
+    suffix = (2..).find do |candidate|
+      names.exclude?("#{name} (#{candidate})".downcase) &&
+        slugs.exclude?(self.class.slug_for("#{name} (#{candidate})"))
+    end
+
+    update!(name: "#{name} (#{suffix})")
+  end
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -317,7 +317,7 @@ class Vehicle < ApplicationRecord
     Inventory.where(vehicle_id: vehicle_ids)
       .includes(vehicle: :model)
       .find_each do |inventory|
-        inventory.update(location: inventory.vehicle.display_name) if inventory.location.blank?
+        inventory.freeze_location!(inventory.vehicle.display_name) if inventory.location.blank?
         inventory.claim_free_name!
       end
   end
@@ -574,10 +574,16 @@ class Vehicle < ApplicationRecord
   # A ship inventory outlives its ship -- the foreign key nullifies rather than
   # cascades -- so it leaves carrying the ship's name as its location, and a name
   # nothing else of this holder's has claimed.
+  #
+  # Written past validation: both values are derived rather than entered, and an
+  # inventory left invalid by something else entirely -- an image the vector
+  # validator now rejects, say -- must not be what stops somebody deleting a
+  # ship. `update` would have been worse than either: it returns false and the
+  # delete carries on, nulling `vehicle_id` on a row whose label never landed.
   private def detach_inventory
     return if inventory.blank?
 
-    inventory.update(location: display_name) if inventory.location.blank?
+    inventory.freeze_location!(display_name) if inventory.location.blank?
     inventory.claim_free_name!
   end
 

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -146,7 +146,7 @@ class Vehicle < ApplicationRecord
   before_save :reset_pledge_id_if_wanted
   before_save :update_slugs
 
-  before_destroy :freeze_inventory_location
+  before_destroy :detach_inventory
 
   after_create :broadcast_create
   after_destroy :remove_loaners, :remove_bundled_snub_crafts, :broadcast_destroy
@@ -240,7 +240,7 @@ class Vehicle < ApplicationRecord
     vehicle_ids |= descendants_of(vehicle_ids)
     loaner_groups = where(id: vehicle_ids, loaner: true).distinct.pluck(:user_id, :model_id)
 
-    freeze_inventory_locations(vehicle_ids)
+    detach_inventories(vehicle_ids)
 
     loadout_ids = VehicleLoadout.where(vehicle_id: vehicle_ids).pluck(:id)
     erase_versions("VehicleLoadout", loadout_ids)
@@ -297,15 +297,16 @@ class Vehicle < ApplicationRecord
       end
   end
 
-  # What `Vehicle#freeze_inventory_location` does on a single destroy. Iterated
-  # rather than expressed as one `UPDATE`, because the label is `display_name`
-  # and the set is bounded by the vehicles carrying an inventory, not by the
-  # vehicles being deleted.
-  private_class_method def self.freeze_inventory_locations(vehicle_ids)
-    Inventory.where(vehicle_id: vehicle_ids, location: nil)
+  # What `Vehicle#detach_inventory` does on a single destroy. Iterated rather
+  # than expressed as one `UPDATE`, because both the label and the free name are
+  # per row, and the set is bounded by the vehicles carrying an inventory rather
+  # than by the vehicles being deleted.
+  private_class_method def self.detach_inventories(vehicle_ids)
+    Inventory.where(vehicle_id: vehicle_ids)
       .includes(vehicle: :model)
       .find_each do |inventory|
-        inventory.update_column(:location, inventory.vehicle.display_name)
+        inventory.update(location: inventory.vehicle.display_name) if inventory.location.blank?
+        inventory.claim_free_name!
       end
   end
 
@@ -558,11 +559,14 @@ class Vehicle < ApplicationRecord
 
   # The foreign key nullifies `vehicle_id`, which would otherwise leave the stock
   # with no hint of where it came from.
-  private def freeze_inventory_location
+  # A ship inventory outlives its ship -- the foreign key nullifies rather than
+  # cascades -- so it leaves carrying the ship's name as its location, and a name
+  # nothing else of this holder's has claimed.
+  private def detach_inventory
     return if inventory.blank?
-    return if inventory.location.present?
 
-    inventory.update(location: display_name)
+    inventory.update(location: display_name) if inventory.location.blank?
+    inventory.claim_free_name!
   end
 
   private def model_must_be_player_ownable

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -234,30 +234,35 @@ class Vehicle < ApplicationRecord
   # the last edit is one nobody cleans up. Missing one used to mean an orphaned
   # row nobody noticed; `vehicle_loadouts` has a foreign key, so missing that one
   # raises `ActiveRecord::InvalidForeignKey` and the whole delete rolls back.
+  # Wraps itself rather than leaving it to the caller: it is a dozen statements
+  # that only make sense together, and a caller already inside a transaction
+  # joins this one rather than opening a second.
   def self.delete_with_dependents(vehicle_ids)
     return 0 if vehicle_ids.blank?
 
-    vehicle_ids |= descendants_of(vehicle_ids)
-    loaner_groups = where(id: vehicle_ids, loaner: true).distinct.pluck(:user_id, :model_id)
+    transaction do
+      vehicle_ids |= descendants_of(vehicle_ids)
+      loaner_groups = where(id: vehicle_ids, loaner: true).distinct.pluck(:user_id, :model_id)
 
-    detach_inventories(vehicle_ids)
+      detach_inventories(vehicle_ids)
 
-    loadout_ids = VehicleLoadout.where(vehicle_id: vehicle_ids).pluck(:id)
-    erase_versions("VehicleLoadout", loadout_ids)
-    VehicleLoadout.where(id: loadout_ids).delete_all
+      loadout_ids = VehicleLoadout.where(vehicle_id: vehicle_ids).pluck(:id)
+      erase_versions("VehicleLoadout", loadout_ids)
+      VehicleLoadout.where(id: loadout_ids).delete_all
 
-    VehicleUpgrade.where(vehicle_id: vehicle_ids).delete_all
-    VehicleModule.where(vehicle_id: vehicle_ids).delete_all
-    TaskForce.where(vehicle_id: vehicle_ids).delete_all
-    FleetVehicle.where(vehicle_id: vehicle_ids).delete_all
+      VehicleUpgrade.where(vehicle_id: vehicle_ids).delete_all
+      VehicleModule.where(vehicle_id: vehicle_ids).delete_all
+      TaskForce.where(vehicle_id: vehicle_ids).delete_all
+      FleetVehicle.where(vehicle_id: vehicle_ids).delete_all
 
-    erase_versions("Vehicle", vehicle_ids)
+      erase_versions("Vehicle", vehicle_ids)
 
-    deleted = where(id: vehicle_ids).delete_all
+      deleted = where(id: vehicle_ids).delete_all
 
-    revisit_loaner_visibility(loaner_groups)
+      revisit_loaner_visibility(loaner_groups)
 
-    deleted
+      deleted
+    end
   end
 
   # The loaners and bundled snub crafts `after_destroy` would have taken with
@@ -276,25 +281,32 @@ class Vehicle < ApplicationRecord
   #
   # `update_columns` skips the `after_commit` that keeps the fleet side in step,
   # and that callback returns early for a hidden vehicle anyway, so the job is
-  # queued from here.
+  # queued from here -- after the outermost transaction commits, so a worker
+  # picking it up cannot read the hangar as it was before the delete.
   private_class_method def self.revisit_loaner_visibility(loaner_groups)
     return if loaner_groups.blank?
 
     user_ids, model_ids = loaner_groups.transpose
 
-    where(loaner: true, user_id: user_ids, model_id: model_ids)
+    flipped = where(loaner: true, user_id: user_ids, model_id: model_ids)
       .group_by { |loaner| [loaner.user_id, loaner.model_id, loaner.wanted] }
-      .each do |_group_key, group|
+      .flat_map do |_group_key, group|
         visible = group.find { |loaner| !loaner.hidden? } || group.first
 
-        group.each do |loaner|
+        group.select do |loaner|
           should_hide = !loaner.equal?(visible)
-          next if loaner.hidden? == should_hide
+          next false if loaner.hidden? == should_hide
 
           loaner.update_columns(hidden: should_hide, updated_at: Time.zone.now)
-          Updater::FleetVehicleUpdateJob.perform_async(loaner.id)
+          true
         end
       end
+
+    return if flipped.empty?
+
+    ActiveRecord.after_all_transactions_commit do
+      flipped.each { |loaner| Updater::FleetVehicleUpdateJob.perform_async(loaner.id) }
+    end
   end
 
   # What `Vehicle#detach_inventory` does on a single destroy. Iterated rather

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -227,6 +227,97 @@ class Vehicle < ApplicationRecord
     where(public: true)
   end
 
+  # The hangar's bulk deletions go around `destroy`: a wishlist wipe is a few
+  # thousand rows and every callback on the way out queries, broadcasts and
+  # queues a job per vehicle. What `destroy` would have taken with it has to be
+  # cleared here instead, and the list is hand-maintained -- a table added since
+  # the last edit is one nobody cleans up. Missing one used to mean an orphaned
+  # row nobody noticed; `vehicle_loadouts` has a foreign key, so missing that one
+  # raises `ActiveRecord::InvalidForeignKey` and the whole delete rolls back.
+  def self.delete_with_dependents(vehicle_ids)
+    return 0 if vehicle_ids.blank?
+
+    vehicle_ids |= descendants_of(vehicle_ids)
+    loaner_groups = where(id: vehicle_ids, loaner: true).distinct.pluck(:user_id, :model_id)
+
+    freeze_inventory_locations(vehicle_ids)
+
+    loadout_ids = VehicleLoadout.where(vehicle_id: vehicle_ids).pluck(:id)
+    erase_versions("VehicleLoadout", loadout_ids)
+    VehicleLoadout.where(id: loadout_ids).delete_all
+
+    VehicleUpgrade.where(vehicle_id: vehicle_ids).delete_all
+    VehicleModule.where(vehicle_id: vehicle_ids).delete_all
+    TaskForce.where(vehicle_id: vehicle_ids).delete_all
+    FleetVehicle.where(vehicle_id: vehicle_ids).delete_all
+
+    erase_versions("Vehicle", vehicle_ids)
+
+    deleted = where(id: vehicle_ids).delete_all
+
+    revisit_loaner_visibility(loaner_groups)
+
+    deleted
+  end
+
+  # The loaners and bundled snub crafts `after_destroy` would have taken with
+  # the parent. One level is enough: neither is given loaners or snub crafts of
+  # its own, and nothing else ever sets `vehicle_id`.
+  private_class_method def self.descendants_of(vehicle_ids)
+    where(vehicle_id: vehicle_ids).where(loaner: true)
+      .or(where(vehicle_id: vehicle_ids).where(bundled: true))
+      .pluck(:id)
+  end
+
+  # `hidden` is a property of a whole (model, wanted) group rather than of a row
+  # -- exactly one visible -- so deleting a loaner can leave its group with none.
+  # The survivor is one already visible where there is one, so a group that was
+  # correct apart from the rows that just went keeps the loaner its user sees.
+  #
+  # `update_columns` skips the `after_commit` that keeps the fleet side in step,
+  # and that callback returns early for a hidden vehicle anyway, so the job is
+  # queued from here.
+  private_class_method def self.revisit_loaner_visibility(loaner_groups)
+    return if loaner_groups.blank?
+
+    user_ids, model_ids = loaner_groups.transpose
+
+    where(loaner: true, user_id: user_ids, model_id: model_ids)
+      .group_by { |loaner| [loaner.user_id, loaner.model_id, loaner.wanted] }
+      .each do |_group_key, group|
+        visible = group.find { |loaner| !loaner.hidden? } || group.first
+
+        group.each do |loaner|
+          should_hide = !loaner.equal?(visible)
+          next if loaner.hidden? == should_hide
+
+          loaner.update_columns(hidden: should_hide, updated_at: Time.zone.now)
+          Updater::FleetVehicleUpdateJob.perform_async(loaner.id)
+        end
+      end
+  end
+
+  # What `Vehicle#freeze_inventory_location` does on a single destroy. Iterated
+  # rather than expressed as one `UPDATE`, because the label is `display_name`
+  # and the set is bounded by the vehicles carrying an inventory, not by the
+  # vehicles being deleted.
+  private_class_method def self.freeze_inventory_locations(vehicle_ids)
+    Inventory.where(vehicle_id: vehicle_ids, location: nil)
+      .includes(vehicle: :model)
+      .find_each do |inventory|
+        inventory.update_column(:location, inventory.vehicle.display_name)
+      end
+  end
+
+  # `ErasableVersionsConcern` is an `after_destroy`, and these rows never see
+  # one. Leaving the versions behind would leave the names and serials somebody
+  # deleted sitting in a table no erasure path reaches.
+  private_class_method def self.erase_versions(item_type, item_ids)
+    return if item_ids.blank?
+
+    PaperTrail::Version.where(item_type:, item_id: item_ids).delete_all
+  end
+
   def reset_pledge_id_if_wanted
     return unless wanted?
 

--- a/app/tasks/maintenance/drop_vehicle_orphans_task.rb
+++ b/app/tasks/maintenance/drop_vehicle_orphans_task.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module Maintenance
+  # Drops the rows the hangar's bulk deletions left pointing at vehicles that no
+  # longer exist.
+  #
+  # `wishlists#destroy`, `vehicles#destroy_bulk` and `vehicles#destroy_all_ingame`
+  # go around `Vehicle#destroy` -- a wishlist wipe is a few thousand rows and
+  # every callback on the way out queues a job -- and cleared a hand-maintained
+  # list of child tables that only ever covered `vehicle_upgrades` and
+  # `vehicle_modules`. They share `Vehicle.delete_with_dependents` now, so nothing
+  # new is stranded. This clears what is already on disk:
+  #
+  #     13,437 vehicles -- 13,436 loaners and one bundled snub craft
+  #    195,457 fleet_vehicles of 1,063,946
+  #     18,278 task_forces of 96,229
+  #
+  # Only `vehicle_loadouts` has a foreign key, which is why that one table turned
+  # a silent orphan into an `ActiveRecord::InvalidForeignKey` and surfaced the
+  # rest. Nothing constrains the other three, so they accumulated unnoticed.
+  #
+  # The vehicles are not bookkeeping: 4,769 of them are visible, spread over
+  # 1,135 users, so this takes ships out of hangars people are looking at. Each
+  # is a loaner for a pledge its owner deleted, which is the case
+  # `RepairLoanerFlagsTask` deliberately left alone -- "destroying it is a
+  # decision for whoever finds out how it got orphaned". This is that decision.
+  #
+  # A maintenance task rather than a data migration, for the reason
+  # `DropChangelessVersionsTask` records: it destroys rows and cannot be undone,
+  # and `data:migrate` runs unattended inside the Kamal pre-deploy hook.
+  #
+  # It clears roughly a row in five from `fleet_vehicles` and `task_forces`, so
+  # follow it with `VACUUM ANALYZE fleet_vehicles, task_forces` for the planner's
+  # sake rather than waiting for autovacuum.
+  class DropVehicleOrphansTask < MaintenanceTasks::Task
+    no_collection
+
+    # A vehicle batch is several statements and a `hidden` regroup per pass, so
+    # it is the smaller one.
+    VEHICLE_BATCH_SIZE = 1_000
+    JOIN_BATCH_SIZE = 5_000
+
+    # Left on by default so an accidental run reports instead of destroying.
+    # `MaintenanceTasks::Runner.run` with no `arguments:` takes this default and
+    # still finishes as "succeeded", so a real run has to pass `dry_run => "0"`.
+    attribute :dry_run, :boolean, default: true
+
+    # `vehicle_id` is nowhere null in any of the three, so "missing" and "dangling"
+    # are the same set -- but `where.missing` states the one that matters, and a
+    # null arriving later is not this task's row to delete.
+    def self.orphaned_vehicles
+      Vehicle.where.not(vehicle_id: nil).where.missing(:parent_vehicle)
+    end
+
+    def self.orphaned_fleet_vehicles
+      FleetVehicle.where.missing(:vehicle)
+    end
+
+    def self.orphaned_task_forces
+      TaskForce.where.missing(:vehicle)
+    end
+
+    def process
+      dry_run ? report_plan : apply
+    end
+
+    # Vehicles first: an orphan carries `fleet_vehicles` and `task_forces` of its
+    # own, which are not orphaned while it stands, and
+    # `Vehicle.delete_with_dependents` takes them with it. Running the join tables
+    # first would leave those behind for a second run to find.
+    private def apply
+      vehicles = drop_in_batches(self.class.orphaned_vehicles, size: VEHICLE_BATCH_SIZE) do |ids|
+        Vehicle.delete_with_dependents(ids)
+      end
+
+      fleet_vehicles = drop_in_batches(self.class.orphaned_fleet_vehicles, size: JOIN_BATCH_SIZE) do |ids|
+        FleetVehicle.where(id: ids).delete_all
+      end
+
+      task_forces = drop_in_batches(self.class.orphaned_task_forces, size: JOIN_BATCH_SIZE) do |ids|
+        TaskForce.where(id: ids).delete_all
+      end
+
+      log "vehicles: deleted #{vehicles}"
+      log "fleet_vehicles: deleted #{fleet_vehicles}"
+      log "task_forces: deleted #{task_forces}"
+    end
+
+    # Re-reads the scope each pass rather than iterating it once: every row it
+    # selects on is a row it deletes, so there is no cursor to carry and nothing
+    # for a resumed run to skip past.
+    private def drop_in_batches(scope, size:)
+      deleted = 0
+
+      while (ids = scope.limit(size).pluck(:id)).any?
+        deleted += yield(ids)
+      end
+
+      deleted
+    end
+
+    # The join-table counts are reported in two parts, because that is how the
+    # apply removes them: the vehicles take their own rows with them, so the
+    # orphaned count alone does not add up to what a run reports deleting.
+    private def report_plan
+      vehicles = self.class.orphaned_vehicles
+
+      log "vehicles: #{vehicles.count} orphaned of #{Vehicle.count}, " \
+        "#{vehicles.visible.count} visible, across #{vehicles.distinct.count(:user_id)} users"
+      log "fleet_vehicles: #{self.class.orphaned_fleet_vehicles.count} orphaned of #{FleetVehicle.count}, " \
+        "plus #{FleetVehicle.where(vehicle_id: vehicles.select(:id)).count} carried by those vehicles"
+      log "task_forces: #{self.class.orphaned_task_forces.count} orphaned of #{TaskForce.count}, " \
+        "plus #{TaskForce.where(vehicle_id: vehicles.select(:id)).count} carried by those vehicles"
+      log "dry run -- nothing was deleted"
+    end
+
+    # The task's log is its output in the UI, which is stdout for this engine.
+    private def log(message)
+      puts message
+    end
+  end
+end

--- a/app/tasks/maintenance/drop_vehicle_orphans_task.rb
+++ b/app/tasks/maintenance/drop_vehicle_orphans_task.rb
@@ -45,19 +45,21 @@ module Maintenance
     # still finishes as "succeeded", so a real run has to pass `dry_run => "0"`.
     attribute :dry_run, :boolean, default: true
 
-    # `vehicle_id` is nowhere null in any of the three, so "missing" and "dangling"
-    # are the same set -- but `where.missing` states the one that matters, and a
-    # null arriving later is not this task's row to delete.
+    # `where.missing` is a left join tested for no match, which a null foreign key
+    # satisfies as readily as a dangling one. All three columns are nullable and
+    # none of them is null today, but a row that names no vehicle at all was not
+    # stranded by a delete and is not this task's to remove -- so each scope says
+    # so rather than relying on that staying true.
     def self.orphaned_vehicles
       Vehicle.where.not(vehicle_id: nil).where.missing(:parent_vehicle)
     end
 
     def self.orphaned_fleet_vehicles
-      FleetVehicle.where.missing(:vehicle)
+      FleetVehicle.where.not(vehicle_id: nil).where.missing(:vehicle)
     end
 
     def self.orphaned_task_forces
-      TaskForce.where.missing(:vehicle)
+      TaskForce.where.not(vehicle_id: nil).where.missing(:vehicle)
     end
 
     def process

--- a/test/integration/api/v1/vehicles_destroy_bulk_test.rb
+++ b/test/integration/api/v1/vehicles_destroy_bulk_test.rb
@@ -41,6 +41,23 @@ class Api::V1::VehiclesDestroyBulkTest < ActionDispatch::IntegrationTest
     assert_api_response :put, 204, body: {ids: vehicles.map(&:id)}
   end
 
+  test "PUT /vehicles/destroy-bulk destroys what hangs off the vehicles" do
+    vehicle = create(:vehicle, user: @user)
+    create(:vehicle_loadout, vehicle: vehicle)
+    TaskForce.create!(vehicle: vehicle, hangar_group: create(:hangar_group, user: @user))
+    FleetVehicle.create!(fleet: create(:fleet), vehicle: vehicle)
+    sign_in @user
+
+    assert_not_empty PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id)
+
+    assert_api_response :put, 204, body: {ids: [vehicle.id]}
+
+    assert_empty VehicleLoadout.where(vehicle_id: vehicle.id)
+    assert_empty TaskForce.where(vehicle_id: vehicle.id)
+    assert_empty FleetVehicle.where(vehicle_id: vehicle.id)
+    assert_empty PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id)
+  end
+
   test "PUT /vehicles/destroy-bulk returns 401 when not signed in" do
     vehicles = create_list(:vehicle, 3, user: @user)
 

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -377,11 +377,17 @@ class VehicleDeleteWithDependentsTest < ActiveSupport::TestCase
 
     visible = Vehicle.find_by(loaner: true, user_id: @user.id, model_id: loaner_model.id, hidden: false)
 
+    Sidekiq::Worker.clear_all
+
     Vehicle.delete_with_dependents([visible.parent_vehicle.id])
 
     remaining = Vehicle.where(loaner: true, user_id: @user.id, model_id: loaner_model.id)
     assert_equal 1, remaining.count
     assert_equal 1, remaining.where(hidden: false).count
+
+    # Queued from `after_all_transactions_commit`, so a worker cannot read the
+    # hangar as it was before the delete.
+    assert_equal [remaining.first.id], Updater::FleetVehicleUpdateJob.jobs.map { |job| job["args"].first }
   end
 
   test "detaches a ship inventory under a name no sibling holds" do

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -383,4 +383,34 @@ class VehicleDeleteWithDependentsTest < ActiveSupport::TestCase
     assert_equal 1, remaining.count
     assert_equal 1, remaining.where(hidden: false).count
   end
+
+  test "detaches a ship inventory under a name no sibling holds" do
+    model = create(:model)
+    first = create(:vehicle, user: @user, model: model)
+    second = create(:vehicle, user: @user, model: model)
+    Inventory.provision_for(first, holder: @user)
+    Inventory.provision_for(second, holder: @user)
+
+    Vehicle.delete_with_dependents([first.id, second.id])
+
+    inventories = Inventory.where(holder: @user)
+    assert_equal 2, inventories.count
+    assert_equal 2, inventories.pluck(:name).uniq.size
+    assert_equal 2, inventories.pluck(:slug).uniq.size
+    assert_equal [model.name, model.name], inventories.pluck(:location)
+    assert_equal [nil, nil], inventories.pluck(:vehicle_id)
+  end
+
+  test "detaches a ship inventory on a single destroy too" do
+    model = create(:model)
+    first = create(:vehicle, user: @user, model: model)
+    second = create(:vehicle, user: @user, model: model)
+    Inventory.provision_for(first, holder: @user)
+    Inventory.provision_for(second, holder: @user)
+
+    Vehicle.find(first.id).destroy!
+    Vehicle.find(second.id).destroy!
+
+    assert_equal 2, Inventory.where(holder: @user).pluck(:name).uniq.size
+  end
 end

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -331,3 +331,56 @@ class VehicleVersioningTest < ActiveSupport::TestCase
     end
   end
 end
+
+class VehicleDeleteWithDependentsTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+  end
+
+  test "takes the loadouts and the rows hanging off the vehicle" do
+    vehicle = create(:vehicle, user: @user)
+    create(:vehicle_loadout, vehicle: vehicle)
+    TaskForce.create!(vehicle: vehicle, hangar_group: create(:hangar_group, user: @user))
+    FleetVehicle.create!(fleet: create(:fleet), vehicle: vehicle)
+
+    Vehicle.delete_with_dependents([vehicle.id])
+
+    assert_empty Vehicle.where(id: vehicle.id)
+    assert_empty VehicleLoadout.where(vehicle_id: vehicle.id)
+    assert_empty TaskForce.where(vehicle_id: vehicle.id)
+    assert_empty FleetVehicle.where(vehicle_id: vehicle.id)
+    assert_empty PaperTrail::Version.where(item_type: "Vehicle", item_id: vehicle.id)
+  end
+
+  test "takes the loaners and bundled snub crafts of the vehicles it deletes" do
+    loaner_model = create(:model)
+    snub_craft_model = create(:model)
+    parent_model = create(:model).tap do |model|
+      model.loaners << loaner_model
+      model.snub_crafts << snub_craft_model
+    end
+    parent = create(:vehicle, user: @user, model: parent_model)
+
+    assert_equal 2, Vehicle.where(vehicle_id: parent.id).count
+
+    Vehicle.delete_with_dependents([parent.id])
+
+    assert_empty Vehicle.where(vehicle_id: parent.id)
+  end
+
+  test "leaves a visible loaner behind when the visible one is deleted" do
+    loaner_model = create(:model)
+    parent_model = create(:model).tap { |model| model.loaners << loaner_model }
+    other_parent_model = create(:model).tap { |model| model.loaners << loaner_model }
+    create(:vehicle, user: @user, model: parent_model)
+    create(:vehicle, user: @user, model: other_parent_model)
+
+    visible = Vehicle.find_by(loaner: true, user_id: @user.id, model_id: loaner_model.id, hidden: false)
+
+    Vehicle.delete_with_dependents([visible.parent_vehicle.id])
+
+    remaining = Vehicle.where(loaner: true, user_id: @user.id, model_id: loaner_model.id)
+    assert_equal 1, remaining.count
+    assert_equal 1, remaining.where(hidden: false).count
+  end
+end

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -407,6 +407,33 @@ class VehicleDeleteWithDependentsTest < ActiveSupport::TestCase
     assert_equal [nil, nil], inventories.pluck(:vehicle_id)
   end
 
+  # An inventory left invalid by something else entirely must not be what stops
+  # somebody deleting a ship, and the label still has to land.
+  test "detaches an inventory that no longer validates" do
+    vehicle = create(:vehicle, user: @user)
+    inventory = Inventory.provision_for(vehicle, holder: @user)
+    inventory.update_column(:name, "")
+    assert_not inventory.reload.valid?
+
+    Vehicle.find(vehicle.id).destroy!
+
+    assert_nil Vehicle.find_by(id: vehicle.id)
+    assert_equal vehicle.display_name, inventory.reload.location
+  end
+
+  # What keeps two inventories detaching at once from choosing the same suffix:
+  # the read is locked, and ordered so neither waits on a row the other holds.
+  test "claims the name under a lock taken in a fixed order" do
+    vehicle = create(:vehicle, user: @user)
+    Inventory.provision_for(vehicle, holder: @user)
+
+    claim = statements_for { Vehicle.find(vehicle.id).destroy! }
+      .find { |sql| sql.include?("inventories") && sql.include?("FOR UPDATE") }
+
+    assert claim, "the name claim takes no lock"
+    assert_includes claim, %(ORDER BY "inventories"."id")
+  end
+
   test "detaches a ship inventory on a single destroy too" do
     model = create(:model)
     first = create(:vehicle, user: @user, model: model)
@@ -418,5 +445,17 @@ class VehicleDeleteWithDependentsTest < ActiveSupport::TestCase
     Vehicle.find(second.id).destroy!
 
     assert_equal 2, Inventory.where(holder: @user).pluck(:name).uniq.size
+  end
+
+  private def statements_for
+    statements = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*, payload|
+      statements << payload[:sql] unless payload[:name] == "SCHEMA"
+    end
+
+    yield
+    statements
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber)
   end
 end

--- a/test/tasks/maintenance/drop_vehicle_orphans_task_test.rb
+++ b/test/tasks/maintenance/drop_vehicle_orphans_task_test.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Maintenance
+  class DropVehicleOrphansTaskTest < ActiveSupport::TestCase
+    setup do
+      @user = create(:user)
+      @kept = create(:vehicle, user: @user)
+    end
+
+    # An accidental run has to report rather than destroy, so the safe mode is
+    # the one you get by not choosing.
+    test "dry_run is on unless it is turned off" do
+      assert_predicate ::Maintenance::DropVehicleOrphansTask.new, :dry_run
+    end
+
+    test "#process leaves every row in place on a dry run" do
+      orphan_vehicle
+      orphan_fleet_vehicle
+      orphan_task_force
+
+      assert_no_difference [-> { Vehicle.count }, -> { FleetVehicle.count }, -> { TaskForce.count }] do
+        run_task(dry_run: true)
+      end
+    end
+
+    test "#process reports what it would do on a dry run" do
+      orphan = orphan_vehicle
+      FleetVehicle.create!(fleet: create(:fleet), vehicle: orphan)
+      orphan_fleet_vehicle
+      orphan_task_force
+
+      output = run_task(dry_run: true)
+
+      assert_includes output, "vehicles: 1 orphaned of #{Vehicle.count}, 1 visible, across 1 users"
+      assert_includes output, "fleet_vehicles: 1 orphaned of #{FleetVehicle.count}, plus 1 carried by those vehicles"
+      assert_includes output, "task_forces: 1 orphaned of #{TaskForce.count}, plus 0 carried by those vehicles"
+      assert_includes output, "dry run"
+    end
+
+    test "#process drops a vehicle whose parent is gone" do
+      orphan = orphan_vehicle
+
+      run_task(dry_run: false)
+
+      assert_nil Vehicle.find_by(id: orphan.id)
+      assert Vehicle.exists?(@kept.id)
+    end
+
+    test "#process drops the rows an orphaned vehicle carries" do
+      orphan = orphan_vehicle
+      carried = FleetVehicle.create!(fleet: create(:fleet), vehicle: orphan)
+      loadout = create(:vehicle_loadout, vehicle: orphan)
+
+      run_task(dry_run: false)
+
+      assert_nil FleetVehicle.find_by(id: carried.id)
+      assert_nil VehicleLoadout.find_by(id: loadout.id)
+    end
+
+    test "#process drops join rows pointing at a vehicle that is gone" do
+      fleet_vehicle = orphan_fleet_vehicle
+      task_force = orphan_task_force
+
+      run_task(dry_run: false)
+
+      assert_nil FleetVehicle.find_by(id: fleet_vehicle.id)
+      assert_nil TaskForce.find_by(id: task_force.id)
+    end
+
+    test "#process keeps the rows of a vehicle that still has its parent" do
+      loaner_model = create(:model)
+      parent_model = create(:model).tap { |model| model.loaners << loaner_model }
+      parent = create(:vehicle, user: @user, model: parent_model)
+      loaner = Vehicle.find_by!(loaner: true, vehicle_id: parent.id)
+      fleet_vehicle = FleetVehicle.create!(fleet: create(:fleet), vehicle: loaner)
+      task_force = TaskForce.create!(vehicle: @kept, hangar_group: create(:hangar_group, user: @user))
+
+      run_task(dry_run: false)
+
+      assert Vehicle.exists?(loaner.id)
+      assert FleetVehicle.exists?(fleet_vehicle.id)
+      assert TaskForce.exists?(task_force.id)
+    end
+
+    test "#process drops every orphan, not just the first batch" do
+      3.times { orphan_vehicle }
+      3.times { orphan_fleet_vehicle }
+
+      run_task(dry_run: false)
+
+      assert_empty ::Maintenance::DropVehicleOrphansTask.orphaned_vehicles
+      assert_empty ::Maintenance::DropVehicleOrphansTask.orphaned_fleet_vehicles
+    end
+
+    # A loaner left standing by a bulk delete: the row is intact, the parent it
+    # names is not.
+    private def orphan_vehicle
+      parent = create(:vehicle, user: @user)
+      orphan = create(:vehicle, :loaner, user: @user, vehicle_id: parent.id)
+      Vehicle.where(id: parent.id).delete_all
+
+      orphan
+    end
+
+    private def orphan_fleet_vehicle
+      vehicle = create(:vehicle, user: @user)
+      fleet_vehicle = FleetVehicle.create!(fleet: create(:fleet), vehicle: vehicle)
+      Vehicle.where(id: vehicle.id).delete_all
+
+      fleet_vehicle
+    end
+
+    private def orphan_task_force
+      vehicle = create(:vehicle, user: @user)
+      task_force = TaskForce.create!(vehicle: vehicle, hangar_group: create(:hangar_group, user: @user))
+      Vehicle.where(id: vehicle.id).delete_all
+
+      task_force
+    end
+
+    private def run_task(dry_run:)
+      task = ::Maintenance::DropVehicleOrphansTask.new
+      task.dry_run = dry_run
+
+      capture_io { task.process }.first
+    end
+  end
+end

--- a/test/tasks/maintenance/drop_vehicle_orphans_task_test.rb
+++ b/test/tasks/maintenance/drop_vehicle_orphans_task_test.rb
@@ -84,6 +84,20 @@ module Maintenance
       assert TaskForce.exists?(task_force.id)
     end
 
+    # `where.missing` is a left join tested for no match, which a row naming no
+    # vehicle at all satisfies too. It was not stranded by a delete, so it stays.
+    test "#process keeps a row that names no vehicle at all" do
+      fleet_vehicle = orphan_fleet_vehicle
+      task_force = orphan_task_force
+      FleetVehicle.where(id: fleet_vehicle.id).update_all(vehicle_id: nil)
+      TaskForce.where(id: task_force.id).update_all(vehicle_id: nil)
+
+      run_task(dry_run: false)
+
+      assert FleetVehicle.exists?(fleet_vehicle.id)
+      assert TaskForce.exists?(task_force.id)
+    end
+
     test "#process drops every orphan, not just the first batch" do
       3.times { orphan_vehicle }
       3.times { orphan_fleet_vehicle }


### PR DESCRIPTION
Starts from a crash on a bulk hangar delete:

```
ActiveRecord::InvalidForeignKey: PG::ForeignKeyViolation: ERROR:
  update or delete on table "vehicles" violates foreign key constraint
  "fk_rails_b167fd356b" on table "vehicle_loadouts"
```

## Why it raises

`wishlists#destroy`, `vehicles#destroy_bulk` and `vehicles#destroy_all_ingame` go around `Vehicle#destroy` on purpose — a wishlist wipe is up to 3,618 rows for one user, and every callback on the way out queries, broadcasts and queues a job. Each one cleared its own hand-maintained list of child tables instead:

```ruby
VehicleUpgrade.where(vehicle_id: vehicle_ids).delete_all
VehicleModule.where(vehicle_id: vehicle_ids).delete_all
Vehicle.where(id: vehicle_ids).delete_all
```

That list has not changed since the controllers were written. `vehicle_loadouts` arrived in April with a foreign key, which is the only reason this surfaced as an error rather than as nothing at all.

## What the silent failures left behind

The other child tables have no constraint, so they were stranded without a word. Counted in the production dump:

| | orphaned | of | |
|---|---:|---:|---|
| `fleet_vehicles` | 195,457 | 1,063,946 | 18% |
| `task_forces` | 18,278 | 96,229 | 19% |
| vehicles (loaners, bundled snub crafts) | 13,437 | 1,573,370 | 4,769 of them visible, across 1,135 users |

The vehicles are not bookkeeping — they are loaners still sitting in hangars whose parent pledge was deleted. `RepairLoanerFlagsTask` deliberately left that case alone: *"destroying it is a decision for whoever finds out how it got orphaned."*

## The fix

The three call sites share `Vehicle.delete_with_dependents` now. Beyond the missing tables it does what `destroy` would have: takes the loaners and bundled snub crafts with it, revisits `hidden` across the loaner groups it thins (queueing `FleetVehicleUpdateJob` for each row it flips, since `update_columns` skips the `after_commit` that would), and erases the versions the rows carried — `ErasableVersionsConcern` is an `after_destroy`, and these rows never saw one.

## A second bug, found on the way

A ship inventory outlives its ship by design: the foreign key nullifies rather than cascades, and `freeze_inventory_location` stamps the ship's name on it first so the detached row still says where it came from.

Losing `vehicle_id` also moves it into the two unique indexes that only cover `vehicle_id IS NULL` — on `lower(name)` and on `slug`. A ship inventory is named after its ship, so a user with two of the same model holds two rows with the same name:

```
NAMES: [["Saul Reynolds Inventory", "saul-reynolds-inventory"],
        ["Saul Reynolds Inventory", "saul-reynolds-inventory"]]
SEQ: ActiveRecord::RecordNotUnique: PG::UniqueViolation:
     duplicate key value violates unique constraint "index_inventories_on_holder_and_lower_name"
```

Deleting the first ship succeeds; deleting the second raises. **This is not limited to the bulk paths** — it reproduces with two plain sequential `destroy!` calls. Nothing catches it at the app level because Postgres does the detaching, so `validates :name, uniqueness: ..., unless: :vehicle_id?` is never on the path.

The name is made free before the ship goes, checked against *all* the holder's inventories rather than just the hand-made ones — a sibling detached in the same breath is still holding its `vehicle_id` while this runs and would be invisible to the narrower check.

Latent today (one inventory row in production), so this is ahead of the feature rather than behind it.

## The cleanup task

`Maintenance::DropVehicleOrphansTask` clears the rows already on disk. Vehicles first, through `delete_with_dependents` rather than `delete_all` — an orphan carries 4,990 `fleet_vehicles` and 3 `task_forces` of its own that are not orphaned while it stands. A dry run against the dump:

```
vehicles: 13437 orphaned of 1573370, 4769 visible, across 1135 users
fleet_vehicles: 195457 orphaned of 1063946, plus 4990 carried by those vehicles
task_forces: 18278 orphaned of 96229, plus 3 carried by those vehicles
dry run -- nothing was deleted
```

Two things to know before running it:

- **It takes ships out of live hangars** — the 4,769 visible ones, across 1,135 users.
- `dry_run` defaults to true, and `MaintenanceTasks::Runner.run(name:)` with no `arguments:` takes that default, changes nothing, and still finishes as `succeeded`. A real run needs `{"dry_run" => "0"}`.

Follow it with `VACUUM ANALYZE fleet_vehicles, task_forces` — it clears roughly a row in five from both.

## Verification

Every new test was confirmed to fail without its fix; the loadout one reproduces the exact error above.

```
794 tests, 1866 assertions, 0 failures   test/models + test/tasks + hangar/wishlist/bulk integration
2550 files inspected, no offenses        bin/ruby-lint
```

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vehicle deletion now consistently removes related loadouts, fleet assignments, task forces, bundled crafts, and history records.
  * Detached ship inventories automatically receive unique names and slugs to prevent conflicts.
  * Added maintenance tooling to identify and clean up orphaned vehicles and related records, with a safe dry-run default.

* **Bug Fixes**
  * Improved loaner visibility handling when vehicles are deleted.
  * Ensured dependent records are cleaned up during bulk and wishlist vehicle deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->