### PR TITLE
fix(users): drop the counter_cache that made .size raise

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,12 +125,10 @@ class User < ApplicationRecord
   has_many :purchased_vehicles,
     -> { where(wanted: false) },
     class_name: "Vehicle",
-    counter_cache: true,
     inverse_of: false
   has_many :wanted_vehicles,
     -> { where(wanted: true) },
     class_name: "Vehicle",
-    counter_cache: true,
     inverse_of: false
   has_many :models,
     through: :vehicles

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -273,3 +273,35 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 end
+
+# `counter_cache: true` belongs on a `belongs_to`, and `Vehicle belongs_to :user`
+# never declared it -- so on these two scoped `has_many`s it maintained nothing,
+# while still making the reflection claim a cached counter with no column behind
+# it. `size` then raised `NoMethodError` inside `counter_cache_column`, where
+# `count` and `length` answered correctly.
+class UserVehicleCountingTest < ActiveSupport::TestCase
+  setup do
+    @user = create(:user)
+    create_list(:vehicle, 3, user: @user, wanted: false)
+    create(:vehicle, user: @user, wanted: true)
+  end
+
+  test "counts the hangar and the wishlist every way of asking" do
+    user = User.find(@user.id)
+
+    assert_equal 3, user.purchased_vehicles.size
+    assert_equal 3, user.purchased_vehicles.count
+    assert_equal 3, user.purchased_vehicles.length
+
+    assert_equal 1, user.wanted_vehicles.size
+    assert_equal 1, user.wanted_vehicles.count
+    assert_equal 1, user.wanted_vehicles.length
+  end
+
+  test "claims no cached counter for either association" do
+    %i[purchased_vehicles wanted_vehicles].each do |association|
+      assert_not User.reflect_on_association(association).has_cached_counter?,
+        "#{association} claims a cached counter, which has no column behind it"
+    end
+  end
+end


### PR DESCRIPTION
Came out of the review on #4871, where a bot flagged the bulk delete for not decrementing `users.purchased_vehicles_count`. It doesn't — but neither does anything else, including `destroy`.

## The declaration does nothing

```ruby
has_many :purchased_vehicles,
  -> { where(wanted: false) },
  class_name: "Vehicle",
  counter_cache: true,     # <- wrong side
  inverse_of: false
```

`counter_cache` only has an effect on the `belongs_to` side, and `Vehicle belongs_to :user` never declared it. So neither column has moved since the migration that added them in October 2023:

```
start:    0 purchased / 0 wanted
+bought:  0 purchased / 0 wanted      <- create doesn't increment
+wanted:  0 purchased / 0 wanted
flip:     0 purchased / 0 wanted      <- moving a ship to the wishlist doesn't move the counts
destroy:  0 purchased / 0 wanted      <- destroy doesn't decrement
actual:   0 purchased / 1 wanted
```

In production 39,824 of 59,946 users carry a wrong `purchased_vehicles_count`, drifting downward — 34,729 too low against 5,095 too high, net −695,843.

## But it isn't inert

The reflection still reports a cached counter, with no column behind it:

```
has_cached_counter? => {active: true, column: nil}
```

so `.size` raises, where `count` and `length` answer correctly:

```
purchased_vehicles.size   -> NoMethodError: undefined method '-@' for nil
                             at activerecord-8.1.3.1 reflection.rb:253
                             in AbstractReflection#counter_cache_column
purchased_vehicles.count  -> 3
purchased_vehicles.length -> 3
```

Nothing calls `size` on either association today — that is the only reason this has never surfaced. With the option gone, all three agree.

## Scope

Only the two `counter_cache: true` options, plus a test pinning all three counting methods and asserting neither association claims a counter.

The **columns stay**. Dropping them is a second step: the pre-deploy hook migrates before the new containers boot, so the old release would briefly run against a schema missing a column its model still knows about. #4873 carries that decision — either make the counters real (which needs a custom counter, since a `wanted` flip moves a row between the two associations) or drop both columns and the `wanted_vehicles_count` entry in `User.ransackable_attributes`.

## Verification

Both new tests confirmed failing with the option back in — the `NoMethodError` on `size`, and the reflection assertion.

🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Vehicle association counts now reflect current records without relying on a cached counter.
  - Improved consistency when counting purchased and wanted vehicles using different count methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->