### PR TITLE
feat(admin): find and take over dimensions the game files disagree with

### DIFF
--- a/app/api_components/admin/v1/schemas/queries/model_query.rb
+++ b/app/api_components/admin/v1/schemas/queries/model_query.rb
@@ -24,6 +24,7 @@ module Admin
               topViewColoredBlank: {type: :boolean},
               frontViewBlank: {type: :boolean},
               positionsNeedCurationEq: {type: :boolean},
+              dimensionsDrifted: {type: :boolean},
               s: {anyOf: [{
                 type: :array, items: ::Shared::V1::Schemas::Sorts::ModelSortEnum
               }, ::Shared::V1::Schemas::Sorts::ModelSortEnum]},

--- a/app/controllers/admin/api/v1/models_controller.rb
+++ b/app/controllers/admin/api/v1/models_controller.rb
@@ -164,7 +164,7 @@ module Admin
         private def model_query_params
           @model_query_params ||= params.permit(q: [
             :search_cont, :name_cont, :id_eq, :front_view_blank, :fleetchart_image_blank,
-            :top_view_colored_blank, :holo_blank, :sc_key_blank, :s, :sorts,
+            :top_view_colored_blank, :holo_blank, :sc_key_blank, :dimensions_drifted, :s, :sorts,
             name_in: [], id_in: [], id_not_in: [], production_status_in: [],
             manufacturer_in: [], s: [], sorts: []
           ]).fetch(:q, {})

--- a/app/frontend/admin/components/Models/FilterForm/index.vue
+++ b/app/frontend/admin/components/Models/FilterForm/index.vue
@@ -35,6 +35,7 @@ const prefillFormValues = () => {
     topViewColoredBlank: filters.value.topViewColoredBlank,
     frontViewBlank: filters.value.frontViewBlank,
     positionsNeedCurationEq: filters.value.positionsNeedCurationEq,
+    dimensionsDrifted: filters.value.dimensionsDrifted,
   };
 };
 
@@ -131,6 +132,14 @@ watch(
       :reset-label="t('labels.all')"
       :options="booleanOptions"
       name="positionsNeedCurationEq"
+    />
+
+    <RadioList
+      v-model="form.dimensionsDrifted"
+      :label="t('labels.filters.models.dimensionsDrifted')"
+      :reset-label="t('labels.all')"
+      :options="booleanOptions"
+      name="dimensionsDrifted"
     />
 
     <br />

--- a/app/frontend/admin/pages/models/[id]/edit/metrics.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/metrics.vue
@@ -18,6 +18,7 @@ import { InputAlignmentsEnum } from "@/shared/components/base/FormInput/types";
 import ModelSizeSelect from "@/frontend/components/base/ModelSizeSelect/index.vue";
 import ModelDockSizeSelect from "@/admin/components/base/ModelDockSizeSelect/index.vue";
 import ModelVehicleSizeSelect from "@/admin/components/base/ModelVehicleSizeSelect/index.vue";
+import { hasDrifted, isAppliable } from "@/admin/utils/DimensionDrift";
 
 type Props = {
   model: ModelExtended;
@@ -89,19 +90,26 @@ const [height, heightProps] = defineField("height");
 // and nothing keeps the two in step. A difference is worth looking at but not
 // automatically wrong -- the Hull C is deliberately recorded expanded -- so it
 // is shown and taken over one field at a time.
-const drifted = (current: unknown, source?: number | null) =>
-  source !== null &&
-  source !== undefined &&
-  current !== null &&
-  current !== undefined &&
-  Number(current) !== Number(source);
-
 const lengthDrifted = computed(() =>
-  drifted(length.value, props.model.scLength),
+  hasDrifted(length.value, props.model.scLength),
 );
-const beamDrifted = computed(() => drifted(beam.value, props.model.scBeam));
+const beamDrifted = computed(() => hasDrifted(beam.value, props.model.scBeam));
 const heightDrifted = computed(() =>
-  drifted(height.value, props.model.scHeight),
+  hasDrifted(height.value, props.model.scHeight),
+);
+
+const lengthAppliable = computed(() =>
+  isAppliable(length.value, props.model.scLength),
+);
+const beamAppliable = computed(() =>
+  isAppliable(beam.value, props.model.scBeam),
+);
+const heightAppliable = computed(() =>
+  isAppliable(height.value, props.model.scHeight),
+);
+
+const anyAppliable = computed(
+  () => lengthAppliable.value || beamAppliable.value || heightAppliable.value,
 );
 
 const anyDrifted = computed(
@@ -173,7 +181,12 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
     <div v-if="anyDrifted" class="metrics__drift-notice">
       <i class="fa-duotone fa-triangle-exclamation" />
       <span>{{ t("messages.model.dimensionsDrifted") }}</span>
-      <button type="button" class="metrics__apply" @click="applyScDimensions">
+      <button
+        v-if="anyAppliable"
+        type="button"
+        class="metrics__apply"
+        @click="applyScDimensions"
+      >
         {{ t("actions.applyAllGameFileValues") }}
       </button>
     </div>
@@ -192,7 +205,7 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
               SC Length: {{ model.scLength ?? "—" }}
             </span>
             <button
-              v-if="lengthDrifted"
+              v-if="lengthAppliable"
               type="button"
               class="metrics__apply"
               @click="length = model.scLength"
@@ -216,7 +229,7 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
               SC Beam: {{ model.scBeam ?? "—" }}
             </span>
             <button
-              v-if="beamDrifted"
+              v-if="beamAppliable"
               type="button"
               class="metrics__apply"
               @click="beam = model.scBeam"
@@ -240,7 +253,7 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
               SC Height: {{ model.scHeight ?? "—" }}
             </span>
             <button
-              v-if="heightDrifted"
+              v-if="heightAppliable"
               type="button"
               class="metrics__apply"
               @click="height = model.scHeight"

--- a/app/frontend/admin/pages/models/[id]/edit/metrics.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/metrics.vue
@@ -83,6 +83,42 @@ const [extendedFleetchartOffsetBeam, extendedFleetchartOffsetBeamProps] =
   defineField("extendedFleetchartOffsetBeam");
 const [beam, beamProps] = defineField("beam");
 const [height, heightProps] = defineField("height");
+
+// `sc_*` is what the loader read from the game files and rewrites on every
+// import; the fields above are what `Dock#fits?` and the public payload use,
+// and nothing keeps the two in step. A difference is worth looking at but not
+// automatically wrong -- the Hull C is deliberately recorded expanded -- so it
+// is shown and taken over one field at a time.
+const drifted = (current: unknown, source?: number | null) =>
+  source !== null &&
+  source !== undefined &&
+  current !== null &&
+  current !== undefined &&
+  Number(current) !== Number(source);
+
+const lengthDrifted = computed(() =>
+  drifted(length.value, props.model.scLength),
+);
+const beamDrifted = computed(() => drifted(beam.value, props.model.scBeam));
+const heightDrifted = computed(() =>
+  drifted(height.value, props.model.scHeight),
+);
+
+const anyDrifted = computed(
+  () => lengthDrifted.value || beamDrifted.value || heightDrifted.value,
+);
+
+const applyScDimensions = () => {
+  if (props.model.scLength !== null && props.model.scLength !== undefined) {
+    length.value = props.model.scLength;
+  }
+  if (props.model.scBeam !== null && props.model.scBeam !== undefined) {
+    beam.value = props.model.scBeam;
+  }
+  if (props.model.scHeight !== null && props.model.scHeight !== undefined) {
+    height.value = props.model.scHeight;
+  }
+};
 const [mass, massProps] = defineField("mass");
 const [minCrew, minCrewProps] = defineField("minCrew");
 const [maxCrew, maxCrewProps] = defineField("maxCrew");
@@ -134,6 +170,13 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
       </div>
     </div>
     <hr />
+    <div v-if="anyDrifted" class="metrics__drift-notice">
+      <i class="fa-duotone fa-triangle-exclamation" />
+      <span>{{ t("messages.model.dimensionsDrifted") }}</span>
+      <button type="button" class="metrics__apply" @click="applyScDimensions">
+        {{ t("actions.applyAllGameFileValues") }}
+      </button>
+    </div>
     <div class="row">
       <div class="col-12 col-md-4">
         <FormInput
@@ -144,7 +187,19 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
           translation-key="model.length"
           :suffix="t('number.units.distance')"
         >
-          <template #subline>SC Length: {{ model.scLength }}</template>
+          <template #subline>
+            <span :class="{ 'metrics__sc--drifted': lengthDrifted }">
+              SC Length: {{ model.scLength ?? "—" }}
+            </span>
+            <button
+              v-if="lengthDrifted"
+              type="button"
+              class="metrics__apply"
+              @click="length = model.scLength"
+            >
+              {{ t("actions.applyGameFileValue") }}
+            </button>
+          </template>
         </FormInput>
       </div>
       <div class="col-12 col-md-4">
@@ -156,7 +211,19 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
           translation-key="model.beam"
           :suffix="t('number.units.distance')"
         >
-          <template #subline>SC Beam: {{ model.scBeam }}</template>
+          <template #subline>
+            <span :class="{ 'metrics__sc--drifted': beamDrifted }">
+              SC Beam: {{ model.scBeam ?? "—" }}
+            </span>
+            <button
+              v-if="beamDrifted"
+              type="button"
+              class="metrics__apply"
+              @click="beam = model.scBeam"
+            >
+              {{ t("actions.applyGameFileValue") }}
+            </button>
+          </template>
         </FormInput>
       </div>
       <div class="col-12 col-md-4">
@@ -168,7 +235,19 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
           translation-key="model.height"
           :suffix="t('number.units.distance')"
         >
-          <template #subline>SC Height: {{ model.scHeight }}</template>
+          <template #subline>
+            <span :class="{ 'metrics__sc--drifted': heightDrifted }">
+              SC Height: {{ model.scHeight ?? "—" }}
+            </span>
+            <button
+              v-if="heightDrifted"
+              type="button"
+              class="metrics__apply"
+              @click="height = model.scHeight"
+            >
+              {{ t("actions.applyGameFileValue") }}
+            </button>
+          </template>
         </FormInput>
       </div>
     </div>
@@ -394,3 +473,27 @@ const [rollBoosted, rollBoostedProps] = defineField("rollBoosted");
     </div>
   </ModelForm>
 </template>
+
+<style lang="scss" scoped>
+.metrics__drift-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.metrics__sc--drifted {
+  font-weight: 600;
+}
+
+.metrics__apply {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  font: inherit;
+  color: inherit;
+}
+</style>

--- a/app/frontend/admin/utils/DimensionDrift.spec.ts
+++ b/app/frontend/admin/utils/DimensionDrift.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { hasDrifted, isAppliable, isPresent } from "./DimensionDrift";
+
+describe("isPresent", () => {
+  it("counts zero and empty string as present", () => {
+    expect(isPresent(0)).toBe(true);
+    expect(isPresent("")).toBe(true);
+  });
+
+  it("counts null and undefined as absent", () => {
+    expect(isPresent(null)).toBe(false);
+    expect(isPresent(undefined)).toBe(false);
+  });
+});
+
+describe("hasDrifted", () => {
+  it("is false when the two agree", () => {
+    expect(hasDrifted(10, 10)).toBe(false);
+  });
+
+  it("is false when the field is a string of the same number", () => {
+    expect(hasDrifted("10", 10)).toBe(false);
+    expect(hasDrifted("10.00", 10)).toBe(false);
+  });
+
+  it("is true when they differ", () => {
+    expect(hasDrifted(10, 12)).toBe(true);
+  });
+
+  // The backend scope selects these, so the page has to show something.
+  it("is true when the game files gave no value", () => {
+    expect(hasDrifted(10, null)).toBe(true);
+    expect(hasDrifted(10, undefined)).toBe(true);
+  });
+
+  it("is false when neither side has a value", () => {
+    expect(hasDrifted(null, null)).toBe(false);
+    expect(hasDrifted(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("isAppliable", () => {
+  it("is true when there is a differing value to take over", () => {
+    expect(isAppliable(10, 12)).toBe(true);
+  });
+
+  it("is false when they already agree", () => {
+    expect(isAppliable(10, 10)).toBe(false);
+  });
+
+  // Drifted, but there is nothing to copy -- so no button.
+  it("is false when the game files gave no value", () => {
+    expect(isAppliable(10, null)).toBe(false);
+    expect(hasDrifted(10, null)).toBe(true);
+  });
+});

--- a/app/frontend/admin/utils/DimensionDrift.ts
+++ b/app/frontend/admin/utils/DimensionDrift.ts
@@ -1,0 +1,27 @@
+// Whether a curated dimension disagrees with what the loader read from the game
+// files. The two are kept in separate columns and nothing keeps them in step,
+// so the admin has to be able to see the difference and take the value over.
+//
+// A missing game-file value counts as a difference, matching the backend scope:
+// a model the filter selected because its `scHeight` is null would otherwise
+// show nothing at all on the page it sent the administrator to. There is just
+// nothing to take over in that case, which is what `isAppliable` separates.
+
+export const isPresent = (value: unknown): boolean =>
+  value !== null && value !== undefined;
+
+export const hasDrifted = (
+  current: unknown,
+  source?: number | null,
+): boolean => {
+  if (!isPresent(source)) {
+    return isPresent(current);
+  }
+
+  return isPresent(current) && Number(current) !== Number(source);
+};
+
+export const isAppliable = (
+  current: unknown,
+  source?: number | null,
+): boolean => isPresent(source) && hasDrifted(current, source);

--- a/app/frontend/translations/de/actions.json
+++ b/app/frontend/translations/de/actions.json
@@ -372,7 +372,9 @@
         "downloadExample": "Beispieldatei",
         "toggleDetails": "Details anzeigen"
       },
-      "selectFile": "Datei auswählen"
+      "selectFile": "Datei auswählen",
+      "applyGameFileValue": "Übernehmen",
+      "applyAllGameFileValues": "Alle übernehmen"
     }
   }
 }

--- a/app/frontend/translations/de/labels.json
+++ b/app/frontend/translations/de/labels.json
@@ -1463,7 +1463,8 @@
           "frontViewBlank": "Ohne Frontansicht-Bild?",
           "topViewColoredBlank": "Ohne farbige Draufsicht?",
           "scIdentifierBlank": "Ohne SC-Kennung?",
-          "vehicleSize": "Fahrzeuggröße"
+          "vehicleSize": "Fahrzeuggröße",
+          "dimensionsDrifted": "Maße weichen von den Spieldateien ab"
         },
         "modelModules": {
           "name": "Name"

--- a/app/frontend/translations/de/messages.json
+++ b/app/frontend/translations/de/messages.json
@@ -150,7 +150,8 @@
         "onSale": "%{model} jetzt im Verkauf!",
         "syncMatrixStarted": "Matrix-Synchronisation gestartet. Du wirst benachrichtigt, wenn sie abgeschlossen ist.",
         "syncScDataStarted": "SC-Daten-Synchronisation gestartet. Du wirst benachrichtigt, wenn sie abgeschlossen ist.",
-        "importPaintsStarted": "Lackierungs-Import gestartet. Du wirst benachrichtigt, sobald er abgeschlossen ist."
+        "importPaintsStarted": "Lackierungs-Import gestartet. Du wirst benachrichtigt, sobald er abgeschlossen ist.",
+        "dimensionsDrifted": "Diese Maße weichen von den Spieldateien ab."
       },
       "fundingGoal": {
         "created": "Finanzierungsziel angelegt.",

--- a/app/frontend/translations/en/actions.json
+++ b/app/frontend/translations/en/actions.json
@@ -372,7 +372,9 @@
         "downloadExample": "Example file",
         "toggleDetails": "Show what happened"
       },
-      "selectFile": "Select File"
+      "selectFile": "Select File",
+      "applyGameFileValue": "Apply",
+      "applyAllGameFileValues": "Apply all"
     }
   }
 }

--- a/app/frontend/translations/en/labels.json
+++ b/app/frontend/translations/en/labels.json
@@ -1458,7 +1458,8 @@
           "holoBlank": "Without Holo?",
           "frontViewBlank": "Without Front View Image?",
           "topViewColoredBlank": "Without Top View Colored Image?",
-          "vehicleSize": "Vehicle Size"
+          "vehicleSize": "Vehicle Size",
+          "dimensionsDrifted": "Dimensions differ from game files"
         },
         "modelModules": {
           "name": "Name"

--- a/app/frontend/translations/en/messages.json
+++ b/app/frontend/translations/en/messages.json
@@ -149,7 +149,8 @@
         "onSale": "%{model} now on Sale!",
         "syncMatrixStarted": "Model matrix sync started. You will be notified when it completes.",
         "syncScDataStarted": "Model SC data sync started. You will be notified when it completes.",
-        "importPaintsStarted": "Paint import started. You will be notified when it completes."
+        "importPaintsStarted": "Paint import started. You will be notified when it completes.",
+        "dimensionsDrifted": "These dimensions differ from the game files."
       },
       "fundingGoal": {
         "created": "Funding goal created.",

--- a/app/frontend/translations/es/actions.json
+++ b/app/frontend/translations/es/actions.json
@@ -372,7 +372,9 @@
         "downloadExample": "Archivo de ejemplo",
         "toggleDetails": "Ver qué ocurrió"
       },
-      "selectFile": "Seleccionar archivo"
+      "selectFile": "Seleccionar archivo",
+      "applyGameFileValue": "Aplicar",
+      "applyAllGameFileValues": "Aplicar todo"
     }
   }
 }

--- a/app/frontend/translations/es/labels.json
+++ b/app/frontend/translations/es/labels.json
@@ -1463,7 +1463,8 @@
           "frontViewBlank": "¿Sin imagen de vista frontal?",
           "topViewColoredBlank": "¿Sin imagen de vista superior a color?",
           "scIdentifierBlank": "¿Sin identificador SC?",
-          "vehicleSize": "Tamaño de vehículo"
+          "vehicleSize": "Tamaño de vehículo",
+          "dimensionsDrifted": "Dimensiones difieren de los archivos del juego"
         },
         "modelModules": {
           "name": "Nombre"

--- a/app/frontend/translations/es/messages.json
+++ b/app/frontend/translations/es/messages.json
@@ -150,7 +150,8 @@
         "onSale": "¡%{model} ahora en oferta!",
         "syncMatrixStarted": "Model matrix sync started. You will be notified when it completes.",
         "syncScDataStarted": "Model SC data sync started. You will be notified when it completes.",
-        "importPaintsStarted": "Importación de pinturas iniciada. Se te avisará cuando termine."
+        "importPaintsStarted": "Importación de pinturas iniciada. Se te avisará cuando termine.",
+        "dimensionsDrifted": "Estas dimensiones difieren de los archivos del juego."
       },
       "fundingGoal": {
         "created": "Objetivo de financiación creado.",

--- a/app/frontend/translations/fr/actions.json
+++ b/app/frontend/translations/fr/actions.json
@@ -372,7 +372,9 @@
         "downloadExample": "Fichier d'exemple",
         "toggleDetails": "Voir ce qui s'est passé"
       },
-      "selectFile": "Choisir un fichier"
+      "selectFile": "Choisir un fichier",
+      "applyGameFileValue": "Appliquer",
+      "applyAllGameFileValues": "Tout appliquer"
     }
   }
 }

--- a/app/frontend/translations/fr/labels.json
+++ b/app/frontend/translations/fr/labels.json
@@ -1463,7 +1463,8 @@
           "frontViewBlank": "Sans image de vue de face ?",
           "topViewColoredBlank": "Sans image de vue de dessus colorée ?",
           "scIdentifierBlank": "Sans identifiant SC ?",
-          "vehicleSize": "Taille de véhicule"
+          "vehicleSize": "Taille de véhicule",
+          "dimensionsDrifted": "Dimensions différentes des fichiers de jeu"
         },
         "modelModules": {
           "name": "Nom"

--- a/app/frontend/translations/fr/messages.json
+++ b/app/frontend/translations/fr/messages.json
@@ -150,7 +150,8 @@
         "onSale": "%{model} maintenant en vente !",
         "syncMatrixStarted": "Model matrix sync started. You will be notified when it completes.",
         "syncScDataStarted": "Model SC data sync started. You will be notified when it completes.",
-        "importPaintsStarted": "Import des peintures démarré. Vous serez notifié lorsqu'il sera terminé."
+        "importPaintsStarted": "Import des peintures démarré. Vous serez notifié lorsqu'il sera terminé.",
+        "dimensionsDrifted": "Ces dimensions diffèrent des fichiers de jeu."
       },
       "fundingGoal": {
         "created": "Objectif de financement créé.",

--- a/app/frontend/translations/it/actions.json
+++ b/app/frontend/translations/it/actions.json
@@ -372,7 +372,9 @@
         "downloadExample": "File di esempio",
         "toggleDetails": "Mostra cosa è successo"
       },
-      "selectFile": "Seleziona file"
+      "selectFile": "Seleziona file",
+      "applyGameFileValue": "Applica",
+      "applyAllGameFileValues": "Applica tutto"
     }
   }
 }

--- a/app/frontend/translations/it/labels.json
+++ b/app/frontend/translations/it/labels.json
@@ -1463,7 +1463,8 @@
           "frontViewBlank": "Senza immagine vista frontale?",
           "topViewColoredBlank": "Senza immagine vista dall'alto a colori?",
           "scIdentifierBlank": "Senza identificatore SC?",
-          "vehicleSize": "Dimensione del veicolo"
+          "vehicleSize": "Dimensione del veicolo",
+          "dimensionsDrifted": "Dimensioni diverse dai file di gioco"
         },
         "modelModules": {
           "name": "Nome"

--- a/app/frontend/translations/it/messages.json
+++ b/app/frontend/translations/it/messages.json
@@ -149,7 +149,8 @@
         "onSale": "%{model} è ora in vendita!",
         "syncMatrixStarted": "Model matrix sync started. You will be notified when it completes.",
         "syncScDataStarted": "Model SC data sync started. You will be notified when it completes.",
-        "importPaintsStarted": "Importazione delle verniciature avviata. Riceverai una notifica al termine."
+        "importPaintsStarted": "Importazione delle verniciature avviata. Riceverai una notifica al termine.",
+        "dimensionsDrifted": "Queste dimensioni differiscono dai file di gioco."
       },
       "fundingGoal": {
         "created": "Obiettivo di finanziamento creato.",

--- a/app/frontend/translations/zh-CN/actions.json
+++ b/app/frontend/translations/zh-CN/actions.json
@@ -372,7 +372,9 @@
         "downloadExample": "示例文件",
         "toggleDetails": "查看详情"
       },
-      "selectFile": "选择文件"
+      "selectFile": "选择文件",
+      "applyGameFileValue": "采用",
+      "applyAllGameFileValues": "全部采用"
     }
   }
 }

--- a/app/frontend/translations/zh-CN/labels.json
+++ b/app/frontend/translations/zh-CN/labels.json
@@ -1463,7 +1463,8 @@
           "frontViewBlank": "没有前视图图片?",
           "topViewColoredBlank": "没有彩色俯视图图片?",
           "scIdentifierBlank": "没有 SC 标识?",
-          "vehicleSize": "载具尺寸"
+          "vehicleSize": "载具尺寸",
+          "dimensionsDrifted": "尺寸与游戏文件不一致"
         },
         "modelModules": {
           "name": "名称"

--- a/app/frontend/translations/zh-CN/messages.json
+++ b/app/frontend/translations/zh-CN/messages.json
@@ -149,7 +149,8 @@
         "onSale": "%{model} 现在特价销售！",
         "syncMatrixStarted": "Model matrix sync started. You will be notified when it completes.",
         "syncScDataStarted": "Model SC data sync started. You will be notified when it completes.",
-        "importPaintsStarted": "涂装导入已开始。完成后将通知您。"
+        "importPaintsStarted": "涂装导入已开始。完成后将通知您。",
+        "dimensionsDrifted": "这些尺寸与游戏文件不一致。"
       },
       "fundingGoal": {
         "created": "筹款目标已创建。",

--- a/app/frontend/translations/zh-TW/actions.json
+++ b/app/frontend/translations/zh-TW/actions.json
@@ -372,7 +372,9 @@
         "downloadExample": "範例檔案",
         "toggleDetails": "查看詳情"
       },
-      "selectFile": "選擇檔案"
+      "selectFile": "選擇檔案",
+      "applyGameFileValue": "採用",
+      "applyAllGameFileValues": "全部採用"
     }
   }
 }

--- a/app/frontend/translations/zh-TW/labels.json
+++ b/app/frontend/translations/zh-TW/labels.json
@@ -1463,7 +1463,8 @@
           "frontViewBlank": "沒有前視圖圖片?",
           "topViewColoredBlank": "沒有彩色俯視圖圖片?",
           "scIdentifierBlank": "沒有 SC 標識?",
-          "vehicleSize": "載具尺寸"
+          "vehicleSize": "載具尺寸",
+          "dimensionsDrifted": "尺寸與遊戲檔案不一致"
         },
         "modelModules": {
           "name": "名稱"

--- a/app/frontend/translations/zh-TW/messages.json
+++ b/app/frontend/translations/zh-TW/messages.json
@@ -149,7 +149,8 @@
         "onSale": "%{model}現在特價中！",
         "syncMatrixStarted": "Model matrix sync started. You will be notified when it completes.",
         "syncScDataStarted": "Model SC data sync started. You will be notified when it completes.",
-        "importPaintsStarted": "塗裝匯入已開始。完成後會通知您。"
+        "importPaintsStarted": "塗裝匯入已開始。完成後會通知您。",
+        "dimensionsDrifted": "這些尺寸與遊戲檔案不一致。"
       },
       "fundingGoal": {
         "created": "募資目標已建立。",

--- a/app/models/dock.rb
+++ b/app/models/dock.rb
@@ -13,7 +13,6 @@
 #  max_ship_size :integer
 #  min_ship_size :integer
 #  name          :string
-#  ramp          :boolean          default(FALSE), not null
 #  ship_size     :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -628,17 +628,26 @@ class Model < ApplicationRecord
   # to look at, and the taking-over happens one field at a time.
   #
   # `IS DISTINCT FROM` rather than `<>`, which is NULL when either side is, and
-  # would drop a model whose curated height was never filled in.
-  scope :dimensions_drifted, ->(flag = true) {
-    unless ActiveModel::Type::Boolean.new.cast(flag)
-      next all
-    end
+  # would drop a model whose game-file height the loader never wrote.
+  #
+  # The filter offers yes and no, so `false` answers the opposite question --
+  # the models the loader described and whose dimensions match it -- rather than
+  # falling through to everything, which would have made "no" indistinguishable
+  # from clearing the filter.
+  DIMENSION_DRIFT_SQL = <<~SQL.squish
+    models.length IS DISTINCT FROM models.sc_length
+    OR models.beam IS DISTINCT FROM models.sc_beam
+    OR models.height IS DISTINCT FROM models.sc_height
+  SQL
 
-    where.not(sc_length: nil).where(
-      "models.length IS DISTINCT FROM models.sc_length" \
-      " OR models.beam IS DISTINCT FROM models.sc_beam" \
-      " OR models.height IS DISTINCT FROM models.sc_height"
-    )
+  scope :dimensions_drifted, ->(flag = true) {
+    described = where.not(sc_length: nil)
+
+    if ActiveModel::Type::Boolean.new.cast(flag)
+      described.where(DIMENSION_DRIFT_SQL)
+    else
+      described.where.not(DIMENSION_DRIFT_SQL)
+    end
   }
 
   def self.ransackable_scopes(auth_object = nil)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -618,6 +618,33 @@ class Model < ApplicationRecord
     where(active: true)
   end
 
+  # Where the curated dimensions disagree with what the loader read from the game
+  # files. `sc_*` is rewritten on every load; `length`/`beam`/`height` are what
+  # `Dock#fits?` and the public payload use, and nothing keeps the two in step --
+  # 111 of the 216 models carrying both had drifted when this was added.
+  #
+  # Not every difference is a mistake: the Hull C is recorded expanded at 125 m
+  # against 91 m in the files, which is a deliberate curation. So this finds them
+  # to look at, and the taking-over happens one field at a time.
+  #
+  # `IS DISTINCT FROM` rather than `<>`, which is NULL when either side is, and
+  # would drop a model whose curated height was never filled in.
+  scope :dimensions_drifted, ->(flag = true) {
+    unless ActiveModel::Type::Boolean.new.cast(flag)
+      next all
+    end
+
+    where.not(sc_length: nil).where(
+      "models.length IS DISTINCT FROM models.sc_length" \
+      " OR models.beam IS DISTINCT FROM models.sc_beam" \
+      " OR models.height IS DISTINCT FROM models.sc_height"
+    )
+  }
+
+  def self.ransackable_scopes(auth_object = nil)
+    ["dimensions_drifted"]
+  end
+
   def self.with_dock
     includes(:docks).where.not(docks: {model_id: nil})
   end

--- a/swagger/admin/v1/schema.yaml
+++ b/swagger/admin/v1/schema.yaml
@@ -14327,6 +14327,8 @@ components:
           type: boolean
         positionsNeedCurationEq:
           type: boolean
+        dimensionsDrifted:
+          type: boolean
         s:
           anyOf:
           - type: array

--- a/test/integration/admin/api/v1/models_test.rb
+++ b/test/integration/admin/api/v1/models_test.rb
@@ -176,6 +176,20 @@ class Admin::Api::V1::ModelsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "GET /models filters by dimensionsDrifted" do
+    create(:model, length: 10.0, beam: 5.0, height: 3.0,
+      sc_length: 10.0, sc_beam: 5.0, sc_height: 3.0)
+    drifted = create(:model, length: 10.0, beam: 5.0, height: 3.0,
+      sc_length: 12.0, sc_beam: 5.0, sc_height: 3.0)
+    # No game-file values at all is not a difference; it is silence.
+    create(:model, length: 10.0, beam: 5.0, height: 3.0)
+    sign_in @user
+
+    assert_api_response :get, 200, params: {q: {"dimensionsDrifted" => true}} do
+      assert_equal [drifted.name], parsed_body["items"].map { |item| item["name"] }
+    end
+  end
+
   test "GET /models honours perPage and totals" do
     create_list(:model, 10)
     sign_in @user

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -128,6 +128,43 @@ require "test_helper"
 #  index_models_on_size                      (size)
 #
 class ModelTest < ActiveSupport::TestCase
+  # The loader rewrites sc_* on every import while the curated columns -- the
+  # ones fits? and the public payload read -- stay put. Nothing kept them in
+  # step, so this is how the drift becomes findable.
+  test "#dimensions_drifted finds a curated value that disagrees with the game files" do
+    same = create(:model, length: 10.0, beam: 5.0, height: 3.0,
+      sc_length: 10.0, sc_beam: 5.0, sc_height: 3.0)
+    drifted = create(:model, length: 10.0, beam: 5.0, height: 3.0,
+      sc_length: 12.0, sc_beam: 5.0, sc_height: 3.0)
+
+    results = Model.dimensions_drifted
+
+    assert_includes results, drifted
+    assert_not_includes results, same
+  end
+
+  test "#dimensions_drifted ignores a model the loader never touched" do
+    untouched = create(:model, length: 10.0, beam: 5.0, height: 3.0, sc_length: nil)
+
+    assert_not_includes Model.dimensions_drifted, untouched
+  end
+
+  # The game files can describe a hull without giving every axis. A curated
+  # height against no game-file height is still a difference worth seeing, and
+  # `<>` would be NULL there and drop the row.
+  test "#dimensions_drifted sees a null on the game-file side" do
+    partial = create(:model, length: 10.0, beam: 5.0, height: 3.0,
+      sc_length: 10.0, sc_beam: 5.0, sc_height: nil)
+
+    assert_includes Model.dimensions_drifted, partial
+  end
+
+  test "#dimensions_drifted passed false is every model" do
+    create(:model, length: 10.0, sc_length: 12.0)
+
+    assert_equal Model.count, Model.dimensions_drifted(false).count
+  end
+
   test "#hangar_link_slug returns the legacy_slug when present" do
     manufacturer = create(:manufacturer, code: "DRAK")
     model = create(:model, name: "Corsair", manufacturer:)

--- a/test/models/model_test.rb
+++ b/test/models/model_test.rb
@@ -159,10 +159,20 @@ class ModelTest < ActiveSupport::TestCase
     assert_includes Model.dimensions_drifted, partial
   end
 
-  test "#dimensions_drifted passed false is every model" do
-    create(:model, length: 10.0, sc_length: 12.0)
+  # "No" on the filter has to answer the opposite question. Falling through to
+  # everything would make it indistinguishable from clearing the filter.
+  test "#dimensions_drifted passed false is the models that agree" do
+    same = create(:model, length: 10.0, beam: 5.0, height: 3.0,
+      sc_length: 10.0, sc_beam: 5.0, sc_height: 3.0)
+    drifted = create(:model, length: 10.0, beam: 5.0, height: 3.0,
+      sc_length: 12.0, sc_beam: 5.0, sc_height: 3.0)
+    untouched = create(:model, length: 10.0, beam: 5.0, height: 3.0, sc_length: nil)
 
-    assert_equal Model.count, Model.dimensions_drifted(false).count
+    results = Model.dimensions_drifted(false)
+
+    assert_includes results, same
+    assert_not_includes results, drifted
+    assert_not_includes results, untouched
   end
 
   test "#hangar_link_slug returns the legacy_slug when present" do


### PR DESCRIPTION
A model carries **two sets of dimensions** and nothing kept them in step.

`sc_length` / `sc_beam` / `sc_height` are what the loader reads from the game files and rewrites on every import. `length` / `beam` / `height` are what `Dock#fits?` and the public payload use. **111 of the 216 models carrying both have drifted.**

The values were already on the metrics page — as a subline under each field. But nothing said that a subline *disagreed* with the field above it, and at 105 models where they match you stop reading them. Taking one over meant retyping it by hand.

## What this adds

**A filter on the admin model list** — `dimensionsDrifted`, so the 111 are findable instead of theoretical.

**Marked sublines** on the metrics page when the game-file value differs from the field.

**A button per field**, and one for all three. That is the part that was missing: the number was on screen and could only be copied by typing it.

## Not a bulk sync, on purpose

Not every difference is a mistake. The Hull C is recorded expanded at 125 m against 91 m in the files — a deliberate curation that a blanket "apply all" would destroy. Roughly six of the 111 are pure axis swaps where the loader is demonstrably right; the rest need somebody who knows the ship.

## Notes

`IS DISTINCT FROM` rather than `<>`, which is NULL when either side is and would drop a model the loader gave no height for. There is a test for exactly that case.

`ransackable_scopes` follows the `Component.current_version` precedent — the scope takes the flag as its single argument.

## Verification

- 82 tests green across the model and admin-model suites, four of them new
- `ruby-lint`, `lint:ts`, `lint:js`, prettier clean
- Schema and clients regenerated
- Scope SQL checked against the production dump: 111, matching a Ruby-side comparison of the same rows

🤖
