### PR TITLE
fix(sc-data): read the Nox with its length on z

### DIFF
--- a/app/lib/sc_data/loader/models_loader.rb
+++ b/app/lib/sc_data/loader/models_loader.rb
@@ -34,6 +34,8 @@ module ScData
         "rsi_scorpius_antares" => %i[x y z],
         "rsi_hermes" => %i[x y z],
         "tmbl_cyclone" => %i[x y z],
+        "xian_nox" => %i[z x y],
+        "xian_nox_kue" => %i[z x y],
         "tmbl_storm_aa" => %i[x y z]
       }.freeze
 

--- a/test/loaders/sc_data/models_loader_test.rb
+++ b/test/loaders/sc_data/models_loader_test.rb
@@ -74,6 +74,26 @@ module ScData
         assert_in_delta 13.4, model.sc_height.to_f
       end
 
+      # A hover bike, and the third ship authored with its length on z. Left on the
+      # default it came out 1.45 m long and 5.15 m tall, which is a bike stood on
+      # its end -- and both columns agreed on it, because both come from the same
+      # bounding box.
+      test "#load_model uses the curated order for the Nox" do
+        loader = ::ScData::Loader::ModelsLoader.new
+        model = create(:model, name: "Nox", sc_key: "xian_nox")
+
+        loader.stubs(:load_model_data).returns(
+          {"mass" => 1000.0, "loadout" => [], "metrics" => {"x" => 1.32, "y" => 1.45, "z" => 5.15}}
+        )
+
+        loader.load_model(model)
+        model.reload
+
+        assert_in_delta 5.15, model.sc_length.to_f
+        assert_in_delta 1.32, model.sc_beam.to_f
+        assert_in_delta 1.45, model.sc_height.to_f
+      end
+
       # The Cyclone is the case that shows why the renders decide this and not the
       # matrix: the matrix has it 6.0 m long and 8.8 m wide, and the render says
       # the opposite. So the curated order deliberately disagrees with the matrix.

--- a/test/loaders/sc_data/models_loader_test.rb
+++ b/test/loaders/sc_data/models_loader_test.rb
@@ -78,20 +78,24 @@ module ScData
       # default it came out 1.45 m long and 5.15 m tall, which is a bike stood on
       # its end -- and both columns agreed on it, because both come from the same
       # bounding box.
-      test "#load_model uses the curated order for the Nox" do
-        loader = ::ScData::Loader::ModelsLoader.new
-        model = create(:model, name: "Nox", sc_key: "xian_nox")
+      # Both keys, because the Kue is a separate entry and a typo in it would
+      # restore the bad dimensions for that one variant without failing anything.
+      {"Nox" => "xian_nox", "Nox Kue" => "xian_nox_kue"}.each do |name, key|
+        test "#load_model uses the curated order for the #{name}" do
+          loader = ::ScData::Loader::ModelsLoader.new
+          model = create(:model, name:, sc_key: key)
 
-        loader.stubs(:load_model_data).returns(
-          {"mass" => 1000.0, "loadout" => [], "metrics" => {"x" => 1.32, "y" => 1.45, "z" => 5.15}}
-        )
+          loader.stubs(:load_model_data).returns(
+            {"mass" => 1000.0, "loadout" => [], "metrics" => {"x" => 1.32, "y" => 1.45, "z" => 5.15}}
+          )
 
-        loader.load_model(model)
-        model.reload
+          loader.load_model(model)
+          model.reload
 
-        assert_in_delta 5.15, model.sc_length.to_f
-        assert_in_delta 1.32, model.sc_beam.to_f
-        assert_in_delta 1.45, model.sc_height.to_f
+          assert_in_delta 5.15, model.sc_length.to_f
+          assert_in_delta 1.32, model.sc_beam.to_f
+          assert_in_delta 1.45, model.sc_height.to_f
+        end
       end
 
       # The Cyclone is the case that shows why the renders decide this and not the


### PR DESCRIPTION
Left on the default axis order the Nox reads **1.45 m long and 5.15 m tall** — a hover bike stood on its end.

Both dimension columns agreed on it, because `length/beam/height` and `sc_*` trace back to the same bounding box. So nothing flagged it: it is not a drift between curated and loaded values, it is the order being wrong at the source for both.

`%i[z x y]` — the same permutation as the Caterpillar, from the same source, the proportions read off the orthographic renders. That gives 5.15 × 1.32 × 1.45, which is a bike.

Covers the Kue, which is the same chassis.

## Note

This takes effect on the **next model load**. The stored rows keep the old order until then, so the Nox stays wrong in production until a load runs.

## Verification

- 11 loader tests green, one of them new and shaped like the existing Caterpillar and Cyclone cases
- `ruby-lint` clean

🤖
