### PR TITLE
fix(admin): render the dropdowns in four more forms

### DIFF
--- a/app/frontend/admin/components/ItemPrices/List.vue
+++ b/app/frontend/admin/components/ItemPrices/List.vue
@@ -27,6 +27,9 @@ import {
 import BasePill from "@/shared/components/base/Pill/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
 import { PillVariantsEnum } from "@/shared/components/base/Pill/types";
+// Registered globally as `Select`, so `<BaseSelect>` resolves to nothing
+// without this and every dropdown below renders as an empty comment.
+import BaseSelect from "@/shared/components/base/Select/index.vue";
 
 interface ItemPriceFormData extends ItemPriceInput {
   timeRange?: (typeof ItemPriceTimeRangeEnum)[keyof typeof ItemPriceTimeRangeEnum];

--- a/app/frontend/admin/pages/models/[id]/edit/hardpoints.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/hardpoints.vue
@@ -9,6 +9,9 @@ import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
 import BasePill from "@/shared/components/base/Pill/index.vue";
+// Registered globally as `Select`, so `<BaseSelect>` resolves to nothing
+// without this and every dropdown below renders as an empty comment.
+import BaseSelect from "@/shared/components/base/Select/index.vue";
 import {
   type AdminHardpoint,
   type AdminHardpointInput,

--- a/app/frontend/admin/pages/models/[id]/edit/positions.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/positions.vue
@@ -24,6 +24,9 @@ import { useQueryClient } from "@tanstack/vue-query";
 import { usePagination } from "@/shared/composables/usePagination";
 import Paginator from "@/shared/components/Paginator/index.vue";
 import BasePill from "@/shared/components/base/Pill/index.vue";
+// Registered globally as `Select`, so `<BaseSelect>` resolves to nothing
+// without this and every dropdown below renders as an empty comment.
+import BaseSelect from "@/shared/components/base/Select/index.vue";
 
 type Props = {
   model: ModelExtended;

--- a/app/frontend/admin/pages/models/[id]/edit/videos.vue
+++ b/app/frontend/admin/pages/models/[id]/edit/videos.vue
@@ -7,6 +7,9 @@ export default {
 <script lang="ts" setup>
 import { useI18n } from "@/shared/composables/useI18n";
 import Heading from "@/shared/components/base/Heading/index.vue";
+// Registered globally as `Select`, so `<BaseSelect>` resolves to nothing
+// without this and every dropdown below renders as an empty comment.
+import BaseSelect from "@/shared/components/base/Select/index.vue";
 import InlineEditableList from "@/shared/components/InlineEditableList/index.vue";
 import {
   type ModelExtended,


### PR DESCRIPTION
`<BaseSelect>` is registered globally as **`Select`** — the auto-import scans `shared/components/base`, so `base/Select/index.vue` becomes `Select`, and `BaseSelect` matches nothing. The tag resolves to an empty comment and the dropdown never appears.

Four admin forms use it without importing it, so their dropdowns have never rendered:

- item prices
- model positions
- videos
- hardpoints

Whatever those selects were meant to set could only ever be saved as whatever the create form preselected, because nobody could reach them. That is how every dock created through the admin ended up a `landingpad / medium`.

One import per file. The tag stays `BaseSelect` in the templates, matching how `BasePill` is imported alongside it.

`docks.vue` has the same bug and is fixed in #4869, which replaces that page with a shared component. Touching it here would only collide.

## Verification

- `lint:ts`, `lint:js`, prettier clean

🤖
